### PR TITLE
Feature/new regionInfo.json content

### DIFF
--- a/Tests/Data/regionInfo-Nuremberg.json
+++ b/Tests/Data/regionInfo-Nuremberg.json
@@ -11,8 +11,8 @@
             "red": 236
           },
           "integrations": [
-            "routing",
-            "real_time"
+            "real_time",
+            "routing"
           ],
           "modeIdentifier": "cy_bic-s_norisbike-nurnberg",
           "title": "NorisBike"
@@ -33,60 +33,6 @@
           "title": "Taxi"
         },
         {
-          "URL": "https://mydriver.com",
-          "color": {
-            "blue": 0,
-            "green": 0,
-            "red": 0
-          },
-          "icon": "mydriver",
-          "integrations": [
-            "routing"
-          ],
-          "modeIdentifier": "ps_tax_MYDRIVER",
-          "title": "myDriver"
-        },
-        {
-          "URL": "https://www.flinkster.de",
-          "color": {
-            "blue": 27,
-            "green": 13,
-            "red": 252
-          },
-          "integrations": [
-            "routing",
-            "real_time"
-          ],
-          "modeIdentifier": "me_car-s_FLINK",
-          "title": "Flinkster"
-        },
-        {
-          "color": {
-            "blue": 243,
-            "green": 169,
-            "red": 115
-          },
-          "integrations": [
-            "routing"
-          ],
-          "modeIdentifier": "me_car-r_SwiftFleet",
-          "title": "Car rental"
-        },
-        {
-          "URL": "https://www.blablacar.com",
-          "color": {
-            "blue": 184,
-            "green": 132,
-            "red": 19
-          },
-          "icon": "blablacar",
-          "integrations": [
-            "routing"
-          ],
-          "modeIdentifier": "me_car-p_BlaBlaCar",
-          "title": "BlaBlaCar"
-        },
-        {
           "URL": "http://www.norisbike.de",
           "color": {
             "blue": 56,
@@ -94,8 +40,8 @@
             "red": 236
           },
           "integrations": [
-            "routing",
-            "real_time"
+            "real_time",
+            "routing"
           ],
           "modeIdentifier": "cy_bic-s_norisbike-nurnberg",
           "title": "NorisBike"
@@ -118,8 +64,8 @@
           "specificModes": [
             {
               "integrations": [
-                "routing",
-                "real_time"
+                "real_time",
+                "routing"
               ],
               "minimumLocalCostForMembership": 0,
               "modeInfo": {
@@ -209,8 +155,8 @@
           "lockedModes": [
             {
               "integrations": [
-                "routing",
-                "real_time"
+                "real_time",
+                "routing"
               ],
               "modeInfo": {
                 "alt": "Flinkster",
@@ -282,7 +228,7 @@
               "red": 45
             },
             "identifier": "pt_pub",
-            "localIcon": "public"
+            "localIcon": "public-transport"
           },
           "specificModes": [
             {
@@ -340,19 +286,19 @@
       "operators": [
         {
           "modes": [
-            "pt_pub_train",
+            "pt_pub_bus",
             "pt_pub_tram",
             "pt_pub_subway",
-            "pt_pub_bus"
+            "pt_pub_train"
           ],
           "name": "VGN",
           "numberOfServices": 50056,
           "realTimeStatus": "INCAPABLE",
           "types": [
             {
-              "alt": "train",
-              "identifier": "pt_pub_train",
-              "localIcon": "train"
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
             },
             {
               "alt": "tram",
@@ -371,9 +317,9 @@
               "remoteIcon": "subway-germany"
             },
             {
-              "alt": "bus",
-              "identifier": "pt_pub_bus",
-              "localIcon": "bus"
+              "alt": "train",
+              "identifier": "pt_pub_train",
+              "localIcon": "train"
             }
           ]
         },

--- a/Tests/Data/regionInfo-Nuremberg.json
+++ b/Tests/Data/regionInfo-Nuremberg.json
@@ -11,8 +11,8 @@
             "red": 236
           },
           "integrations": [
-            "real_time",
-            "routing"
+            "routing",
+            "real_time"
           ],
           "modeIdentifier": "cy_bic-s_norisbike-nurnberg",
           "title": "NorisBike"
@@ -47,6 +47,46 @@
           "title": "myDriver"
         },
         {
+          "URL": "https://www.flinkster.de",
+          "color": {
+            "blue": 27,
+            "green": 13,
+            "red": 252
+          },
+          "integrations": [
+            "routing",
+            "real_time"
+          ],
+          "modeIdentifier": "me_car-s_FLINK",
+          "title": "Flinkster"
+        },
+        {
+          "color": {
+            "blue": 243,
+            "green": 169,
+            "red": 115
+          },
+          "integrations": [
+            "routing"
+          ],
+          "modeIdentifier": "me_car-r_SwiftFleet",
+          "title": "Car rental"
+        },
+        {
+          "URL": "https://www.blablacar.com",
+          "color": {
+            "blue": 184,
+            "green": 132,
+            "red": 19
+          },
+          "icon": "blablacar",
+          "integrations": [
+            "routing"
+          ],
+          "modeIdentifier": "me_car-p_BlaBlaCar",
+          "title": "BlaBlaCar"
+        },
+        {
           "URL": "http://www.norisbike.de",
           "color": {
             "blue": 56,
@@ -54,8 +94,8 @@
             "red": 236
           },
           "integrations": [
-            "real_time",
-            "routing"
+            "routing",
+            "real_time"
           ],
           "modeIdentifier": "cy_bic-s_norisbike-nurnberg",
           "title": "NorisBike"
@@ -65,99 +105,229 @@
       "hasWheelchairInformation": true,
       "modes": {
         "cy_bic-s": {
-          "color": {
-            "blue": 99,
-            "green": 199,
-            "red": 30
+          "modeInfo": {
+            "alt": "Bike share",
+            "color": {
+              "blue": 99,
+              "green": 199,
+              "red": 30
+            },
+            "identifier": "cy_bic-s",
+            "localIcon": "bicycle-share"
           },
-          "identifier": "cy_bic-s",
           "specificModes": [
             {
-              "color": {
-                "blue": 56,
-                "green": 22,
-                "red": 236
-              },
-              "identifier": "cy_bic-s_norisbike-nurnberg",
               "integrations": [
-                "real_time",
-                "routing"
+                "routing",
+                "real_time"
               ],
               "minimumLocalCostForMembership": 0,
+              "modeInfo": {
+                "alt": "NorisBike",
+                "color": {
+                  "blue": 56,
+                  "green": 22,
+                  "red": 236
+                },
+                "description": "NorisBike",
+                "identifier": "cy_bic-s_norisbike-nurnberg",
+                "localIcon": "bicycle-share"
+              },
               "title": "NorisBike",
               "url": "http://www.norisbike.de"
             }
           ],
           "title": "Bike share"
         },
-        "ps_tax": {
-          "color": {
-            "blue": 62,
-            "green": 202,
-            "red": 221
-          },
-          "identifier": "ps_tax",
+        "me_car-p": {
           "lockedModes": [
             {
-              "color": {
-                "blue": 0,
-                "green": 0,
-                "red": 0
-              },
-              "identifier": "ps_tax_MYDRIVER",
               "integrations": [
                 "routing"
               ],
-              "remoteIcon": "mydriver",
+              "modeInfo": {
+                "alt": "BlaBlaCar",
+                "color": {
+                  "blue": 184,
+                  "green": 132,
+                  "red": 19
+                },
+                "description": "BlaBlaCar",
+                "identifier": "me_car-p_BlaBlaCar",
+                "localIcon": "car-pool",
+                "remoteIcon": "blablacar"
+              },
+              "title": "BlaBlaCar",
+              "url": "https://www.blablacar.com"
+            }
+          ],
+          "modeInfo": {
+            "alt": "Carpooling",
+            "color": {
+              "blue": 199,
+              "green": 196,
+              "red": 46
+            },
+            "identifier": "me_car-p",
+            "localIcon": "car-pool"
+          },
+          "title": "Carpooling"
+        },
+        "me_car-r": {
+          "lockedModes": [
+            {
+              "integrations": [
+                "routing"
+              ],
+              "minimumLocalCostForMembership": 0,
+              "modeInfo": {
+                "alt": "Car rental",
+                "color": {
+                  "blue": 243,
+                  "green": 169,
+                  "red": 115
+                },
+                "identifier": "me_car-r_SwiftFleet",
+                "localIcon": "car-share"
+              },
+              "title": "Car rental"
+            }
+          ],
+          "modeInfo": {
+            "alt": "Car rental",
+            "color": {
+              "blue": 243,
+              "green": 169,
+              "red": 115
+            },
+            "identifier": "me_car-r",
+            "localIcon": "car-share"
+          },
+          "title": "Car rental"
+        },
+        "me_car-s": {
+          "lockedModes": [
+            {
+              "integrations": [
+                "routing",
+                "real_time"
+              ],
+              "modeInfo": {
+                "alt": "Flinkster",
+                "color": {
+                  "blue": 27,
+                  "green": 13,
+                  "red": 252
+                },
+                "description": "Flinkster",
+                "identifier": "me_car-s_FLINK",
+                "localIcon": "car-share"
+              },
+              "title": "Flinkster",
+              "url": "https://www.flinkster.de"
+            }
+          ],
+          "modeInfo": {
+            "alt": "Car share",
+            "color": {
+              "blue": 243,
+              "green": 169,
+              "red": 115
+            },
+            "identifier": "me_car-s",
+            "localIcon": "car-share"
+          },
+          "title": "Car share"
+        },
+        "ps_tax": {
+          "lockedModes": [
+            {
+              "integrations": [
+                "routing"
+              ],
+              "modeInfo": {
+                "alt": "myDriver",
+                "color": {
+                  "blue": 0,
+                  "green": 0,
+                  "red": 0
+                },
+                "description": "myDriver",
+                "identifier": "ps_tax_MYDRIVER",
+                "localIcon": "taxi",
+                "remoteIcon": "mydriver"
+              },
               "title": "myDriver",
               "url": "https://mydriver.com"
             }
           ],
+          "modeInfo": {
+            "alt": "Taxi",
+            "color": {
+              "blue": 62,
+              "green": 202,
+              "red": 221
+            },
+            "identifier": "ps_tax",
+            "localIcon": "taxi"
+          },
           "title": "Taxi"
         },
         "pt_pub": {
-          "color": {
-            "blue": 104,
-            "green": 197,
-            "red": 45
+          "modeInfo": {
+            "alt": "Public transport",
+            "color": {
+              "blue": 104,
+              "green": 197,
+              "red": 45
+            },
+            "identifier": "pt_pub",
+            "localIcon": "public"
           },
-          "identifier": "pt_pub",
           "specificModes": [
             {
-              "alt": "train",
-              "identifier": "pt_pub_train",
-              "localIcon": "train",
+              "modeInfo": {
+                "alt": "train",
+                "identifier": "pt_pub_train",
+                "localIcon": "train"
+              },
               "operators": [
                 "VGN",
                 "DPN"
               ]
             },
             {
-              "alt": "subway",
-              "color": {
-                "blue": 165,
-                "green": 103,
-                "red": 0
+              "modeInfo": {
+                "alt": "subway",
+                "color": {
+                  "blue": 165,
+                  "green": 103,
+                  "red": 0
+                },
+                "identifier": "pt_pub_subway",
+                "localIcon": "subway",
+                "remoteIcon": "subway-germany"
               },
-              "identifier": "pt_pub_subway",
-              "localIcon": "subway",
-              "operators": [
-                "VGN"
-              ],
-              "remoteIcon": "subway-germany"
-            },
-            {
-              "alt": "tram",
-              "identifier": "pt_pub_tram",
-              "localIcon": "tram",
               "operators": [
                 "VGN"
               ]
             },
             {
-              "alt": "bus",
-              "identifier": "pt_pub_bus",
-              "localIcon": "bus",
+              "modeInfo": {
+                "alt": "tram",
+                "identifier": "pt_pub_tram",
+                "localIcon": "tram"
+              },
+              "operators": [
+                "VGN"
+              ]
+            },
+            {
+              "modeInfo": {
+                "alt": "bus",
+                "identifier": "pt_pub_bus",
+                "localIcon": "bus"
+              },
               "operators": [
                 "VGN",
                 "FlixBus"
@@ -172,8 +342,8 @@
           "modes": [
             "pt_pub_train",
             "pt_pub_tram",
-            "pt_pub_bus",
-            "pt_pub_subway"
+            "pt_pub_subway",
+            "pt_pub_bus"
           ],
           "name": "VGN",
           "numberOfServices": 50056,
@@ -190,11 +360,6 @@
               "localIcon": "tram"
             },
             {
-              "alt": "bus",
-              "identifier": "pt_pub_bus",
-              "localIcon": "bus"
-            },
-            {
               "alt": "subway",
               "color": {
                 "blue": 165,
@@ -204,6 +369,11 @@
               "identifier": "pt_pub_subway",
               "localIcon": "subway",
               "remoteIcon": "subway-germany"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
             }
           ]
         },

--- a/Tests/Data/regionInfo-Nuremberg.json
+++ b/Tests/Data/regionInfo-Nuremberg.json
@@ -1,0 +1,278 @@
+{
+  "regions": [
+    {
+      "allowsBicyclesOnPublicTransport": true,
+      "bikeShare": [
+        {
+          "URL": "http://www.norisbike.de",
+          "color": {
+            "blue": 56,
+            "green": 22,
+            "red": 236
+          },
+          "integrations": [
+            "real_time",
+            "routing"
+          ],
+          "modeIdentifier": "cy_bic-s_norisbike-nurnberg",
+          "title": "NorisBike"
+        }
+      ],
+      "code": "DE_BV_Nuremberg",
+      "extraModes": [
+        {
+          "color": {
+            "blue": 62,
+            "green": 202,
+            "red": 221
+          },
+          "integrations": [
+            "routing"
+          ],
+          "modeIdentifier": "ps_tax",
+          "title": "Taxi"
+        },
+        {
+          "URL": "https://mydriver.com",
+          "color": {
+            "blue": 0,
+            "green": 0,
+            "red": 0
+          },
+          "icon": "mydriver",
+          "integrations": [
+            "routing"
+          ],
+          "modeIdentifier": "ps_tax_MYDRIVER",
+          "title": "myDriver"
+        },
+        {
+          "URL": "http://www.norisbike.de",
+          "color": {
+            "blue": 56,
+            "green": 22,
+            "red": 236
+          },
+          "integrations": [
+            "real_time",
+            "routing"
+          ],
+          "modeIdentifier": "cy_bic-s_norisbike-nurnberg",
+          "title": "NorisBike"
+        }
+      ],
+      "hasSchoolServices": false,
+      "hasWheelchairInformation": true,
+      "modes": {
+        "cy_bic-s": {
+          "color": {
+            "blue": 99,
+            "green": 199,
+            "red": 30
+          },
+          "identifier": "cy_bic-s",
+          "specificModes": [
+            {
+              "color": {
+                "blue": 56,
+                "green": 22,
+                "red": 236
+              },
+              "identifier": "cy_bic-s_norisbike-nurnberg",
+              "integrations": [
+                "real_time",
+                "routing"
+              ],
+              "minimumLocalCostForMembership": 0,
+              "title": "NorisBike",
+              "url": "http://www.norisbike.de"
+            }
+          ],
+          "title": "Bike share"
+        },
+        "ps_tax": {
+          "color": {
+            "blue": 62,
+            "green": 202,
+            "red": 221
+          },
+          "identifier": "ps_tax",
+          "lockedModes": [
+            {
+              "color": {
+                "blue": 0,
+                "green": 0,
+                "red": 0
+              },
+              "identifier": "ps_tax_MYDRIVER",
+              "integrations": [
+                "routing"
+              ],
+              "remoteIcon": "mydriver",
+              "title": "myDriver",
+              "url": "https://mydriver.com"
+            }
+          ],
+          "title": "Taxi"
+        },
+        "pt_pub": {
+          "color": {
+            "blue": 104,
+            "green": 197,
+            "red": 45
+          },
+          "identifier": "pt_pub",
+          "specificModes": [
+            {
+              "alt": "train",
+              "identifier": "pt_pub_train",
+              "localIcon": "train",
+              "operators": [
+                "VGN",
+                "DPN"
+              ]
+            },
+            {
+              "alt": "subway",
+              "color": {
+                "blue": 165,
+                "green": 103,
+                "red": 0
+              },
+              "identifier": "pt_pub_subway",
+              "localIcon": "subway",
+              "operators": [
+                "VGN"
+              ],
+              "remoteIcon": "subway-germany"
+            },
+            {
+              "alt": "tram",
+              "identifier": "pt_pub_tram",
+              "localIcon": "tram",
+              "operators": [
+                "VGN"
+              ]
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus",
+              "operators": [
+                "VGN",
+                "FlixBus"
+              ]
+            }
+          ],
+          "title": "Public transport"
+        }
+      },
+      "operators": [
+        {
+          "modes": [
+            "pt_pub_train",
+            "pt_pub_tram",
+            "pt_pub_bus",
+            "pt_pub_subway"
+          ],
+          "name": "VGN",
+          "numberOfServices": 50056,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "train",
+              "identifier": "pt_pub_train",
+              "localIcon": "train"
+            },
+            {
+              "alt": "tram",
+              "identifier": "pt_pub_tram",
+              "localIcon": "tram"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            },
+            {
+              "alt": "subway",
+              "color": {
+                "blue": 165,
+                "green": 103,
+                "red": 0
+              },
+              "identifier": "pt_pub_subway",
+              "localIcon": "subway",
+              "remoteIcon": "subway-germany"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "FlixBus",
+          "numberOfServices": 1597,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_train"
+          ],
+          "name": "DPN",
+          "numberOfServices": 201,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "train",
+              "identifier": "pt_pub_train",
+              "localIcon": "train"
+            }
+          ]
+        }
+      ],
+      "streetBicyclePaths": true,
+      "streetWheelchairAccessibility": true,
+      "supportsConcessionPricing": false,
+      "transitBicycleAccessibility": true,
+      "transitConcessionPricing": false,
+      "transitModes": [
+        {
+          "alt": "train",
+          "identifier": "pt_pub_train",
+          "localIcon": "train"
+        },
+        {
+          "alt": "subway",
+          "color": {
+            "blue": 165,
+            "green": 103,
+            "red": 0
+          },
+          "identifier": "pt_pub_subway",
+          "localIcon": "subway",
+          "remoteIcon": "subway-germany"
+        },
+        {
+          "alt": "tram",
+          "identifier": "pt_pub_tram",
+          "localIcon": "tram"
+        },
+        {
+          "alt": "bus",
+          "identifier": "pt_pub_bus",
+          "localIcon": "bus"
+        }
+      ],
+      "transitWheelchairAccessibility": true
+    }
+  ],
+  "server": "104.28.7.61"
+}

--- a/Tests/Data/regionInfo-Sydney.json
+++ b/Tests/Data/regionInfo-Sydney.json
@@ -32,6 +32,22 @@
           "title": "myDriver"
         },
         {
+          "URL": "https://www.uber.com",
+          "color": {
+            "blue": 213,
+            "green": 186,
+            "red": 47
+          },
+          "icon": "uber",
+          "integrations": [
+            "bookings",
+            "routing",
+            "real_time"
+          ],
+          "modeIdentifier": "ps_tnc_UBER",
+          "title": "Uber"
+        },
+        {
           "URL": "http://www.jayride.com.au/",
           "color": {
             "blue": 60,
@@ -43,75 +59,261 @@
           ],
           "modeIdentifier": "ps_shu",
           "title": "Shuttle"
+        },
+        {
+          "URL": "http://www.carnextdoor.com.au",
+          "color": {
+            "blue": 134,
+            "green": 82,
+            "red": 253
+          },
+          "icon": "carnextdoor",
+          "integrations": [
+            "routing"
+          ],
+          "modeIdentifier": "me_car-s_CND",
+          "title": "Car Next Door"
+        },
+        {
+          "URL": "http://www.goget.com.au/",
+          "color": {
+            "blue": 106,
+            "green": 63,
+            "red": 0
+          },
+          "darkIcon": "goget-dark",
+          "icon": "goget",
+          "integrations": [
+            "routing"
+          ],
+          "modeIdentifier": "me_car-s_GOG",
+          "title": "GoGet"
+        },
+        {
+          "color": {
+            "blue": 243,
+            "green": 169,
+            "red": 115
+          },
+          "integrations": [
+            "routing"
+          ],
+          "modeIdentifier": "me_car-r_SwiftFleet",
+          "title": "Car rental"
         }
       ],
       "hasSchoolServices": true,
       "hasWheelchairInformation": true,
       "modes": {
-        "ps_shu": {
-          "color": {
-            "blue": 60,
-            "green": 123,
-            "red": 233
+        "me_car-r": {
+          "lockedModes": [
+            {
+              "integrations": [
+                "routing"
+              ],
+              "minimumLocalCostForMembership": 0,
+              "modeInfo": {
+                "alt": "Car rental",
+                "color": {
+                  "blue": 243,
+                  "green": 169,
+                  "red": 115
+                },
+                "identifier": "me_car-r_SwiftFleet",
+                "localIcon": "car-share"
+              },
+              "title": "Car rental"
+            }
+          ],
+          "modeInfo": {
+            "alt": "Car rental",
+            "color": {
+              "blue": 243,
+              "green": 169,
+              "red": 115
+            },
+            "identifier": "me_car-r",
+            "localIcon": "car-share"
           },
-          "identifier": "ps_shu",
+          "title": "Car rental"
+        },
+        "me_car-s": {
+          "lockedModes": [
+            {
+              "integrations": [
+                "routing"
+              ],
+              "modeInfo": {
+                "alt": "Car Next Door",
+                "color": {
+                  "blue": 134,
+                  "green": 82,
+                  "red": 253
+                },
+                "description": "Car Next Door",
+                "identifier": "me_car-s_CND",
+                "localIcon": "car-share",
+                "remoteIcon": "carnextdoor"
+              },
+              "title": "Car Next Door",
+              "url": "http://www.carnextdoor.com.au"
+            },
+            {
+              "integrations": [
+                "routing"
+              ],
+              "modeInfo": {
+                "alt": "GoGet",
+                "color": {
+                  "blue": 106,
+                  "green": 63,
+                  "red": 0
+                },
+                "description": "GoGet",
+                "identifier": "me_car-s_GOG",
+                "localIcon": "car-share",
+                "remoteDarkIcon": "goget-dark",
+                "remoteIcon": "goget"
+              },
+              "title": "GoGet",
+              "url": "http://www.goget.com.au/"
+            }
+          ],
+          "modeInfo": {
+            "alt": "Car share",
+            "color": {
+              "blue": 243,
+              "green": 169,
+              "red": 115
+            },
+            "identifier": "me_car-s",
+            "localIcon": "car-share"
+          },
+          "title": "Car share"
+        },
+        "ps_shu": {
+          "modeInfo": {
+            "alt": "Shuttle",
+            "color": {
+              "blue": 60,
+              "green": 123,
+              "red": 233
+            },
+            "identifier": "ps_shu",
+            "localIcon": "shuttlebus"
+          },
           "title": "Shuttle",
           "url": "http://www.jayride.com.au/"
         },
         "ps_tax": {
-          "color": {
-            "blue": 62,
-            "green": 202,
-            "red": 221
+          "modeInfo": {
+            "alt": "Taxi",
+            "color": {
+              "blue": 62,
+              "green": 202,
+              "red": 221
+            },
+            "identifier": "ps_tax",
+            "localIcon": "taxi"
           },
-          "identifier": "ps_tax",
+          "title": "Taxi",
           "lockedModes": [
             {
-              "color": {
-                "blue": 0,
-                "green": 0,
-                "red": 0
-              },
-              "identifier": "ps_tax_MYDRIVER",
               "integrations": [
                 "routing"
               ],
-              "remoteIcon": "mydriver",
+              "modeInfo": {
+                "alt": "myDriver",
+                "color": {
+                  "blue": 0,
+                  "green": 0,
+                  "red": 0
+                },
+                "description": "myDriver",
+                "identifier": "ps_tax_MYDRIVER",
+                "localIcon": "taxi",
+                "remoteIcon": "mydriver"
+              },
               "title": "myDriver",
               "url": "https://mydriver.com"
             }
+          ]
+        },
+        "ps_tnc": {
+          "lockedModes": [
+            {
+              "integrations": [
+                "bookings",
+                "routing",
+                "real_time"
+              ],
+              "modeInfo": {
+                "alt": "Uber",
+                "color": {
+                  "blue": 213,
+                  "green": 186,
+                  "red": 47
+                },
+                "description": "Uber",
+                "identifier": "ps_tnc_UBER",
+                "localIcon": "tnc",
+                "remoteIcon": "uber"
+              },
+              "title": "Uber",
+              "url": "https://www.uber.com"
+            }
           ],
-          "title": "Taxi"
+          "modeInfo": {
+            "alt": "Ride share",
+            "color": {
+              "blue": 243,
+              "green": 169,
+              "red": 115
+            },
+            "identifier": "ps_tnc",
+            "localIcon": "tnc"
+          },
+          "title": "Ride share"
         },
         "pt_pub": {
-          "color": {
-            "blue": 104,
-            "green": 197,
-            "red": 45
+          "modeInfo": {
+            "alt": "Public transport",
+            "color": {
+              "blue": 104,
+              "green": 197,
+              "red": 45
+            },
+            "identifier": "pt_pub",
+            "localIcon": "public"
           },
-          "identifier": "pt_pub",
           "specificModes": [
             {
-              "alt": "train",
-              "identifier": "pt_pub_train",
-              "localIcon": "train",
+              "modeInfo": {
+                "alt": "train",
+                "identifier": "pt_pub_train",
+                "localIcon": "train"
+              },
               "operators": [
                 "Sydney Trains",
                 "NSW Trains"
               ]
             },
             {
-              "alt": "tram",
-              "identifier": "pt_pub_tram",
-              "localIcon": "tram",
+              "modeInfo": {
+                "alt": "tram",
+                "identifier": "pt_pub_tram",
+                "localIcon": "tram"
+              },
               "operators": [
                 "Sydney Light Rail"
               ]
             },
             {
-              "alt": "ferry",
-              "identifier": "pt_pub_ferry",
-              "localIcon": "ferry",
+              "modeInfo": {
+                "alt": "ferry",
+                "identifier": "pt_pub_ferry",
+                "localIcon": "ferry"
+              },
               "operators": [
                 "Newcastle Transport",
                 "Sydney Ferries",
@@ -125,16 +327,18 @@
               ]
             },
             {
-              "alt": "bus",
-              "identifier": "pt_pub_bus",
-              "localIcon": "bus",
+              "modeInfo": {
+                "alt": "bus",
+                "identifier": "pt_pub_bus",
+                "localIcon": "bus"
+              },
               "operators": [
                 "State Transit Sydney",
                 "Transdev NSW",
-                "Hillsbus",
                 "Busways Western Sydney",
-                "Hunter Valley Buses",
+                "Hillsbus",
                 "Transit Systems",
+                "Hunter Valley Buses",
                 "Newcastle Transport",
                 "Busways Central Coast",
                 "Busabout",
@@ -160,31 +364,10 @@
       "operators": [
         {
           "modes": [
-            "pt_ltd_SCHOOLBUS",
-            "pt_pub_bus"
-          ],
-          "name": "State Transit Sydney",
-          "numberOfServices": 41466,
-          "realTimeStatus": "CAPABLE",
-          "types": [
-            {
-              "alt": "bus",
-              "identifier": "pt_ltd_SCHOOLBUS",
-              "localIcon": "bus"
-            },
-            {
-              "alt": "bus",
-              "identifier": "pt_pub_bus",
-              "localIcon": "bus"
-            }
-          ]
-        },
-        {
-          "modes": [
             "pt_pub_train"
           ],
           "name": "Sydney Trains",
-          "numberOfServices": 28222,
+          "numberOfServices": 38201,
           "realTimeStatus": "CAPABLE",
           "types": [
             {
@@ -199,50 +382,8 @@
             "pt_ltd_SCHOOLBUS",
             "pt_pub_bus"
           ],
-          "name": "Transdev NSW",
-          "numberOfServices": 7006,
-          "realTimeStatus": "CAPABLE",
-          "types": [
-            {
-              "alt": "bus",
-              "identifier": "pt_ltd_SCHOOLBUS",
-              "localIcon": "bus"
-            },
-            {
-              "alt": "bus",
-              "identifier": "pt_pub_bus",
-              "localIcon": "bus"
-            }
-          ]
-        },
-        {
-          "modes": [
-            "pt_ltd_SCHOOLBUS",
-            "pt_pub_bus"
-          ],
-          "name": "Hillsbus",
-          "numberOfServices": 6187,
-          "realTimeStatus": "CAPABLE",
-          "types": [
-            {
-              "alt": "bus",
-              "identifier": "pt_ltd_SCHOOLBUS",
-              "localIcon": "bus"
-            },
-            {
-              "alt": "bus",
-              "identifier": "pt_pub_bus",
-              "localIcon": "bus"
-            }
-          ]
-        },
-        {
-          "modes": [
-            "pt_ltd_SCHOOLBUS",
-            "pt_pub_bus"
-          ],
-          "name": "Busways Western Sydney",
-          "numberOfServices": 6130,
+          "name": "State Transit Sydney",
+          "numberOfServices": 37917,
           "realTimeStatus": "CAPABLE",
           "types": [
             {
@@ -262,7 +403,7 @@
             "pt_pub_train"
           ],
           "name": "NSW Trains",
-          "numberOfServices": 5058,
+          "numberOfServices": 7141,
           "realTimeStatus": "INCAPABLE",
           "types": [
             {
@@ -274,60 +415,123 @@
         },
         {
           "modes": [
-            "pt_ltd_SCHOOLBUS",
-            "pt_pub_bus"
+            "pt_pub_bus",
+            "pt_ltd_SCHOOLBUS"
           ],
-          "name": "Hunter Valley Buses",
-          "numberOfServices": 3232,
+          "name": "Transdev NSW",
+          "numberOfServices": 6907,
           "realTimeStatus": "CAPABLE",
           "types": [
             {
               "alt": "bus",
-              "identifier": "pt_ltd_SCHOOLBUS",
+              "identifier": "pt_pub_bus",
               "localIcon": "bus"
             },
             {
               "alt": "bus",
-              "identifier": "pt_pub_bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
               "localIcon": "bus"
             }
           ]
         },
         {
           "modes": [
-            "pt_ltd_SCHOOLBUS",
-            "pt_pub_bus"
+            "pt_pub_bus",
+            "pt_ltd_SCHOOLBUS"
+          ],
+          "name": "Busways Western Sydney",
+          "numberOfServices": 6092,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus",
+            "pt_ltd_SCHOOLBUS"
+          ],
+          "name": "Hillsbus",
+          "numberOfServices": 5947,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus",
+            "pt_ltd_SCHOOLBUS"
           ],
           "name": "Transit Systems",
-          "numberOfServices": 2878,
+          "numberOfServices": 2856,
           "realTimeStatus": "CAPABLE",
           "types": [
             {
               "alt": "bus",
-              "identifier": "pt_ltd_SCHOOLBUS",
+              "identifier": "pt_pub_bus",
               "localIcon": "bus"
             },
             {
               "alt": "bus",
-              "identifier": "pt_pub_bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
               "localIcon": "bus"
             }
           ]
         },
         {
           "modes": [
-            "pt_ltd_SCHOOLBUS",
             "pt_pub_bus",
-            "pt_pub_ferry"
+            "pt_ltd_SCHOOLBUS"
+          ],
+          "name": "Hunter Valley Buses",
+          "numberOfServices": 2800,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_ferry",
+            "pt_pub_bus",
+            "pt_ltd_SCHOOLBUS"
           ],
           "name": "Newcastle Transport",
           "numberOfServices": 2761,
           "realTimeStatus": "CAPABLE",
           "types": [
             {
-              "alt": "bus",
-              "identifier": "pt_ltd_SCHOOLBUS",
-              "localIcon": "bus"
+              "alt": "ferry",
+              "identifier": "pt_pub_ferry",
+              "localIcon": "ferry"
             },
             {
               "alt": "bus",
@@ -335,16 +539,16 @@
               "localIcon": "bus"
             },
             {
-              "alt": "ferry",
-              "identifier": "pt_pub_ferry",
-              "localIcon": "ferry"
+              "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
             }
           ]
         },
         {
           "modes": [
-            "pt_ltd_SCHOOLBUS",
-            "pt_pub_bus"
+            "pt_pub_bus",
+            "pt_ltd_SCHOOLBUS"
           ],
           "name": "Busways Central Coast",
           "numberOfServices": 2416,
@@ -352,20 +556,20 @@
           "types": [
             {
               "alt": "bus",
-              "identifier": "pt_ltd_SCHOOLBUS",
+              "identifier": "pt_pub_bus",
               "localIcon": "bus"
             },
             {
               "alt": "bus",
-              "identifier": "pt_pub_bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
               "localIcon": "bus"
             }
           ]
         },
         {
           "modes": [
-            "pt_ltd_SCHOOLBUS",
-            "pt_pub_bus"
+            "pt_pub_bus",
+            "pt_ltd_SCHOOLBUS"
           ],
           "name": "Busabout",
           "numberOfServices": 2087,
@@ -373,12 +577,12 @@
           "types": [
             {
               "alt": "bus",
-              "identifier": "pt_ltd_SCHOOLBUS",
+              "identifier": "pt_pub_bus",
               "localIcon": "bus"
             },
             {
               "alt": "bus",
-              "identifier": "pt_pub_bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
               "localIcon": "bus"
             }
           ]
@@ -421,8 +625,8 @@
         },
         {
           "modes": [
-            "pt_ltd_SCHOOLBUS",
-            "pt_pub_bus"
+            "pt_pub_bus",
+            "pt_ltd_SCHOOLBUS"
           ],
           "name": "Premier Illawarra",
           "numberOfServices": 1789,
@@ -430,54 +634,54 @@
           "types": [
             {
               "alt": "bus",
-              "identifier": "pt_ltd_SCHOOLBUS",
+              "identifier": "pt_pub_bus",
               "localIcon": "bus"
             },
             {
               "alt": "bus",
-              "identifier": "pt_pub_bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
               "localIcon": "bus"
             }
           ]
         },
         {
           "modes": [
-            "pt_ltd_SCHOOLBUS",
-            "pt_pub_bus"
+            "pt_pub_bus",
+            "pt_ltd_SCHOOLBUS"
           ],
           "name": "Punchbowl Bus Company",
-          "numberOfServices": 1526,
+          "numberOfServices": 1558,
           "realTimeStatus": "CAPABLE",
           "types": [
             {
               "alt": "bus",
-              "identifier": "pt_ltd_SCHOOLBUS",
+              "identifier": "pt_pub_bus",
               "localIcon": "bus"
             },
             {
               "alt": "bus",
-              "identifier": "pt_pub_bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
               "localIcon": "bus"
             }
           ]
         },
         {
           "modes": [
-            "pt_ltd_SCHOOLBUS",
-            "pt_pub_bus"
+            "pt_pub_bus",
+            "pt_ltd_SCHOOLBUS"
           ],
           "name": "Forest Coach Lines",
-          "numberOfServices": 1252,
+          "numberOfServices": 1142,
           "realTimeStatus": "CAPABLE",
           "types": [
             {
               "alt": "bus",
-              "identifier": "pt_ltd_SCHOOLBUS",
+              "identifier": "pt_pub_bus",
               "localIcon": "bus"
             },
             {
               "alt": "bus",
-              "identifier": "pt_pub_bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
               "localIcon": "bus"
             }
           ]
@@ -499,21 +703,21 @@
         },
         {
           "modes": [
-            "pt_ltd_SCHOOLBUS",
-            "pt_pub_bus"
+            "pt_pub_bus",
+            "pt_ltd_SCHOOLBUS"
           ],
           "name": "Red Bus Service",
-          "numberOfServices": 913,
+          "numberOfServices": 912,
           "realTimeStatus": "CAPABLE",
           "types": [
             {
               "alt": "bus",
-              "identifier": "pt_ltd_SCHOOLBUS",
+              "identifier": "pt_pub_bus",
               "localIcon": "bus"
             },
             {
               "alt": "bus",
-              "identifier": "pt_pub_bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
               "localIcon": "bus"
             }
           ]
@@ -524,7 +728,7 @@
             "pt_pub_bus"
           ],
           "name": "Blue Mountains Transit",
-          "numberOfServices": 723,
+          "numberOfServices": 765,
           "realTimeStatus": "CAPABLE",
           "types": [
             {
@@ -541,10 +745,31 @@
         },
         {
           "modes": [
+            "pt_pub_bus",
+            "pt_ltd_SCHOOLBUS"
+          ],
+          "name": "Dions Bus Service",
+          "numberOfServices": 347,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
             "pt_pub_ferry"
           ],
           "name": "Captain Cook Cruises",
-          "numberOfServices": 332,
+          "numberOfServices": 278,
           "realTimeStatus": "INCAPABLE",
           "types": [
             {
@@ -556,42 +781,21 @@
         },
         {
           "modes": [
-            "pt_ltd_SCHOOLBUS",
-            "pt_pub_bus"
-          ],
-          "name": "Dions Bus Service",
-          "numberOfServices": 325,
-          "realTimeStatus": "CAPABLE",
-          "types": [
-            {
-              "alt": "bus",
-              "identifier": "pt_ltd_SCHOOLBUS",
-              "localIcon": "bus"
-            },
-            {
-              "alt": "bus",
-              "identifier": "pt_pub_bus",
-              "localIcon": "bus"
-            }
-          ]
-        },
-        {
-          "modes": [
-            "pt_ltd_SCHOOLBUS",
-            "pt_pub_bus"
+            "pt_pub_bus",
+            "pt_ltd_SCHOOLBUS"
           ],
           "name": "Rover Coaches",
-          "numberOfServices": 271,
+          "numberOfServices": 275,
           "realTimeStatus": "CAPABLE",
           "types": [
             {
               "alt": "bus",
-              "identifier": "pt_ltd_SCHOOLBUS",
+              "identifier": "pt_pub_bus",
               "localIcon": "bus"
             },
             {
               "alt": "bus",
-              "identifier": "pt_pub_bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
               "localIcon": "bus"
             }
           ]
@@ -602,7 +806,7 @@
             "pt_pub_bus"
           ],
           "name": "Port Stephens Coaches",
-          "numberOfServices": 262,
+          "numberOfServices": 244,
           "realTimeStatus": "CAPABLE",
           "types": [
             {
@@ -622,7 +826,7 @@
             "pt_pub_bus"
           ],
           "name": "NightRide",
-          "numberOfServices": 213,
+          "numberOfServices": 208,
           "realTimeStatus": "CAPABLE",
           "types": [
             {

--- a/Tests/Data/regionInfo-Sydney.json
+++ b/Tests/Data/regionInfo-Sydney.json
@@ -18,36 +18,6 @@
           "title": "Taxi"
         },
         {
-          "URL": "https://mydriver.com",
-          "color": {
-            "blue": 0,
-            "green": 0,
-            "red": 0
-          },
-          "icon": "mydriver",
-          "integrations": [
-            "routing"
-          ],
-          "modeIdentifier": "ps_tax_MYDRIVER",
-          "title": "myDriver"
-        },
-        {
-          "URL": "https://www.uber.com",
-          "color": {
-            "blue": 213,
-            "green": 186,
-            "red": 47
-          },
-          "icon": "uber",
-          "integrations": [
-            "bookings",
-            "routing",
-            "real_time"
-          ],
-          "modeIdentifier": "ps_tnc_UBER",
-          "title": "Uber"
-        },
-        {
           "URL": "http://www.jayride.com.au/",
           "color": {
             "blue": 60,
@@ -59,47 +29,6 @@
           ],
           "modeIdentifier": "ps_shu",
           "title": "Shuttle"
-        },
-        {
-          "URL": "http://www.carnextdoor.com.au",
-          "color": {
-            "blue": 134,
-            "green": 82,
-            "red": 253
-          },
-          "icon": "carnextdoor",
-          "integrations": [
-            "routing"
-          ],
-          "modeIdentifier": "me_car-s_CND",
-          "title": "Car Next Door"
-        },
-        {
-          "URL": "http://www.goget.com.au/",
-          "color": {
-            "blue": 106,
-            "green": 63,
-            "red": 0
-          },
-          "darkIcon": "goget-dark",
-          "icon": "goget",
-          "integrations": [
-            "routing"
-          ],
-          "modeIdentifier": "me_car-s_GOG",
-          "title": "GoGet"
-        },
-        {
-          "color": {
-            "blue": 243,
-            "green": 169,
-            "red": 115
-          },
-          "integrations": [
-            "routing"
-          ],
-          "modeIdentifier": "me_car-r_SwiftFleet",
-          "title": "Car rental"
         }
       ],
       "hasSchoolServices": true,
@@ -206,17 +135,6 @@
           "url": "http://www.jayride.com.au/"
         },
         "ps_tax": {
-          "modeInfo": {
-            "alt": "Taxi",
-            "color": {
-              "blue": 62,
-              "green": 202,
-              "red": 221
-            },
-            "identifier": "ps_tax",
-            "localIcon": "taxi"
-          },
-          "title": "Taxi",
           "lockedModes": [
             {
               "integrations": [
@@ -237,7 +155,18 @@
               "title": "myDriver",
               "url": "https://mydriver.com"
             }
-          ]
+          ],
+          "modeInfo": {
+            "alt": "Taxi",
+            "color": {
+              "blue": 62,
+              "green": 202,
+              "red": 221
+            },
+            "identifier": "ps_tax",
+            "localIcon": "taxi"
+          },
+          "title": "Taxi"
         },
         "ps_tnc": {
           "lockedModes": [
@@ -256,7 +185,7 @@
                 },
                 "description": "Uber",
                 "identifier": "ps_tnc_UBER",
-                "localIcon": "tnc",
+                "localIcon": "car-ride-share",
                 "remoteIcon": "uber"
               },
               "title": "Uber",
@@ -271,7 +200,7 @@
               "red": 115
             },
             "identifier": "ps_tnc",
-            "localIcon": "tnc"
+            "localIcon": "car-ride-share"
           },
           "title": "Ride share"
         },
@@ -284,7 +213,7 @@
               "red": 45
             },
             "identifier": "pt_pub",
-            "localIcon": "public"
+            "localIcon": "public-transport"
           },
           "specificModes": [
             {
@@ -335,10 +264,10 @@
               "operators": [
                 "State Transit Sydney",
                 "Transdev NSW",
-                "Busways Western Sydney",
                 "Hillsbus",
-                "Transit Systems",
+                "Busways Western Sydney",
                 "Hunter Valley Buses",
+                "Transit Systems",
                 "Newcastle Transport",
                 "Busways Central Coast",
                 "Busabout",
@@ -364,37 +293,22 @@
       "operators": [
         {
           "modes": [
-            "pt_pub_train"
-          ],
-          "name": "Sydney Trains",
-          "numberOfServices": 38201,
-          "realTimeStatus": "CAPABLE",
-          "types": [
-            {
-              "alt": "train",
-              "identifier": "pt_pub_train",
-              "localIcon": "train"
-            }
-          ]
-        },
-        {
-          "modes": [
-            "pt_ltd_SCHOOLBUS",
-            "pt_pub_bus"
+            "pt_pub_bus",
+            "pt_ltd_SCHOOLBUS"
           ],
           "name": "State Transit Sydney",
-          "numberOfServices": 37917,
+          "numberOfServices": 41466,
           "realTimeStatus": "CAPABLE",
           "types": [
-            {
-              "alt": "bus",
-              "identifier": "pt_ltd_SCHOOLBUS",
-              "localIcon": "bus"
-            },
             {
               "alt": "bus",
               "identifier": "pt_pub_bus",
               "localIcon": "bus"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
             }
           ]
         },
@@ -402,9 +316,9 @@
           "modes": [
             "pt_pub_train"
           ],
-          "name": "NSW Trains",
-          "numberOfServices": 7141,
-          "realTimeStatus": "INCAPABLE",
+          "name": "Sydney Trains",
+          "numberOfServices": 28222,
+          "realTimeStatus": "CAPABLE",
           "types": [
             {
               "alt": "train",
@@ -419,28 +333,7 @@
             "pt_ltd_SCHOOLBUS"
           ],
           "name": "Transdev NSW",
-          "numberOfServices": 6907,
-          "realTimeStatus": "CAPABLE",
-          "types": [
-            {
-              "alt": "bus",
-              "identifier": "pt_pub_bus",
-              "localIcon": "bus"
-            },
-            {
-              "alt": "bus",
-              "identifier": "pt_ltd_SCHOOLBUS",
-              "localIcon": "bus"
-            }
-          ]
-        },
-        {
-          "modes": [
-            "pt_pub_bus",
-            "pt_ltd_SCHOOLBUS"
-          ],
-          "name": "Busways Western Sydney",
-          "numberOfServices": 6092,
+          "numberOfServices": 7006,
           "realTimeStatus": "CAPABLE",
           "types": [
             {
@@ -461,7 +354,64 @@
             "pt_ltd_SCHOOLBUS"
           ],
           "name": "Hillsbus",
-          "numberOfServices": 5947,
+          "numberOfServices": 6187,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus",
+            "pt_ltd_SCHOOLBUS"
+          ],
+          "name": "Busways Western Sydney",
+          "numberOfServices": 6130,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_train"
+          ],
+          "name": "NSW Trains",
+          "numberOfServices": 5058,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "train",
+              "identifier": "pt_pub_train",
+              "localIcon": "train"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus",
+            "pt_ltd_SCHOOLBUS"
+          ],
+          "name": "Hunter Valley Buses",
+          "numberOfServices": 3232,
           "realTimeStatus": "CAPABLE",
           "types": [
             {
@@ -482,28 +432,7 @@
             "pt_ltd_SCHOOLBUS"
           ],
           "name": "Transit Systems",
-          "numberOfServices": 2856,
-          "realTimeStatus": "CAPABLE",
-          "types": [
-            {
-              "alt": "bus",
-              "identifier": "pt_pub_bus",
-              "localIcon": "bus"
-            },
-            {
-              "alt": "bus",
-              "identifier": "pt_ltd_SCHOOLBUS",
-              "localIcon": "bus"
-            }
-          ]
-        },
-        {
-          "modes": [
-            "pt_pub_bus",
-            "pt_ltd_SCHOOLBUS"
-          ],
-          "name": "Hunter Valley Buses",
-          "numberOfServices": 2800,
+          "numberOfServices": 2878,
           "realTimeStatus": "CAPABLE",
           "types": [
             {
@@ -604,8 +533,8 @@
         },
         {
           "modes": [
-            "pt_ltd_SCHOOLBUS",
-            "pt_pub_bus"
+            "pt_pub_bus",
+            "pt_ltd_SCHOOLBUS"
           ],
           "name": "Interline Bus Services",
           "numberOfServices": 1879,
@@ -613,12 +542,12 @@
           "types": [
             {
               "alt": "bus",
-              "identifier": "pt_ltd_SCHOOLBUS",
+              "identifier": "pt_pub_bus",
               "localIcon": "bus"
             },
             {
               "alt": "bus",
-              "identifier": "pt_pub_bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
               "localIcon": "bus"
             }
           ]
@@ -650,7 +579,7 @@
             "pt_ltd_SCHOOLBUS"
           ],
           "name": "Punchbowl Bus Company",
-          "numberOfServices": 1558,
+          "numberOfServices": 1526,
           "realTimeStatus": "CAPABLE",
           "types": [
             {
@@ -671,7 +600,7 @@
             "pt_ltd_SCHOOLBUS"
           ],
           "name": "Forest Coach Lines",
-          "numberOfServices": 1142,
+          "numberOfServices": 1252,
           "realTimeStatus": "CAPABLE",
           "types": [
             {
@@ -707,7 +636,7 @@
             "pt_ltd_SCHOOLBUS"
           ],
           "name": "Red Bus Service",
-          "numberOfServices": 912,
+          "numberOfServices": 913,
           "realTimeStatus": "CAPABLE",
           "types": [
             {
@@ -718,27 +647,6 @@
             {
               "alt": "bus",
               "identifier": "pt_ltd_SCHOOLBUS",
-              "localIcon": "bus"
-            }
-          ]
-        },
-        {
-          "modes": [
-            "pt_ltd_SCHOOLBUS",
-            "pt_pub_bus"
-          ],
-          "name": "Blue Mountains Transit",
-          "numberOfServices": 765,
-          "realTimeStatus": "CAPABLE",
-          "types": [
-            {
-              "alt": "bus",
-              "identifier": "pt_ltd_SCHOOLBUS",
-              "localIcon": "bus"
-            },
-            {
-              "alt": "bus",
-              "identifier": "pt_pub_bus",
               "localIcon": "bus"
             }
           ]
@@ -748,8 +656,8 @@
             "pt_pub_bus",
             "pt_ltd_SCHOOLBUS"
           ],
-          "name": "Dions Bus Service",
-          "numberOfServices": 347,
+          "name": "Blue Mountains Transit",
+          "numberOfServices": 723,
           "realTimeStatus": "CAPABLE",
           "types": [
             {
@@ -769,7 +677,7 @@
             "pt_pub_ferry"
           ],
           "name": "Captain Cook Cruises",
-          "numberOfServices": 278,
+          "numberOfServices": 332,
           "realTimeStatus": "INCAPABLE",
           "types": [
             {
@@ -784,8 +692,8 @@
             "pt_pub_bus",
             "pt_ltd_SCHOOLBUS"
           ],
-          "name": "Rover Coaches",
-          "numberOfServices": 275,
+          "name": "Dions Bus Service",
+          "numberOfServices": 325,
           "realTimeStatus": "CAPABLE",
           "types": [
             {
@@ -802,21 +710,42 @@
         },
         {
           "modes": [
-            "pt_ltd_SCHOOLBUS",
-            "pt_pub_bus"
+            "pt_pub_bus",
+            "pt_ltd_SCHOOLBUS"
           ],
-          "name": "Port Stephens Coaches",
-          "numberOfServices": 244,
+          "name": "Rover Coaches",
+          "numberOfServices": 271,
           "realTimeStatus": "CAPABLE",
           "types": [
             {
               "alt": "bus",
-              "identifier": "pt_ltd_SCHOOLBUS",
+              "identifier": "pt_pub_bus",
               "localIcon": "bus"
             },
             {
               "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus",
+            "pt_ltd_SCHOOLBUS"
+          ],
+          "name": "Port Stephens Coaches",
+          "numberOfServices": 262,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
               "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
               "localIcon": "bus"
             }
           ]
@@ -826,7 +755,7 @@
             "pt_pub_bus"
           ],
           "name": "NightRide",
-          "numberOfServices": 208,
+          "numberOfServices": 213,
           "realTimeStatus": "CAPABLE",
           "types": [
             {
@@ -853,8 +782,8 @@
         },
         {
           "modes": [
-            "pt_ltd_SCHOOLBUS",
-            "pt_pub_bus"
+            "pt_pub_bus",
+            "pt_ltd_SCHOOLBUS"
           ],
           "name": "Premier Charters",
           "numberOfServices": 190,
@@ -862,12 +791,12 @@
           "types": [
             {
               "alt": "bus",
-              "identifier": "pt_ltd_SCHOOLBUS",
+              "identifier": "pt_pub_bus",
               "localIcon": "bus"
             },
             {
               "alt": "bus",
-              "identifier": "pt_pub_bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
               "localIcon": "bus"
             }
           ]
@@ -889,8 +818,8 @@
         },
         {
           "modes": [
-            "pt_ltd_SCHOOLBUS",
-            "pt_pub_bus"
+            "pt_pub_bus",
+            "pt_ltd_SCHOOLBUS"
           ],
           "name": "Coastal Liner",
           "numberOfServices": 94,
@@ -898,12 +827,12 @@
           "types": [
             {
               "alt": "bus",
-              "identifier": "pt_ltd_SCHOOLBUS",
+              "identifier": "pt_pub_bus",
               "localIcon": "bus"
             },
             {
               "alt": "bus",
-              "identifier": "pt_pub_bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
               "localIcon": "bus"
             }
           ]
@@ -1014,5 +943,5 @@
       "transitWheelchairAccessibility": true
     }
   ],
-  "server": "104.28.7.61"
+  "server": "104.28.6.61"
 }

--- a/Tests/Data/regionInfo-Sydney.json
+++ b/Tests/Data/regionInfo-Sydney.json
@@ -2,55 +2,189 @@
   "regions": [
     {
       "allowsBicyclesOnPublicTransport": true,
+      "bikeShare": [],
       "code": "AU_NSW_Sydney",
       "extraModes": [
         {
-          "title": "Car rental"
-        },
-        {
-          "URL": "http://www.carnextdoor.com.au",
           "color": {
-            "blue": 134,
-            "green": 82,
-            "red": 253
+            "blue": 62,
+            "green": 202,
+            "red": 221
           },
-          "icon": "carnextdoor",
-          "title": "Car Next Door"
+          "integrations": [
+            "routing"
+          ],
+          "modeIdentifier": "ps_tax",
+          "title": "Taxi"
         },
         {
-          "URL": "http://www.goget.com.au/",
+          "URL": "https://mydriver.com",
           "color": {
-            "blue": 106,
-            "green": 63,
+            "blue": 0,
+            "green": 0,
             "red": 0
           },
-          "icon": "goget",
-          "title": "GoGet"
+          "icon": "mydriver",
+          "integrations": [
+            "routing"
+          ],
+          "modeIdentifier": "ps_tax_MYDRIVER",
+          "title": "myDriver"
+        },
+        {
+          "URL": "http://www.jayride.com.au/",
+          "color": {
+            "blue": 60,
+            "green": 123,
+            "red": 233
+          },
+          "integrations": [
+            "routing"
+          ],
+          "modeIdentifier": "ps_shu",
+          "title": "Shuttle"
         }
       ],
       "hasSchoolServices": true,
       "hasWheelchairInformation": true,
+      "modes": {
+        "ps_shu": {
+          "color": {
+            "blue": 60,
+            "green": 123,
+            "red": 233
+          },
+          "identifier": "ps_shu",
+          "title": "Shuttle",
+          "url": "http://www.jayride.com.au/"
+        },
+        "ps_tax": {
+          "color": {
+            "blue": 62,
+            "green": 202,
+            "red": 221
+          },
+          "identifier": "ps_tax",
+          "lockedModes": [
+            {
+              "color": {
+                "blue": 0,
+                "green": 0,
+                "red": 0
+              },
+              "identifier": "ps_tax_MYDRIVER",
+              "integrations": [
+                "routing"
+              ],
+              "remoteIcon": "mydriver",
+              "title": "myDriver",
+              "url": "https://mydriver.com"
+            }
+          ],
+          "title": "Taxi"
+        },
+        "pt_pub": {
+          "color": {
+            "blue": 104,
+            "green": 197,
+            "red": 45
+          },
+          "identifier": "pt_pub",
+          "specificModes": [
+            {
+              "alt": "train",
+              "identifier": "pt_pub_train",
+              "localIcon": "train",
+              "operators": [
+                "Sydney Trains",
+                "NSW Trains"
+              ]
+            },
+            {
+              "alt": "tram",
+              "identifier": "pt_pub_tram",
+              "localIcon": "tram",
+              "operators": [
+                "Sydney Light Rail"
+              ]
+            },
+            {
+              "alt": "ferry",
+              "identifier": "pt_pub_ferry",
+              "localIcon": "ferry",
+              "operators": [
+                "Newcastle Transport",
+                "Sydney Ferries",
+                "Captain Cook Cruises",
+                "Manly Fast Ferry",
+                "Cronulla Ferries",
+                "Palm Beach Ferry Service",
+                "Church Point Ferry Service",
+                "Central Coast Ferries",
+                "Brooklyn Ferry Service"
+              ]
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus",
+              "operators": [
+                "State Transit Sydney",
+                "Transdev NSW",
+                "Hillsbus",
+                "Busways Western Sydney",
+                "Hunter Valley Buses",
+                "Transit Systems",
+                "Newcastle Transport",
+                "Busways Central Coast",
+                "Busabout",
+                "Interline Bus Services",
+                "Premier Illawarra",
+                "Punchbowl Bus Company",
+                "Forest Coach Lines",
+                "Red Bus Service",
+                "Blue Mountains Transit",
+                "Dions Bus Service",
+                "Rover Coaches",
+                "Port Stephens Coaches",
+                "NightRide",
+                "Premier Charters",
+                "OPTUS BUS",
+                "Coastal Liner"
+              ]
+            }
+          ],
+          "title": "Public transport"
+        }
+      },
       "operators": [
         {
+          "modes": [
+            "pt_ltd_SCHOOLBUS",
+            "pt_pub_bus"
+          ],
           "name": "State Transit Sydney",
-          "numberOfServices": 38369,
+          "numberOfServices": 41466,
           "realTimeStatus": "CAPABLE",
           "types": [
             {
               "alt": "bus",
-              "identifier": "pt_pub_bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
               "localIcon": "bus"
             },
             {
               "alt": "bus",
-              "identifier": "pt_ltd_SCHOOLBUS",
+              "identifier": "pt_pub_bus",
               "localIcon": "bus"
             }
           ]
         },
         {
+          "modes": [
+            "pt_pub_train"
+          ],
           "name": "Sydney Trains",
-          "numberOfServices": 19484,
+          "numberOfServices": 28222,
           "realTimeStatus": "CAPABLE",
           "types": [
             {
@@ -61,60 +195,75 @@
           ]
         },
         {
-          "name": "Busways Western Sydney",
-          "numberOfServices": 10742,
-          "realTimeStatus": "CAPABLE",
-          "types": [
-            {
-              "alt": "bus",
-              "identifier": "pt_pub_bus",
-              "localIcon": "bus"
-            },
-            {
-              "alt": "bus",
-              "identifier": "pt_ltd_SCHOOLBUS",
-              "localIcon": "bus"
-            }
-          ]
-        },
-        {
+          "modes": [
+            "pt_ltd_SCHOOLBUS",
+            "pt_pub_bus"
+          ],
           "name": "Transdev NSW",
-          "numberOfServices": 6973,
+          "numberOfServices": 7006,
           "realTimeStatus": "CAPABLE",
           "types": [
             {
               "alt": "bus",
-              "identifier": "pt_pub_bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
               "localIcon": "bus"
             },
             {
               "alt": "bus",
-              "identifier": "pt_ltd_SCHOOLBUS",
+              "identifier": "pt_pub_bus",
               "localIcon": "bus"
             }
           ]
         },
         {
+          "modes": [
+            "pt_ltd_SCHOOLBUS",
+            "pt_pub_bus"
+          ],
           "name": "Hillsbus",
-          "numberOfServices": 5667,
+          "numberOfServices": 6187,
           "realTimeStatus": "CAPABLE",
           "types": [
             {
               "alt": "bus",
-              "identifier": "pt_pub_bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
               "localIcon": "bus"
             },
             {
               "alt": "bus",
-              "identifier": "pt_ltd_SCHOOLBUS",
+              "identifier": "pt_pub_bus",
               "localIcon": "bus"
             }
           ]
         },
         {
-          "name": "NSW TrainLink",
-          "numberOfServices": 4288,
+          "modes": [
+            "pt_ltd_SCHOOLBUS",
+            "pt_pub_bus"
+          ],
+          "name": "Busways Western Sydney",
+          "numberOfServices": 6130,
           "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_train"
+          ],
+          "name": "NSW Trains",
+          "numberOfServices": 5058,
+          "realTimeStatus": "INCAPABLE",
           "types": [
             {
               "alt": "train",
@@ -124,59 +273,122 @@
           ]
         },
         {
-          "name": "Transit Systems",
-          "numberOfServices": 4033,
-          "realTimeStatus": "CAPABLE",
-          "types": [
-            {
-              "alt": "bus",
-              "identifier": "pt_pub_bus",
-              "localIcon": "bus"
-            },
-            {
-              "alt": "bus",
-              "identifier": "pt_ltd_SCHOOLBUS",
-              "localIcon": "bus"
-            }
-          ]
-        },
-        {
-          "name": "State Transit Newcastle",
-          "numberOfServices": 2613,
-          "realTimeStatus": "CAPABLE",
-          "types": [
-            {
-              "alt": "bus",
-              "identifier": "pt_pub_bus",
-              "localIcon": "bus"
-            },
-            {
-              "alt": "bus",
-              "identifier": "pt_ltd_SCHOOLBUS",
-              "localIcon": "bus"
-            }
-          ]
-        },
-        {
+          "modes": [
+            "pt_ltd_SCHOOLBUS",
+            "pt_pub_bus"
+          ],
           "name": "Hunter Valley Buses",
-          "numberOfServices": 2564,
+          "numberOfServices": 3232,
           "realTimeStatus": "CAPABLE",
           "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_ltd_SCHOOLBUS",
+            "pt_pub_bus"
+          ],
+          "name": "Transit Systems",
+          "numberOfServices": 2878,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_ltd_SCHOOLBUS",
+            "pt_pub_bus",
+            "pt_pub_ferry"
+          ],
+          "name": "Newcastle Transport",
+          "numberOfServices": 2761,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
+            },
             {
               "alt": "bus",
               "identifier": "pt_pub_bus",
               "localIcon": "bus"
             },
             {
+              "alt": "ferry",
+              "identifier": "pt_pub_ferry",
+              "localIcon": "ferry"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_ltd_SCHOOLBUS",
+            "pt_pub_bus"
+          ],
+          "name": "Busways Central Coast",
+          "numberOfServices": 2416,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
               "alt": "bus",
               "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
               "localIcon": "bus"
             }
           ]
         },
         {
+          "modes": [
+            "pt_ltd_SCHOOLBUS",
+            "pt_pub_bus"
+          ],
+          "name": "Busabout",
+          "numberOfServices": 2087,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_ferry"
+          ],
           "name": "Sydney Ferries",
-          "numberOfServices": 2468,
+          "numberOfServices": 1889,
           "realTimeStatus": "CAPABLE",
           "types": [
             {
@@ -187,127 +399,95 @@
           ]
         },
         {
-          "name": "Busways Central Coast",
-          "numberOfServices": 2429,
-          "realTimeStatus": "CAPABLE",
-          "types": [
-            {
-              "alt": "bus",
-              "identifier": "pt_pub_bus",
-              "localIcon": "bus"
-            },
-            {
-              "alt": "bus",
-              "identifier": "pt_ltd_SCHOOLBUS",
-              "localIcon": "bus"
-            }
-          ]
-        },
-        {
-          "name": "Busabout",
-          "numberOfServices": 2033,
-          "realTimeStatus": "CAPABLE",
-          "types": [
-            {
-              "alt": "bus",
-              "identifier": "pt_pub_bus",
-              "localIcon": "bus"
-            },
-            {
-              "alt": "bus",
-              "identifier": "pt_ltd_SCHOOLBUS",
-              "localIcon": "bus"
-            }
-          ]
-        },
-        {
+          "modes": [
+            "pt_ltd_SCHOOLBUS",
+            "pt_pub_bus"
+          ],
           "name": "Interline Bus Services",
-          "numberOfServices": 1840,
+          "numberOfServices": 1879,
           "realTimeStatus": "CAPABLE",
           "types": [
             {
               "alt": "bus",
-              "identifier": "pt_pub_bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
               "localIcon": "bus"
             },
             {
               "alt": "bus",
-              "identifier": "pt_ltd_SCHOOLBUS",
+              "identifier": "pt_pub_bus",
               "localIcon": "bus"
             }
           ]
         },
         {
+          "modes": [
+            "pt_ltd_SCHOOLBUS",
+            "pt_pub_bus"
+          ],
           "name": "Premier Illawarra",
-          "numberOfServices": 1805,
+          "numberOfServices": 1789,
           "realTimeStatus": "CAPABLE",
           "types": [
             {
               "alt": "bus",
-              "identifier": "pt_pub_bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
               "localIcon": "bus"
             },
             {
               "alt": "bus",
-              "identifier": "pt_ltd_SCHOOLBUS",
+              "identifier": "pt_pub_bus",
               "localIcon": "bus"
             }
           ]
         },
         {
+          "modes": [
+            "pt_ltd_SCHOOLBUS",
+            "pt_pub_bus"
+          ],
           "name": "Punchbowl Bus Company",
-          "numberOfServices": 1389,
+          "numberOfServices": 1526,
           "realTimeStatus": "CAPABLE",
           "types": [
             {
               "alt": "bus",
-              "identifier": "pt_pub_bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
               "localIcon": "bus"
             },
             {
               "alt": "bus",
-              "identifier": "pt_ltd_SCHOOLBUS",
+              "identifier": "pt_pub_bus",
               "localIcon": "bus"
             }
           ]
         },
         {
+          "modes": [
+            "pt_ltd_SCHOOLBUS",
+            "pt_pub_bus"
+          ],
           "name": "Forest Coach Lines",
-          "numberOfServices": 1029,
+          "numberOfServices": 1252,
           "realTimeStatus": "CAPABLE",
           "types": [
             {
               "alt": "bus",
-              "identifier": "pt_pub_bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
               "localIcon": "bus"
             },
             {
               "alt": "bus",
-              "identifier": "pt_ltd_SCHOOLBUS",
+              "identifier": "pt_pub_bus",
               "localIcon": "bus"
             }
           ]
         },
         {
-          "name": "Red Bus Service",
-          "numberOfServices": 1017,
-          "realTimeStatus": "CAPABLE",
-          "types": [
-            {
-              "alt": "bus",
-              "identifier": "pt_pub_bus",
-              "localIcon": "bus"
-            },
-            {
-              "alt": "bus",
-              "identifier": "pt_ltd_SCHOOLBUS",
-              "localIcon": "bus"
-            }
-          ]
-        },
-        {
+          "modes": [
+            "pt_pub_tram"
+          ],
           "name": "Sydney Light Rail",
-          "numberOfServices": 785,
+          "numberOfServices": 1117,
           "realTimeStatus": "CAPABLE",
           "types": [
             {
@@ -318,125 +498,77 @@
           ]
         },
         {
+          "modes": [
+            "pt_ltd_SCHOOLBUS",
+            "pt_pub_bus"
+          ],
+          "name": "Red Bus Service",
+          "numberOfServices": 913,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_ltd_SCHOOLBUS",
+            "pt_pub_bus"
+          ],
           "name": "Blue Mountains Transit",
-          "numberOfServices": 627,
+          "numberOfServices": 723,
           "realTimeStatus": "CAPABLE",
           "types": [
-            {
-              "alt": "bus",
-              "identifier": "pt_pub_bus",
-              "localIcon": "bus"
-            },
             {
               "alt": "bus",
               "identifier": "pt_ltd_SCHOOLBUS",
               "localIcon": "bus"
-            }
-          ]
-        },
-        {
-          "name": "Rover Coaches",
-          "numberOfServices": 284,
-          "realTimeStatus": "CAPABLE",
-          "types": [
-            {
-              "alt": "bus",
-              "identifier": "pt_pub_bus",
-              "localIcon": "bus"
             },
             {
               "alt": "bus",
-              "identifier": "pt_ltd_SCHOOLBUS",
-              "localIcon": "bus"
-            }
-          ]
-        },
-        {
-          "name": "Dions Bus Service",
-          "numberOfServices": 282,
-          "realTimeStatus": "CAPABLE",
-          "types": [
-            {
-              "alt": "bus",
-              "identifier": "pt_pub_bus",
-              "localIcon": "bus"
-            },
-            {
-              "alt": "bus",
-              "identifier": "pt_ltd_SCHOOLBUS",
-              "localIcon": "bus"
-            }
-          ]
-        },
-        {
-          "name": "Port Stephens Coaches",
-          "numberOfServices": 260,
-          "realTimeStatus": "CAPABLE",
-          "types": [
-            {
-              "alt": "bus",
-              "identifier": "pt_pub_bus",
-              "localIcon": "bus"
-            },
-            {
-              "alt": "bus",
-              "identifier": "pt_ltd_SCHOOLBUS",
-              "localIcon": "bus"
-            }
-          ]
-        },
-        {
-          "name": "NightRide",
-          "numberOfServices": 225,
-          "realTimeStatus": "CAPABLE",
-          "types": [
-            {
-              "alt": "bus",
               "identifier": "pt_pub_bus",
               "localIcon": "bus"
             }
           ]
         },
         {
-          "name": "Premier Charters",
-          "numberOfServices": 191,
-          "realTimeStatus": "CAPABLE",
-          "types": [
-            {
-              "alt": "bus",
-              "identifier": "pt_pub_bus",
-              "localIcon": "bus"
-            },
-            {
-              "alt": "bus",
-              "identifier": "pt_ltd_SCHOOLBUS",
-              "localIcon": "bus"
-            }
-          ]
-        },
-        {
-          "name": "Coastal Liner",
-          "numberOfServices": 126,
-          "realTimeStatus": "CAPABLE",
-          "types": [
-            {
-              "alt": "bus",
-              "identifier": "pt_pub_bus",
-              "localIcon": "bus"
-            },
-            {
-              "alt": "bus",
-              "identifier": "pt_ltd_SCHOOLBUS",
-              "localIcon": "bus"
-            }
-          ]
-        },
-        {
-          "name": "OPTUS BUS",
-          "numberOfServices": 113,
+          "modes": [
+            "pt_pub_ferry"
+          ],
+          "name": "Captain Cook Cruises",
+          "numberOfServices": 332,
           "realTimeStatus": "INCAPABLE",
           "types": [
             {
+              "alt": "ferry",
+              "identifier": "pt_pub_ferry",
+              "localIcon": "ferry"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_ltd_SCHOOLBUS",
+            "pt_pub_bus"
+          ],
+          "name": "Dions Bus Service",
+          "numberOfServices": 325,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
+            },
+            {
               "alt": "bus",
               "identifier": "pt_pub_bus",
               "localIcon": "bus"
@@ -444,8 +576,53 @@
           ]
         },
         {
-          "name": "Sydney Olympic Park Major Event Buses",
-          "numberOfServices": 10,
+          "modes": [
+            "pt_ltd_SCHOOLBUS",
+            "pt_pub_bus"
+          ],
+          "name": "Rover Coaches",
+          "numberOfServices": 271,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_ltd_SCHOOLBUS",
+            "pt_pub_bus"
+          ],
+          "name": "Port Stephens Coaches",
+          "numberOfServices": 262,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "NightRide",
+          "numberOfServices": 213,
           "realTimeStatus": "CAPABLE",
           "types": [
             {
@@ -454,76 +631,153 @@
               "localIcon": "bus"
             }
           ]
-        }
-      ],
-      "realtimeSnapshot": [
-        {
-          "alerts": {
-            "agenciesAlerts": 0,
-            "routesAlerts": 0,
-            "stopsAlerts": 0,
-            "tripsAlerts": 0
-          },
-          "computeTimeMillis": 1,
-          "fetcherFrequency": 30000,
-          "fetcherName": "G Sydney Buses GTFS-R",
-          "matchedServiceStops": 32374,
-          "matchedServices": 1135,
-          "positions": 1151,
-          "snapshotTimestamp": 1477614002000,
-          "totalServiceStops": 35758,
-          "totalServices": 3074
         },
         {
-          "alerts": {
-            "agenciesAlerts": 0,
-            "routesAlerts": 14,
-            "stopsAlerts": 4,
-            "tripsAlerts": 1
-          },
-          "computeTimeMillis": 1,
-          "fetcherFrequency": 30000,
-          "fetcherName": "G AU_NSW_Sydney Trains",
-          "matchedServiceStops": 778,
-          "matchedServices": 66,
-          "positions": 144,
-          "snapshotTimestamp": 1477613953000,
-          "totalServiceStops": 1467,
-          "totalServices": 304
+          "modes": [
+            "pt_pub_ferry"
+          ],
+          "name": "Manly Fast Ferry",
+          "numberOfServices": 190,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "ferry",
+              "identifier": "pt_pub_ferry",
+              "localIcon": "ferry"
+            }
+          ]
         },
         {
-          "alerts": {
-            "agenciesAlerts": 0,
-            "routesAlerts": 1,
-            "stopsAlerts": 0,
-            "tripsAlerts": 0
-          },
-          "computeTimeMillis": 0,
-          "fetcherFrequency": 30000,
-          "fetcherName": "G AU_NSW_Sydney Ferries",
-          "matchedServiceStops": 1371,
-          "matchedServices": 352,
-          "positions": 314,
-          "snapshotTimestamp": 1477613970000,
-          "totalServiceStops": 1546,
-          "totalServices": 352
+          "modes": [
+            "pt_ltd_SCHOOLBUS",
+            "pt_pub_bus"
+          ],
+          "name": "Premier Charters",
+          "numberOfServices": 190,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
         },
         {
-          "alerts": {
-            "agenciesAlerts": 0,
-            "routesAlerts": 0,
-            "stopsAlerts": 0,
-            "tripsAlerts": 0
-          },
-          "computeTimeMillis": 0,
-          "fetcherFrequency": 30000,
-          "fetcherName": "G AU_NSW_Sydney Trams",
-          "matchedServiceStops": 3,
-          "matchedServices": 3,
-          "positions": 4,
-          "snapshotTimestamp": 1477614020000,
-          "totalServiceStops": 3,
-          "totalServices": 4
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "OPTUS BUS",
+          "numberOfServices": 120,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_ltd_SCHOOLBUS",
+            "pt_pub_bus"
+          ],
+          "name": "Coastal Liner",
+          "numberOfServices": 94,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_ferry"
+          ],
+          "name": "Cronulla Ferries",
+          "numberOfServices": 50,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "ferry",
+              "identifier": "pt_pub_ferry",
+              "localIcon": "ferry"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_ferry"
+          ],
+          "name": "Palm Beach Ferry Service",
+          "numberOfServices": 44,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "ferry",
+              "identifier": "pt_pub_ferry",
+              "localIcon": "ferry"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_ferry"
+          ],
+          "name": "Church Point Ferry Service",
+          "numberOfServices": 39,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "ferry",
+              "identifier": "pt_pub_ferry",
+              "localIcon": "ferry"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_ferry"
+          ],
+          "name": "Central Coast Ferries",
+          "numberOfServices": 32,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "ferry",
+              "identifier": "pt_pub_ferry",
+              "localIcon": "ferry"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_ferry"
+          ],
+          "name": "Brooklyn Ferry Service",
+          "numberOfServices": 30,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "ferry",
+              "identifier": "pt_pub_ferry",
+              "localIcon": "ferry"
+            }
+          ]
         }
       ],
       "streetBicyclePaths": true,
@@ -556,5 +810,5 @@
       "transitWheelchairAccessibility": true
     }
   ],
-  "server": "localhost.localdomain"
+  "server": "104.28.7.61"
 }

--- a/Tests/Data/regionInfo-Vancouver.json
+++ b/Tests/Data/regionInfo-Vancouver.json
@@ -1,0 +1,386 @@
+{
+  "regions": [
+    {
+      "allowsBicyclesOnPublicTransport": true,
+      "bikeShare": [
+        {
+          "URL": "https://www.mobibikes.ca/",
+          "color": {
+            "blue": 223,
+            "green": 171,
+            "red": 0
+          },
+          "integrations": [
+            "real_time",
+            "routing"
+          ],
+          "modeIdentifier": "cy_bic-s_mobibikes",
+          "title": "Mobi"
+        }
+      ],
+      "code": "CA_BC_Vancouver",
+      "extraModes": [
+        {
+          "color": {
+            "blue": 62,
+            "green": 202,
+            "red": 221
+          },
+          "integrations": [
+            "routing"
+          ],
+          "modeIdentifier": "ps_tax",
+          "title": "Taxi"
+        },
+        {
+          "URL": "https://modo.coop/",
+          "color": {
+            "blue": 54,
+            "green": 62,
+            "red": 239
+          },
+          "icon": "modo",
+          "integrations": [
+            "real_time",
+            "routing"
+          ],
+          "modeIdentifier": "me_car-s_MODO",
+          "title": "Modo"
+        },
+        {
+          "URL": "https://www.mobibikes.ca/",
+          "color": {
+            "blue": 223,
+            "green": 171,
+            "red": 0
+          },
+          "integrations": [
+            "real_time",
+            "routing"
+          ],
+          "modeIdentifier": "cy_bic-s_mobibikes",
+          "title": "Mobi"
+        }
+      ],
+      "hasSchoolServices": false,
+      "hasWheelchairInformation": false,
+      "modes": {
+        "cy_bic-s": {
+          "color": {
+            "blue": 99,
+            "green": 199,
+            "red": 30
+          },
+          "identifier": "cy_bic-s",
+          "specificModes": [
+            {
+              "color": {
+                "blue": 223,
+                "green": 171,
+                "red": 0
+              },
+              "identifier": "cy_bic-s_mobibikes",
+              "integrations": [
+                "real_time",
+                "routing"
+              ],
+              "minimumLocalCostForMembership": 9.75,
+              "title": "Mobi",
+              "url": "https://www.mobibikes.ca/"
+            }
+          ],
+          "title": "Bike share"
+        },
+        "me_car-s": {
+          "color": {
+            "blue": 243,
+            "green": 169,
+            "red": 115
+          },
+          "identifier": "me_car-s",
+          "specificModes": [
+            {
+              "color": {
+                "blue": 54,
+                "green": 62,
+                "red": 239
+              },
+              "identifier": "me_car-s_MODO",
+              "integrations": [
+                "real_time",
+                "routing"
+              ],
+              "minimumLocalCostForMembership": 1,
+              "remoteIcon": "modo",
+              "title": "Modo",
+              "url": "https://modo.coop/"
+            }
+          ],
+          "title": "Car share"
+        },
+        "ps_tax": {
+          "color": {
+            "blue": 62,
+            "green": 202,
+            "red": 221
+          },
+          "identifier": "ps_tax",
+          "title": "Taxi"
+        },
+        "pt_pub": {
+          "color": {
+            "blue": 104,
+            "green": 197,
+            "red": 45
+          },
+          "identifier": "pt_pub",
+          "specificModes": [
+            {
+              "alt": "train",
+              "identifier": "pt_pub_train",
+              "localIcon": "train",
+              "operators": [
+                "West Coast Express"
+              ]
+            },
+            {
+              "alt": "subway",
+              "identifier": "pt_pub_subway",
+              "localIcon": "subway",
+              "operators": [
+                "British Columbia Rapid Transit Company"
+              ]
+            },
+            {
+              "alt": "ferry",
+              "identifier": "pt_pub_ferry",
+              "localIcon": "ferry",
+              "operators": [
+                "TransLink"
+              ]
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus",
+              "operators": [
+                "TransLink",
+                "BC Transit - Central Fraser Valley Transit System",
+                "BC Transit - Whistler Transit System",
+                "BC Transit - RDN Transit System",
+                "BC Transit - Chilliwack Transit System",
+                "BC Transit - Comox Valley Transit System",
+                "BC Transit - Sunshine Coast Transit System",
+                "BC Transit - Squamish Transit System",
+                "BC Transit - Fraser Valley Express"
+              ]
+            }
+          ],
+          "title": "Public transport"
+        }
+      },
+      "operators": [
+        {
+          "modes": [
+            "pt_pub_bus",
+            "pt_pub_ferry"
+          ],
+          "name": "TransLink",
+          "numberOfServices": 70927,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            },
+            {
+              "alt": "ferry",
+              "identifier": "pt_pub_ferry",
+              "localIcon": "ferry"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_subway"
+          ],
+          "name": "British Columbia Rapid Transit Company",
+          "numberOfServices": 7052,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "subway",
+              "identifier": "pt_pub_subway",
+              "localIcon": "subway"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "BC Transit - Central Fraser Valley Transit System",
+          "numberOfServices": 1554,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "BC Transit - Whistler Transit System",
+          "numberOfServices": 1398,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "BC Transit - RDN Transit System",
+          "numberOfServices": 1128,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "BC Transit - Chilliwack Transit System",
+          "numberOfServices": 536,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "BC Transit - Comox Valley Transit System",
+          "numberOfServices": 417,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "BC Transit - Sunshine Coast Transit System",
+          "numberOfServices": 282,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "BC Transit - Squamish Transit System",
+          "numberOfServices": 241,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "BC Transit - Fraser Valley Express",
+          "numberOfServices": 50,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_train"
+          ],
+          "name": "West Coast Express",
+          "numberOfServices": 18,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "train",
+              "identifier": "pt_pub_train",
+              "localIcon": "train"
+            }
+          ]
+        }
+      ],
+      "streetBicyclePaths": true,
+      "streetWheelchairAccessibility": true,
+      "supportsConcessionPricing": true,
+      "transitBicycleAccessibility": true,
+      "transitConcessionPricing": true,
+      "transitModes": [
+        {
+          "alt": "train",
+          "identifier": "pt_pub_train",
+          "localIcon": "train"
+        },
+        {
+          "alt": "subway",
+          "identifier": "pt_pub_subway",
+          "localIcon": "subway"
+        },
+        {
+          "alt": "ferry",
+          "identifier": "pt_pub_ferry",
+          "localIcon": "ferry"
+        },
+        {
+          "alt": "bus",
+          "identifier": "pt_pub_bus",
+          "localIcon": "bus"
+        }
+      ],
+      "transitWheelchairAccessibility": false
+    }
+  ],
+  "server": "104.28.7.61"
+}

--- a/Tests/Data/regionInfo-Vancouver.json
+++ b/Tests/Data/regionInfo-Vancouver.json
@@ -11,8 +11,8 @@
             "red": 0
           },
           "integrations": [
-            "real_time",
-            "routing"
+            "routing",
+            "real_time"
           ],
           "modeIdentifier": "cy_bic-s_mobibikes",
           "title": "Mobi"
@@ -41,11 +41,23 @@
           },
           "icon": "modo",
           "integrations": [
-            "real_time",
-            "routing"
+            "routing",
+            "real_time"
           ],
           "modeIdentifier": "me_car-s_MODO",
           "title": "Modo"
+        },
+        {
+          "color": {
+            "blue": 243,
+            "green": 169,
+            "red": 115
+          },
+          "integrations": [
+            "routing"
+          ],
+          "modeIdentifier": "me_car-r_SwiftFleet",
+          "title": "Car rental"
         },
         {
           "URL": "https://www.mobibikes.ca/",
@@ -55,8 +67,8 @@
             "red": 0
           },
           "integrations": [
-            "real_time",
-            "routing"
+            "routing",
+            "real_time"
           ],
           "modeIdentifier": "cy_bic-s_mobibikes",
           "title": "Mobi"
@@ -66,52 +78,102 @@
       "hasWheelchairInformation": false,
       "modes": {
         "cy_bic-s": {
-          "color": {
-            "blue": 99,
-            "green": 199,
-            "red": 30
+          "modeInfo": {
+            "alt": "Bike share",
+            "color": {
+              "blue": 99,
+              "green": 199,
+              "red": 30
+            },
+            "identifier": "cy_bic-s",
+            "localIcon": "bicycle-share"
           },
-          "identifier": "cy_bic-s",
           "specificModes": [
             {
-              "color": {
-                "blue": 223,
-                "green": 171,
-                "red": 0
-              },
-              "identifier": "cy_bic-s_mobibikes",
               "integrations": [
-                "real_time",
-                "routing"
+                "routing",
+                "real_time"
               ],
               "minimumLocalCostForMembership": 9.75,
+              "modeInfo": {
+                "alt": "Mobi",
+                "color": {
+                  "blue": 223,
+                  "green": 171,
+                  "red": 0
+                },
+                "description": "Mobi",
+                "identifier": "cy_bic-s_mobibikes",
+                "localIcon": "bicycle-share"
+              },
               "title": "Mobi",
               "url": "https://www.mobibikes.ca/"
             }
           ],
           "title": "Bike share"
         },
-        "me_car-s": {
-          "color": {
-            "blue": 243,
-            "green": 169,
-            "red": 115
-          },
-          "identifier": "me_car-s",
-          "specificModes": [
+        "me_car-r": {
+          "lockedModes": [
             {
-              "color": {
-                "blue": 54,
-                "green": 62,
-                "red": 239
-              },
-              "identifier": "me_car-s_MODO",
               "integrations": [
-                "real_time",
                 "routing"
               ],
+              "minimumLocalCostForMembership": 0,
+              "modeInfo": {
+                "alt": "Car rental",
+                "color": {
+                  "blue": 243,
+                  "green": 169,
+                  "red": 115
+                },
+                "identifier": "me_car-r_SwiftFleet",
+                "localIcon": "car-share"
+              },
+              "title": "Car rental"
+            }
+          ],
+          "modeInfo": {
+            "alt": "Car rental",
+            "color": {
+              "blue": 243,
+              "green": 169,
+              "red": 115
+            },
+            "identifier": "me_car-r",
+            "localIcon": "car-share"
+          },
+          "title": "Car rental"
+        },
+        "me_car-s": {
+          "modeInfo": {
+            "alt": "Car share",
+            "color": {
+              "blue": 243,
+              "green": 169,
+              "red": 115
+            },
+            "identifier": "me_car-s",
+            "localIcon": "car-share"
+          },
+          "specificModes": [
+            {
+              "integrations": [
+                "routing",
+                "real_time"
+              ],
               "minimumLocalCostForMembership": 1,
-              "remoteIcon": "modo",
+              "modeInfo": {
+                "alt": "Modo",
+                "color": {
+                  "blue": 54,
+                  "green": 62,
+                  "red": 239
+                },
+                "description": "Modo",
+                "identifier": "me_car-s_MODO",
+                "localIcon": "car-share",
+                "remoteIcon": "modo"
+              },
               "title": "Modo",
               "url": "https://modo.coop/"
             }
@@ -119,50 +181,57 @@
           "title": "Car share"
         },
         "ps_tax": {
-          "color": {
-            "blue": 62,
-            "green": 202,
-            "red": 221
+          "modeInfo": {
+            "alt": "Taxi",
+            "color": {
+              "blue": 62,
+              "green": 202,
+              "red": 221
+            },
+            "identifier": "ps_tax",
+            "localIcon": "taxi"
           },
-          "identifier": "ps_tax",
           "title": "Taxi"
         },
         "pt_pub": {
-          "color": {
-            "blue": 104,
-            "green": 197,
-            "red": 45
+          "modeInfo": {
+            "alt": "Public transport",
+            "color": {
+              "blue": 104,
+              "green": 197,
+              "red": 45
+            },
+            "identifier": "pt_pub",
+            "localIcon": "public"
           },
-          "identifier": "pt_pub",
           "specificModes": [
             {
-              "alt": "train",
-              "identifier": "pt_pub_train",
-              "localIcon": "train",
+              "modeInfo": {
+                "alt": "train",
+                "identifier": "pt_pub_train",
+                "localIcon": "train"
+              },
               "operators": [
+                "British Columbia Rapid Transit Company",
                 "West Coast Express"
               ]
             },
             {
-              "alt": "subway",
-              "identifier": "pt_pub_subway",
-              "localIcon": "subway",
-              "operators": [
-                "British Columbia Rapid Transit Company"
-              ]
-            },
-            {
-              "alt": "ferry",
-              "identifier": "pt_pub_ferry",
-              "localIcon": "ferry",
+              "modeInfo": {
+                "alt": "ferry",
+                "identifier": "pt_pub_ferry",
+                "localIcon": "ferry"
+              },
               "operators": [
                 "TransLink"
               ]
             },
             {
-              "alt": "bus",
-              "identifier": "pt_pub_bus",
-              "localIcon": "bus",
+              "modeInfo": {
+                "alt": "bus",
+                "identifier": "pt_pub_bus",
+                "localIcon": "bus"
+              },
               "operators": [
                 "TransLink",
                 "BC Transit - Central Fraser Valley Transit System",
@@ -182,37 +251,37 @@
       "operators": [
         {
           "modes": [
-            "pt_pub_bus",
-            "pt_pub_ferry"
+            "pt_pub_ferry",
+            "pt_pub_bus"
           ],
           "name": "TransLink",
           "numberOfServices": 70927,
           "realTimeStatus": "CAPABLE",
           "types": [
             {
-              "alt": "bus",
-              "identifier": "pt_pub_bus",
-              "localIcon": "bus"
-            },
-            {
               "alt": "ferry",
               "identifier": "pt_pub_ferry",
               "localIcon": "ferry"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
             }
           ]
         },
         {
           "modes": [
-            "pt_pub_subway"
+            "pt_pub_train"
           ],
           "name": "British Columbia Rapid Transit Company",
           "numberOfServices": 7052,
           "realTimeStatus": "CAPABLE",
           "types": [
             {
-              "alt": "subway",
-              "identifier": "pt_pub_subway",
-              "localIcon": "subway"
+              "alt": "train",
+              "identifier": "pt_pub_train",
+              "localIcon": "train"
             }
           ]
         },
@@ -362,11 +431,6 @@
           "alt": "train",
           "identifier": "pt_pub_train",
           "localIcon": "train"
-        },
-        {
-          "alt": "subway",
-          "identifier": "pt_pub_subway",
-          "localIcon": "subway"
         },
         {
           "alt": "ferry",

--- a/Tests/Data/regionInfo-Vancouver.json
+++ b/Tests/Data/regionInfo-Vancouver.json
@@ -48,18 +48,6 @@
           "title": "Modo"
         },
         {
-          "color": {
-            "blue": 243,
-            "green": 169,
-            "red": 115
-          },
-          "integrations": [
-            "routing"
-          ],
-          "modeIdentifier": "me_car-r_SwiftFleet",
-          "title": "Car rental"
-        },
-        {
           "URL": "https://www.mobibikes.ca/",
           "color": {
             "blue": 223,
@@ -145,6 +133,28 @@
           "title": "Car rental"
         },
         "me_car-s": {
+          "lockedModes": [
+            {
+              "integrations": [
+                "routing"
+              ],
+              "modeInfo": {
+                "alt": "Zipcar",
+                "color": {
+                  "blue": 28,
+                  "green": 164,
+                  "red": 84
+                },
+                "description": "Zipcar",
+                "identifier": "me_car-s_ZIP",
+                "localIcon": "car-share",
+                "remoteDarkIcon": "zipcar-dark",
+                "remoteIcon": "zipcar"
+              },
+              "title": "Zipcar",
+              "url": "http://www.zipcar.com/"
+            }
+          ],
           "modeInfo": {
             "alt": "Car share",
             "color": {
@@ -202,7 +212,7 @@
               "red": 45
             },
             "identifier": "pt_pub",
-            "localIcon": "public"
+            "localIcon": "public-transport"
           },
           "specificModes": [
             {
@@ -212,8 +222,17 @@
                 "localIcon": "train"
               },
               "operators": [
-                "British Columbia Rapid Transit Company",
                 "West Coast Express"
+              ]
+            },
+            {
+              "modeInfo": {
+                "alt": "subway",
+                "identifier": "pt_pub_subway",
+                "localIcon": "subway"
+              },
+              "operators": [
+                "British Columbia Rapid Transit Company"
               ]
             },
             {
@@ -251,37 +270,37 @@
       "operators": [
         {
           "modes": [
-            "pt_pub_ferry",
-            "pt_pub_bus"
+            "pt_pub_bus",
+            "pt_pub_ferry"
           ],
           "name": "TransLink",
           "numberOfServices": 70927,
           "realTimeStatus": "CAPABLE",
           "types": [
             {
-              "alt": "ferry",
-              "identifier": "pt_pub_ferry",
-              "localIcon": "ferry"
-            },
-            {
               "alt": "bus",
               "identifier": "pt_pub_bus",
               "localIcon": "bus"
+            },
+            {
+              "alt": "ferry",
+              "identifier": "pt_pub_ferry",
+              "localIcon": "ferry"
             }
           ]
         },
         {
           "modes": [
-            "pt_pub_train"
+            "pt_pub_subway"
           ],
           "name": "British Columbia Rapid Transit Company",
           "numberOfServices": 7052,
           "realTimeStatus": "CAPABLE",
           "types": [
             {
-              "alt": "train",
-              "identifier": "pt_pub_train",
-              "localIcon": "train"
+              "alt": "subway",
+              "identifier": "pt_pub_subway",
+              "localIcon": "subway"
             }
           ]
         },
@@ -433,6 +452,11 @@
           "localIcon": "train"
         },
         {
+          "alt": "subway",
+          "identifier": "pt_pub_subway",
+          "localIcon": "subway"
+        },
+        {
           "alt": "ferry",
           "identifier": "pt_pub_ferry",
           "localIcon": "ferry"
@@ -446,5 +470,5 @@
       "transitWheelchairAccessibility": false
     }
   ],
-  "server": "104.28.7.61"
+  "server": "104.28.6.61"
 }

--- a/Tests/Data/regionInfo-multi.json
+++ b/Tests/Data/regionInfo-multi.json
@@ -1,0 +1,3797 @@
+{
+  "regions": [
+    {
+      "allowsBicyclesOnPublicTransport": true,
+      "bikeShare": [],
+      "code": "AU_NSW_Sydney",
+      "extraModes": [
+        {
+          "color": {
+            "blue": 62,
+            "green": 202,
+            "red": 221
+          },
+          "integrations": [
+            "routing"
+          ],
+          "modeIdentifier": "ps_tax",
+          "title": "Taxi"
+        },
+        {
+          "URL": "https://mydriver.com",
+          "color": {
+            "blue": 0,
+            "green": 0,
+            "red": 0
+          },
+          "icon": "mydriver",
+          "integrations": [
+            "routing"
+          ],
+          "modeIdentifier": "ps_tax_MYDRIVER",
+          "title": "myDriver"
+        },
+        {
+          "URL": "https://www.uber.com",
+          "color": {
+            "blue": 213,
+            "green": 186,
+            "red": 47
+          },
+          "icon": "uber",
+          "integrations": [
+            "bookings",
+            "routing",
+            "real_time"
+          ],
+          "modeIdentifier": "ps_tnc_UBER",
+          "title": "Uber"
+        },
+        {
+          "URL": "http://www.jayride.com.au/",
+          "color": {
+            "blue": 60,
+            "green": 123,
+            "red": 233
+          },
+          "integrations": [
+            "routing"
+          ],
+          "modeIdentifier": "ps_shu",
+          "title": "Shuttle"
+        },
+        {
+          "URL": "http://www.carnextdoor.com.au",
+          "color": {
+            "blue": 134,
+            "green": 82,
+            "red": 253
+          },
+          "icon": "carnextdoor",
+          "integrations": [
+            "routing"
+          ],
+          "modeIdentifier": "me_car-s_CND",
+          "title": "Car Next Door"
+        },
+        {
+          "URL": "http://www.goget.com.au/",
+          "color": {
+            "blue": 106,
+            "green": 63,
+            "red": 0
+          },
+          "darkIcon": "goget-dark",
+          "icon": "goget",
+          "integrations": [
+            "routing"
+          ],
+          "modeIdentifier": "me_car-s_GOG",
+          "title": "GoGet"
+        },
+        {
+          "color": {
+            "blue": 243,
+            "green": 169,
+            "red": 115
+          },
+          "integrations": [
+            "routing"
+          ],
+          "modeIdentifier": "me_car-r_SwiftFleet",
+          "title": "Car rental"
+        }
+      ],
+      "hasSchoolServices": true,
+      "hasWheelchairInformation": true,
+      "modes": {
+        "me_car-r": {
+          "lockedModes": [
+            {
+              "integrations": [
+                "routing"
+              ],
+              "minimumLocalCostForMembership": 0,
+              "modeInfo": {
+                "alt": "Car rental",
+                "color": {
+                  "blue": 243,
+                  "green": 169,
+                  "red": 115
+                },
+                "identifier": "me_car-r_SwiftFleet",
+                "localIcon": "car-share"
+              },
+              "title": "Car rental"
+            }
+          ],
+          "modeInfo": {
+            "alt": "Car rental",
+            "color": {
+              "blue": 243,
+              "green": 169,
+              "red": 115
+            },
+            "identifier": "me_car-r",
+            "localIcon": "car-share"
+          },
+          "title": "Car rental"
+        },
+        "me_car-s": {
+          "lockedModes": [
+            {
+              "integrations": [
+                "routing"
+              ],
+              "modeInfo": {
+                "alt": "Car Next Door",
+                "color": {
+                  "blue": 134,
+                  "green": 82,
+                  "red": 253
+                },
+                "description": "Car Next Door",
+                "identifier": "me_car-s_CND",
+                "localIcon": "car-share",
+                "remoteIcon": "carnextdoor"
+              },
+              "title": "Car Next Door",
+              "url": "http://www.carnextdoor.com.au"
+            },
+            {
+              "integrations": [
+                "routing"
+              ],
+              "modeInfo": {
+                "alt": "GoGet",
+                "color": {
+                  "blue": 106,
+                  "green": 63,
+                  "red": 0
+                },
+                "description": "GoGet",
+                "identifier": "me_car-s_GOG",
+                "localIcon": "car-share",
+                "remoteDarkIcon": "goget-dark",
+                "remoteIcon": "goget"
+              },
+              "title": "GoGet",
+              "url": "http://www.goget.com.au/"
+            }
+          ],
+          "modeInfo": {
+            "alt": "Car share",
+            "color": {
+              "blue": 243,
+              "green": 169,
+              "red": 115
+            },
+            "identifier": "me_car-s",
+            "localIcon": "car-share"
+          },
+          "title": "Car share"
+        },
+        "ps_shu": {
+          "modeInfo": {
+            "alt": "Shuttle",
+            "color": {
+              "blue": 60,
+              "green": 123,
+              "red": 233
+            },
+            "identifier": "ps_shu",
+            "localIcon": "shuttlebus"
+          },
+          "title": "Shuttle",
+          "url": "http://www.jayride.com.au/"
+        },
+        "ps_tax": {
+          "modeInfo": {
+            "alt": "Taxi",
+            "color": {
+              "blue": 62,
+              "green": 202,
+              "red": 221
+            },
+            "identifier": "ps_tax",
+            "localIcon": "taxi"
+          },
+          "title": "Taxi",
+          "lockedModes": [
+            {
+              "integrations": [
+                "routing"
+              ],
+              "modeInfo": {
+                "alt": "myDriver",
+                "color": {
+                  "blue": 0,
+                  "green": 0,
+                  "red": 0
+                },
+                "description": "myDriver",
+                "identifier": "ps_tax_MYDRIVER",
+                "localIcon": "taxi",
+                "remoteIcon": "mydriver"
+              },
+              "title": "myDriver",
+              "url": "https://mydriver.com"
+            }
+          ]
+        },
+        "ps_tnc": {
+          "lockedModes": [
+            {
+              "integrations": [
+                "bookings",
+                "routing",
+                "real_time"
+              ],
+              "modeInfo": {
+                "alt": "Uber",
+                "color": {
+                  "blue": 213,
+                  "green": 186,
+                  "red": 47
+                },
+                "description": "Uber",
+                "identifier": "ps_tnc_UBER",
+                "localIcon": "tnc",
+                "remoteIcon": "uber"
+              },
+              "title": "Uber",
+              "url": "https://www.uber.com"
+            }
+          ],
+          "modeInfo": {
+            "alt": "Ride share",
+            "color": {
+              "blue": 243,
+              "green": 169,
+              "red": 115
+            },
+            "identifier": "ps_tnc",
+            "localIcon": "tnc"
+          },
+          "title": "Ride share"
+        },
+        "pt_pub": {
+          "modeInfo": {
+            "alt": "Public transport",
+            "color": {
+              "blue": 104,
+              "green": 197,
+              "red": 45
+            },
+            "identifier": "pt_pub",
+            "localIcon": "public"
+          },
+          "specificModes": [
+            {
+              "modeInfo": {
+                "alt": "train",
+                "identifier": "pt_pub_train",
+                "localIcon": "train"
+              },
+              "operators": [
+                "Sydney Trains",
+                "NSW Trains"
+              ]
+            },
+            {
+              "modeInfo": {
+                "alt": "tram",
+                "identifier": "pt_pub_tram",
+                "localIcon": "tram"
+              },
+              "operators": [
+                "Sydney Light Rail"
+              ]
+            },
+            {
+              "modeInfo": {
+                "alt": "ferry",
+                "identifier": "pt_pub_ferry",
+                "localIcon": "ferry"
+              },
+              "operators": [
+                "Newcastle Transport",
+                "Sydney Ferries",
+                "Captain Cook Cruises",
+                "Manly Fast Ferry",
+                "Cronulla Ferries",
+                "Palm Beach Ferry Service",
+                "Church Point Ferry Service",
+                "Central Coast Ferries",
+                "Brooklyn Ferry Service"
+              ]
+            },
+            {
+              "modeInfo": {
+                "alt": "bus",
+                "identifier": "pt_pub_bus",
+                "localIcon": "bus"
+              },
+              "operators": [
+                "State Transit Sydney",
+                "Transdev NSW",
+                "Busways Western Sydney",
+                "Hillsbus",
+                "Transit Systems",
+                "Hunter Valley Buses",
+                "Newcastle Transport",
+                "Busways Central Coast",
+                "Busabout",
+                "Interline Bus Services",
+                "Premier Illawarra",
+                "Punchbowl Bus Company",
+                "Forest Coach Lines",
+                "Red Bus Service",
+                "Blue Mountains Transit",
+                "Dions Bus Service",
+                "Rover Coaches",
+                "Port Stephens Coaches",
+                "NightRide",
+                "Premier Charters",
+                "OPTUS BUS",
+                "Coastal Liner"
+              ]
+            }
+          ],
+          "title": "Public transport"
+        }
+      },
+      "operators": [
+        {
+          "modes": [
+            "pt_pub_train"
+          ],
+          "name": "Sydney Trains",
+          "numberOfServices": 38201,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "train",
+              "identifier": "pt_pub_train",
+              "localIcon": "train"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_ltd_SCHOOLBUS",
+            "pt_pub_bus"
+          ],
+          "name": "State Transit Sydney",
+          "numberOfServices": 37917,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_train"
+          ],
+          "name": "NSW Trains",
+          "numberOfServices": 7141,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "train",
+              "identifier": "pt_pub_train",
+              "localIcon": "train"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus",
+            "pt_ltd_SCHOOLBUS"
+          ],
+          "name": "Transdev NSW",
+          "numberOfServices": 6907,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus",
+            "pt_ltd_SCHOOLBUS"
+          ],
+          "name": "Busways Western Sydney",
+          "numberOfServices": 6092,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus",
+            "pt_ltd_SCHOOLBUS"
+          ],
+          "name": "Hillsbus",
+          "numberOfServices": 5947,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus",
+            "pt_ltd_SCHOOLBUS"
+          ],
+          "name": "Transit Systems",
+          "numberOfServices": 2856,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus",
+            "pt_ltd_SCHOOLBUS"
+          ],
+          "name": "Hunter Valley Buses",
+          "numberOfServices": 2800,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_ferry",
+            "pt_pub_bus",
+            "pt_ltd_SCHOOLBUS"
+          ],
+          "name": "Newcastle Transport",
+          "numberOfServices": 2761,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "ferry",
+              "identifier": "pt_pub_ferry",
+              "localIcon": "ferry"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus",
+            "pt_ltd_SCHOOLBUS"
+          ],
+          "name": "Busways Central Coast",
+          "numberOfServices": 2416,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus",
+            "pt_ltd_SCHOOLBUS"
+          ],
+          "name": "Busabout",
+          "numberOfServices": 2087,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_ferry"
+          ],
+          "name": "Sydney Ferries",
+          "numberOfServices": 1889,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "ferry",
+              "identifier": "pt_pub_ferry",
+              "localIcon": "ferry"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_ltd_SCHOOLBUS",
+            "pt_pub_bus"
+          ],
+          "name": "Interline Bus Services",
+          "numberOfServices": 1879,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus",
+            "pt_ltd_SCHOOLBUS"
+          ],
+          "name": "Premier Illawarra",
+          "numberOfServices": 1789,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus",
+            "pt_ltd_SCHOOLBUS"
+          ],
+          "name": "Punchbowl Bus Company",
+          "numberOfServices": 1558,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus",
+            "pt_ltd_SCHOOLBUS"
+          ],
+          "name": "Forest Coach Lines",
+          "numberOfServices": 1142,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_tram"
+          ],
+          "name": "Sydney Light Rail",
+          "numberOfServices": 1117,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "tram",
+              "identifier": "pt_pub_tram",
+              "localIcon": "tram"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus",
+            "pt_ltd_SCHOOLBUS"
+          ],
+          "name": "Red Bus Service",
+          "numberOfServices": 912,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_ltd_SCHOOLBUS",
+            "pt_pub_bus"
+          ],
+          "name": "Blue Mountains Transit",
+          "numberOfServices": 765,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus",
+            "pt_ltd_SCHOOLBUS"
+          ],
+          "name": "Dions Bus Service",
+          "numberOfServices": 347,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_ferry"
+          ],
+          "name": "Captain Cook Cruises",
+          "numberOfServices": 278,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "ferry",
+              "identifier": "pt_pub_ferry",
+              "localIcon": "ferry"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus",
+            "pt_ltd_SCHOOLBUS"
+          ],
+          "name": "Rover Coaches",
+          "numberOfServices": 275,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_ltd_SCHOOLBUS",
+            "pt_pub_bus"
+          ],
+          "name": "Port Stephens Coaches",
+          "numberOfServices": 244,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "NightRide",
+          "numberOfServices": 208,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_ferry"
+          ],
+          "name": "Manly Fast Ferry",
+          "numberOfServices": 190,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "ferry",
+              "identifier": "pt_pub_ferry",
+              "localIcon": "ferry"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_ltd_SCHOOLBUS",
+            "pt_pub_bus"
+          ],
+          "name": "Premier Charters",
+          "numberOfServices": 190,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "OPTUS BUS",
+          "numberOfServices": 120,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_ltd_SCHOOLBUS",
+            "pt_pub_bus"
+          ],
+          "name": "Coastal Liner",
+          "numberOfServices": 94,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_ltd_SCHOOLBUS",
+              "localIcon": "bus"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_ferry"
+          ],
+          "name": "Cronulla Ferries",
+          "numberOfServices": 50,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "ferry",
+              "identifier": "pt_pub_ferry",
+              "localIcon": "ferry"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_ferry"
+          ],
+          "name": "Palm Beach Ferry Service",
+          "numberOfServices": 44,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "ferry",
+              "identifier": "pt_pub_ferry",
+              "localIcon": "ferry"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_ferry"
+          ],
+          "name": "Church Point Ferry Service",
+          "numberOfServices": 39,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "ferry",
+              "identifier": "pt_pub_ferry",
+              "localIcon": "ferry"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_ferry"
+          ],
+          "name": "Central Coast Ferries",
+          "numberOfServices": 32,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "ferry",
+              "identifier": "pt_pub_ferry",
+              "localIcon": "ferry"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_ferry"
+          ],
+          "name": "Brooklyn Ferry Service",
+          "numberOfServices": 30,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "ferry",
+              "identifier": "pt_pub_ferry",
+              "localIcon": "ferry"
+            }
+          ]
+        }
+      ],
+      "streetBicyclePaths": true,
+      "streetWheelchairAccessibility": true,
+      "supportsConcessionPricing": true,
+      "transitBicycleAccessibility": true,
+      "transitConcessionPricing": true,
+      "transitModes": [
+        {
+          "alt": "train",
+          "identifier": "pt_pub_train",
+          "localIcon": "train"
+        },
+        {
+          "alt": "tram",
+          "identifier": "pt_pub_tram",
+          "localIcon": "tram"
+        },
+        {
+          "alt": "ferry",
+          "identifier": "pt_pub_ferry",
+          "localIcon": "ferry"
+        },
+        {
+          "alt": "bus",
+          "identifier": "pt_pub_bus",
+          "localIcon": "bus"
+        }
+      ],
+      "transitWheelchairAccessibility": true
+    },
+    {
+      "allowsBicyclesOnPublicTransport": true,
+      "bikeShare": [
+        {
+          "URL": "http://www.melbournebikeshare.com.au",
+          "color": {
+            "blue": 174,
+            "green": 70,
+            "red": 0
+          },
+          "icon": "melbournebikeshare",
+          "integrations": [
+            "routing",
+            "real_time"
+          ],
+          "modeIdentifier": "cy_bic-s_melbourne-bike-share",
+          "title": "Melbourne Bike Share"
+        },
+        {
+          "URL": "https://monashbikeshare.com/",
+          "color": {
+            "blue": 0,
+            "green": 0,
+            "red": 200
+          },
+          "integrations": [
+            "routing",
+            "real_time"
+          ],
+          "modeIdentifier": "cy_bic-s_SoBi36",
+          "title": "Monash Bike Share"
+        }
+      ],
+      "code": "AU_VIC_Melbourne",
+      "extraModes": [
+        {
+          "color": {
+            "blue": 62,
+            "green": 202,
+            "red": 221
+          },
+          "integrations": [
+            "routing"
+          ],
+          "modeIdentifier": "ps_tax",
+          "title": "Taxi"
+        },
+        {
+          "URL": "https://mydriver.com",
+          "color": {
+            "blue": 0,
+            "green": 0,
+            "red": 0
+          },
+          "icon": "mydriver",
+          "integrations": [
+            "routing"
+          ],
+          "modeIdentifier": "ps_tax_MYDRIVER",
+          "title": "myDriver"
+        },
+        {
+          "URL": "https://www.uber.com",
+          "color": {
+            "blue": 213,
+            "green": 186,
+            "red": 47
+          },
+          "icon": "uber",
+          "integrations": [
+            "bookings",
+            "routing",
+            "real_time"
+          ],
+          "modeIdentifier": "ps_tnc_UBER",
+          "title": "Uber"
+        },
+        {
+          "URL": "http://www.jayride.com.au/",
+          "color": {
+            "blue": 60,
+            "green": 123,
+            "red": 233
+          },
+          "integrations": [
+            "routing"
+          ],
+          "modeIdentifier": "ps_shu",
+          "title": "Shuttle"
+        },
+        {
+          "URL": "http://www.flexicar.com.au",
+          "color": {
+            "blue": 243,
+            "green": 169,
+            "red": 115
+          },
+          "integrations": [
+            "routing"
+          ],
+          "modeIdentifier": "me_car-s_FLX",
+          "title": "Flexicar"
+        },
+        {
+          "URL": "http://www.goget.com.au/",
+          "color": {
+            "blue": 106,
+            "green": 63,
+            "red": 0
+          },
+          "darkIcon": "goget-dark",
+          "icon": "goget",
+          "integrations": [
+            "routing"
+          ],
+          "modeIdentifier": "me_car-s_GOG",
+          "title": "GoGet"
+        },
+        {
+          "color": {
+            "blue": 243,
+            "green": 169,
+            "red": 115
+          },
+          "integrations": [
+            "routing"
+          ],
+          "modeIdentifier": "me_car-r_SwiftFleet",
+          "title": "Car rental"
+        },
+        {
+          "URL": "http://www.melbournebikeshare.com.au",
+          "color": {
+            "blue": 174,
+            "green": 70,
+            "red": 0
+          },
+          "icon": "melbournebikeshare",
+          "integrations": [
+            "routing",
+            "real_time"
+          ],
+          "modeIdentifier": "cy_bic-s_melbourne-bike-share",
+          "title": "Melbourne Bike Share"
+        },
+        {
+          "URL": "https://monashbikeshare.com/",
+          "color": {
+            "blue": 0,
+            "green": 0,
+            "red": 200
+          },
+          "integrations": [
+            "routing",
+            "real_time"
+          ],
+          "modeIdentifier": "cy_bic-s_SoBi36",
+          "title": "Monash Bike Share"
+        }
+      ],
+      "hasSchoolServices": false,
+      "hasWheelchairInformation": false,
+      "modes": {
+        "cy_bic-s": {
+          "modeInfo": {
+            "alt": "Bike share",
+            "color": {
+              "blue": 99,
+              "green": 199,
+              "red": 30
+            },
+            "identifier": "cy_bic-s",
+            "localIcon": "bicycle-share"
+          },
+          "specificModes": [
+            {
+              "integrations": [
+                "routing",
+                "real_time"
+              ],
+              "minimumLocalCostForMembership": 3,
+              "modeInfo": {
+                "alt": "Melbourne Bike Share",
+                "color": {
+                  "blue": 174,
+                  "green": 70,
+                  "red": 0
+                },
+                "description": "Melbourne Bike Share",
+                "identifier": "cy_bic-s_melbourne-bike-share",
+                "localIcon": "bicycle-share",
+                "remoteIcon": "melbournebikeshare"
+              },
+              "title": "Melbourne Bike Share",
+              "url": "http://www.melbournebikeshare.com.au"
+            },
+            {
+              "integrations": [
+                "routing",
+                "real_time"
+              ],
+              "minimumLocalCostForMembership": 0,
+              "modeInfo": {
+                "alt": "Monash Bike Share",
+                "color": {
+                  "blue": 0,
+                  "green": 0,
+                  "red": 200
+                },
+                "description": "Monash Bike Share",
+                "identifier": "cy_bic-s_SoBi36",
+                "localIcon": "bicycle-share"
+              },
+              "title": "Monash Bike Share",
+              "url": "https://monashbikeshare.com/"
+            }
+          ],
+          "title": "Bike share"
+        },
+        "me_car-r": {
+          "lockedModes": [
+            {
+              "integrations": [
+                "routing"
+              ],
+              "minimumLocalCostForMembership": 0,
+              "modeInfo": {
+                "alt": "Car rental",
+                "color": {
+                  "blue": 243,
+                  "green": 169,
+                  "red": 115
+                },
+                "identifier": "me_car-r_SwiftFleet",
+                "localIcon": "car-share"
+              },
+              "title": "Car rental"
+            }
+          ],
+          "modeInfo": {
+            "alt": "Car rental",
+            "color": {
+              "blue": 243,
+              "green": 169,
+              "red": 115
+            },
+            "identifier": "me_car-r",
+            "localIcon": "car-share"
+          },
+          "title": "Car rental"
+        },
+        "me_car-s": {
+          "lockedModes": [
+            {
+              "integrations": [
+                "routing"
+              ],
+              "modeInfo": {
+                "alt": "Flexicar",
+                "color": {
+                  "blue": 243,
+                  "green": 169,
+                  "red": 115
+                },
+                "description": "Flexicar",
+                "identifier": "me_car-s_FLX",
+                "localIcon": "car-share"
+              },
+              "title": "Flexicar",
+              "url": "http://www.flexicar.com.au"
+            },
+            {
+              "integrations": [
+                "routing"
+              ],
+              "modeInfo": {
+                "alt": "GoGet",
+                "color": {
+                  "blue": 106,
+                  "green": 63,
+                  "red": 0
+                },
+                "description": "GoGet",
+                "identifier": "me_car-s_GOG",
+                "localIcon": "car-share",
+                "remoteDarkIcon": "goget-dark",
+                "remoteIcon": "goget"
+              },
+              "title": "GoGet",
+              "url": "http://www.goget.com.au/"
+            }
+          ],
+          "modeInfo": {
+            "alt": "Car share",
+            "color": {
+              "blue": 243,
+              "green": 169,
+              "red": 115
+            },
+            "identifier": "me_car-s",
+            "localIcon": "car-share"
+          },
+          "title": "Car share"
+        },
+        "ps_shu": {
+          "modeInfo": {
+            "alt": "Shuttle",
+            "color": {
+              "blue": 60,
+              "green": 123,
+              "red": 233
+            },
+            "identifier": "ps_shu",
+            "localIcon": "shuttlebus"
+          },
+          "title": "Shuttle",
+          "url": "http://www.jayride.com.au/"
+        },
+        "ps_tax": {
+          "lockedModes": [
+            {
+              "integrations": [
+                "routing"
+              ],
+              "modeInfo": {
+                "alt": "myDriver",
+                "color": {
+                  "blue": 0,
+                  "green": 0,
+                  "red": 0
+                },
+                "description": "myDriver",
+                "identifier": "ps_tax_MYDRIVER",
+                "localIcon": "taxi",
+                "remoteIcon": "mydriver"
+              },
+              "title": "myDriver",
+              "url": "https://mydriver.com"
+            }
+          ],
+          "modeInfo": {
+            "alt": "Taxi",
+            "color": {
+              "blue": 62,
+              "green": 202,
+              "red": 221
+            },
+            "identifier": "ps_tax",
+            "localIcon": "taxi"
+          },
+          "title": "Taxi"
+        },
+        "ps_tnc": {
+          "lockedModes": [
+            {
+              "integrations": [
+                "bookings",
+                "routing",
+                "real_time"
+              ],
+              "modeInfo": {
+                "alt": "Uber",
+                "color": {
+                  "blue": 213,
+                  "green": 186,
+                  "red": 47
+                },
+                "description": "Uber",
+                "identifier": "ps_tnc_UBER",
+                "localIcon": "tnc",
+                "remoteIcon": "uber"
+              },
+              "title": "Uber",
+              "url": "https://www.uber.com"
+            }
+          ],
+          "modeInfo": {
+            "alt": "Ride share",
+            "color": {
+              "blue": 243,
+              "green": 169,
+              "red": 115
+            },
+            "identifier": "ps_tnc",
+            "localIcon": "tnc"
+          },
+          "title": "Ride share"
+        },
+        "pt_pub": {
+          "modeInfo": {
+            "alt": "Public transport",
+            "color": {
+              "blue": 104,
+              "green": 197,
+              "red": 45
+            },
+            "identifier": "pt_pub",
+            "localIcon": "public"
+          },
+          "specificModes": [
+            {
+              "modeInfo": {
+                "alt": "train",
+                "identifier": "pt_pub_train",
+                "localIcon": "train"
+              },
+              "operators": [
+                "PTV",
+                "Mornington Railway"
+              ]
+            },
+            {
+              "modeInfo": {
+                "alt": "tram",
+                "identifier": "pt_pub_tram",
+                "localIcon": "tram"
+              },
+              "operators": [
+                "PTV"
+              ]
+            },
+            {
+              "modeInfo": {
+                "alt": "bus",
+                "identifier": "pt_pub_bus",
+                "localIcon": "bus"
+              },
+              "operators": [
+                "PTV"
+              ]
+            },
+            {
+              "modeInfo": {
+                "alt": "ferry",
+                "identifier": "pt_pub_carferry",
+                "localIcon": "ferry"
+              },
+              "operators": [
+                "Queenscliff/Sorrento Ferry"
+              ]
+            }
+          ],
+          "title": "Public transport"
+        }
+      },
+      "operators": [
+        {
+          "modes": [
+            "pt_pub_train",
+            "pt_pub_tram",
+            "pt_pub_bus"
+          ],
+          "name": "PTV",
+          "numberOfServices": 150437,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "train",
+              "identifier": "pt_pub_train",
+              "localIcon": "train"
+            },
+            {
+              "alt": "tram",
+              "identifier": "pt_pub_tram",
+              "localIcon": "tram"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_carferry"
+          ],
+          "name": "Queenscliff/Sorrento Ferry",
+          "numberOfServices": 26,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "ferry",
+              "identifier": "pt_pub_carferry",
+              "localIcon": "ferry"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_train"
+          ],
+          "name": "Mornington Railway",
+          "numberOfServices": 14,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "train",
+              "identifier": "pt_pub_train",
+              "localIcon": "train"
+            }
+          ]
+        }
+      ],
+      "streetBicyclePaths": true,
+      "streetWheelchairAccessibility": true,
+      "supportsConcessionPricing": true,
+      "transitBicycleAccessibility": true,
+      "transitConcessionPricing": true,
+      "transitModes": [
+        {
+          "alt": "train",
+          "identifier": "pt_pub_train",
+          "localIcon": "train"
+        },
+        {
+          "alt": "tram",
+          "identifier": "pt_pub_tram",
+          "localIcon": "tram"
+        },
+        {
+          "alt": "bus",
+          "identifier": "pt_pub_bus",
+          "localIcon": "bus"
+        },
+        {
+          "alt": "ferry",
+          "identifier": "pt_pub_carferry",
+          "localIcon": "ferry"
+        }
+      ],
+      "transitWheelchairAccessibility": false
+    },
+    {
+      "allowsBicyclesOnPublicTransport": true,
+      "bikeShare": [
+        {
+          "URL": "https://www.mobibikes.ca/",
+          "color": {
+            "blue": 223,
+            "green": 171,
+            "red": 0
+          },
+          "integrations": [
+            "routing",
+            "real_time"
+          ],
+          "modeIdentifier": "cy_bic-s_mobibikes",
+          "title": "Mobi"
+        }
+      ],
+      "code": "CA_BC_Vancouver",
+      "extraModes": [
+        {
+          "color": {
+            "blue": 62,
+            "green": 202,
+            "red": 221
+          },
+          "integrations": [
+            "routing"
+          ],
+          "modeIdentifier": "ps_tax",
+          "title": "Taxi"
+        },
+        {
+          "URL": "https://modo.coop/",
+          "color": {
+            "blue": 54,
+            "green": 62,
+            "red": 239
+          },
+          "icon": "modo",
+          "integrations": [
+            "routing",
+            "real_time"
+          ],
+          "modeIdentifier": "me_car-s_MODO",
+          "title": "Modo"
+        },
+        {
+          "color": {
+            "blue": 243,
+            "green": 169,
+            "red": 115
+          },
+          "integrations": [
+            "routing"
+          ],
+          "modeIdentifier": "me_car-r_SwiftFleet",
+          "title": "Car rental"
+        },
+        {
+          "URL": "https://www.mobibikes.ca/",
+          "color": {
+            "blue": 223,
+            "green": 171,
+            "red": 0
+          },
+          "integrations": [
+            "routing",
+            "real_time"
+          ],
+          "modeIdentifier": "cy_bic-s_mobibikes",
+          "title": "Mobi"
+        }
+      ],
+      "hasSchoolServices": false,
+      "hasWheelchairInformation": false,
+      "modes": {
+        "cy_bic-s": {
+          "modeInfo": {
+            "alt": "Bike share",
+            "color": {
+              "blue": 99,
+              "green": 199,
+              "red": 30
+            },
+            "identifier": "cy_bic-s",
+            "localIcon": "bicycle-share"
+          },
+          "specificModes": [
+            {
+              "integrations": [
+                "routing",
+                "real_time"
+              ],
+              "minimumLocalCostForMembership": 9.75,
+              "modeInfo": {
+                "alt": "Mobi",
+                "color": {
+                  "blue": 223,
+                  "green": 171,
+                  "red": 0
+                },
+                "description": "Mobi",
+                "identifier": "cy_bic-s_mobibikes",
+                "localIcon": "bicycle-share"
+              },
+              "title": "Mobi",
+              "url": "https://www.mobibikes.ca/"
+            }
+          ],
+          "title": "Bike share"
+        },
+        "me_car-r": {
+          "lockedModes": [
+            {
+              "integrations": [
+                "routing"
+              ],
+              "minimumLocalCostForMembership": 0,
+              "modeInfo": {
+                "alt": "Car rental",
+                "color": {
+                  "blue": 243,
+                  "green": 169,
+                  "red": 115
+                },
+                "identifier": "me_car-r_SwiftFleet",
+                "localIcon": "car-share"
+              },
+              "title": "Car rental"
+            }
+          ],
+          "modeInfo": {
+            "alt": "Car rental",
+            "color": {
+              "blue": 243,
+              "green": 169,
+              "red": 115
+            },
+            "identifier": "me_car-r",
+            "localIcon": "car-share"
+          },
+          "title": "Car rental"
+        },
+        "me_car-s": {
+          "modeInfo": {
+            "alt": "Car share",
+            "color": {
+              "blue": 243,
+              "green": 169,
+              "red": 115
+            },
+            "identifier": "me_car-s",
+            "localIcon": "car-share"
+          },
+          "specificModes": [
+            {
+              "integrations": [
+                "routing",
+                "real_time"
+              ],
+              "minimumLocalCostForMembership": 1,
+              "modeInfo": {
+                "alt": "Modo",
+                "color": {
+                  "blue": 54,
+                  "green": 62,
+                  "red": 239
+                },
+                "description": "Modo",
+                "identifier": "me_car-s_MODO",
+                "localIcon": "car-share",
+                "remoteIcon": "modo"
+              },
+              "title": "Modo",
+              "url": "https://modo.coop/"
+            }
+          ],
+          "title": "Car share"
+        },
+        "ps_tax": {
+          "modeInfo": {
+            "alt": "Taxi",
+            "color": {
+              "blue": 62,
+              "green": 202,
+              "red": 221
+            },
+            "identifier": "ps_tax",
+            "localIcon": "taxi"
+          },
+          "title": "Taxi"
+        },
+        "pt_pub": {
+          "modeInfo": {
+            "alt": "Public transport",
+            "color": {
+              "blue": 104,
+              "green": 197,
+              "red": 45
+            },
+            "identifier": "pt_pub",
+            "localIcon": "public"
+          },
+          "specificModes": [
+            {
+              "modeInfo": {
+                "alt": "train",
+                "identifier": "pt_pub_train",
+                "localIcon": "train"
+              },
+              "operators": [
+                "British Columbia Rapid Transit Company",
+                "West Coast Express"
+              ]
+            },
+            {
+              "modeInfo": {
+                "alt": "ferry",
+                "identifier": "pt_pub_ferry",
+                "localIcon": "ferry"
+              },
+              "operators": [
+                "TransLink"
+              ]
+            },
+            {
+              "modeInfo": {
+                "alt": "bus",
+                "identifier": "pt_pub_bus",
+                "localIcon": "bus"
+              },
+              "operators": [
+                "TransLink",
+                "BC Transit - Central Fraser Valley Transit System",
+                "BC Transit - Whistler Transit System",
+                "BC Transit - RDN Transit System",
+                "BC Transit - Chilliwack Transit System",
+                "BC Transit - Comox Valley Transit System",
+                "BC Transit - Sunshine Coast Transit System",
+                "BC Transit - Squamish Transit System",
+                "BC Transit - Fraser Valley Express"
+              ]
+            }
+          ],
+          "title": "Public transport"
+        }
+      },
+      "operators": [
+        {
+          "modes": [
+            "pt_pub_ferry",
+            "pt_pub_bus"
+          ],
+          "name": "TransLink",
+          "numberOfServices": 70927,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "ferry",
+              "identifier": "pt_pub_ferry",
+              "localIcon": "ferry"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_train"
+          ],
+          "name": "British Columbia Rapid Transit Company",
+          "numberOfServices": 7052,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "train",
+              "identifier": "pt_pub_train",
+              "localIcon": "train"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "BC Transit - Central Fraser Valley Transit System",
+          "numberOfServices": 1554,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "BC Transit - Whistler Transit System",
+          "numberOfServices": 1398,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "BC Transit - RDN Transit System",
+          "numberOfServices": 1128,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "BC Transit - Chilliwack Transit System",
+          "numberOfServices": 536,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "BC Transit - Comox Valley Transit System",
+          "numberOfServices": 417,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "BC Transit - Sunshine Coast Transit System",
+          "numberOfServices": 282,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "BC Transit - Squamish Transit System",
+          "numberOfServices": 241,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "BC Transit - Fraser Valley Express",
+          "numberOfServices": 50,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_train"
+          ],
+          "name": "West Coast Express",
+          "numberOfServices": 18,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "train",
+              "identifier": "pt_pub_train",
+              "localIcon": "train"
+            }
+          ]
+        }
+      ],
+      "streetBicyclePaths": true,
+      "streetWheelchairAccessibility": true,
+      "supportsConcessionPricing": true,
+      "transitBicycleAccessibility": true,
+      "transitConcessionPricing": true,
+      "transitModes": [
+        {
+          "alt": "train",
+          "identifier": "pt_pub_train",
+          "localIcon": "train"
+        },
+        {
+          "alt": "ferry",
+          "identifier": "pt_pub_ferry",
+          "localIcon": "ferry"
+        },
+        {
+          "alt": "bus",
+          "identifier": "pt_pub_bus",
+          "localIcon": "bus"
+        }
+      ],
+      "transitWheelchairAccessibility": false
+    },
+    {
+      "allowsBicyclesOnPublicTransport": true,
+      "bikeShare": [
+        {
+          "URL": "http://www.norisbike.de",
+          "color": {
+            "blue": 56,
+            "green": 22,
+            "red": 236
+          },
+          "integrations": [
+            "routing",
+            "real_time"
+          ],
+          "modeIdentifier": "cy_bic-s_norisbike-nurnberg",
+          "title": "NorisBike"
+        }
+      ],
+      "code": "DE_BV_Nuremberg",
+      "extraModes": [
+        {
+          "color": {
+            "blue": 62,
+            "green": 202,
+            "red": 221
+          },
+          "integrations": [
+            "routing"
+          ],
+          "modeIdentifier": "ps_tax",
+          "title": "Taxi"
+        },
+        {
+          "URL": "https://mydriver.com",
+          "color": {
+            "blue": 0,
+            "green": 0,
+            "red": 0
+          },
+          "icon": "mydriver",
+          "integrations": [
+            "routing"
+          ],
+          "modeIdentifier": "ps_tax_MYDRIVER",
+          "title": "myDriver"
+        },
+        {
+          "URL": "https://www.flinkster.de",
+          "color": {
+            "blue": 27,
+            "green": 13,
+            "red": 252
+          },
+          "integrations": [
+            "routing",
+            "real_time"
+          ],
+          "modeIdentifier": "me_car-s_FLINK",
+          "title": "Flinkster"
+        },
+        {
+          "color": {
+            "blue": 243,
+            "green": 169,
+            "red": 115
+          },
+          "integrations": [
+            "routing"
+          ],
+          "modeIdentifier": "me_car-r_SwiftFleet",
+          "title": "Car rental"
+        },
+        {
+          "URL": "https://www.blablacar.com",
+          "color": {
+            "blue": 184,
+            "green": 132,
+            "red": 19
+          },
+          "icon": "blablacar",
+          "integrations": [
+            "routing"
+          ],
+          "modeIdentifier": "me_car-p_BlaBlaCar",
+          "title": "BlaBlaCar"
+        },
+        {
+          "URL": "http://www.norisbike.de",
+          "color": {
+            "blue": 56,
+            "green": 22,
+            "red": 236
+          },
+          "integrations": [
+            "routing",
+            "real_time"
+          ],
+          "modeIdentifier": "cy_bic-s_norisbike-nurnberg",
+          "title": "NorisBike"
+        }
+      ],
+      "hasSchoolServices": false,
+      "hasWheelchairInformation": true,
+      "modes": {
+        "cy_bic-s": {
+          "modeInfo": {
+            "alt": "Bike share",
+            "color": {
+              "blue": 99,
+              "green": 199,
+              "red": 30
+            },
+            "identifier": "cy_bic-s",
+            "localIcon": "bicycle-share"
+          },
+          "specificModes": [
+            {
+              "integrations": [
+                "routing",
+                "real_time"
+              ],
+              "minimumLocalCostForMembership": 0,
+              "modeInfo": {
+                "alt": "NorisBike",
+                "color": {
+                  "blue": 56,
+                  "green": 22,
+                  "red": 236
+                },
+                "description": "NorisBike",
+                "identifier": "cy_bic-s_norisbike-nurnberg",
+                "localIcon": "bicycle-share"
+              },
+              "title": "NorisBike",
+              "url": "http://www.norisbike.de"
+            }
+          ],
+          "title": "Bike share"
+        },
+        "me_car-p": {
+          "lockedModes": [
+            {
+              "integrations": [
+                "routing"
+              ],
+              "modeInfo": {
+                "alt": "BlaBlaCar",
+                "color": {
+                  "blue": 184,
+                  "green": 132,
+                  "red": 19
+                },
+                "description": "BlaBlaCar",
+                "identifier": "me_car-p_BlaBlaCar",
+                "localIcon": "car-pool",
+                "remoteIcon": "blablacar"
+              },
+              "title": "BlaBlaCar",
+              "url": "https://www.blablacar.com"
+            }
+          ],
+          "modeInfo": {
+            "alt": "Carpooling",
+            "color": {
+              "blue": 199,
+              "green": 196,
+              "red": 46
+            },
+            "identifier": "me_car-p",
+            "localIcon": "car-pool"
+          },
+          "title": "Carpooling"
+        },
+        "me_car-r": {
+          "lockedModes": [
+            {
+              "integrations": [
+                "routing"
+              ],
+              "minimumLocalCostForMembership": 0,
+              "modeInfo": {
+                "alt": "Car rental",
+                "color": {
+                  "blue": 243,
+                  "green": 169,
+                  "red": 115
+                },
+                "identifier": "me_car-r_SwiftFleet",
+                "localIcon": "car-share"
+              },
+              "title": "Car rental"
+            }
+          ],
+          "modeInfo": {
+            "alt": "Car rental",
+            "color": {
+              "blue": 243,
+              "green": 169,
+              "red": 115
+            },
+            "identifier": "me_car-r",
+            "localIcon": "car-share"
+          },
+          "title": "Car rental"
+        },
+        "me_car-s": {
+          "lockedModes": [
+            {
+              "integrations": [
+                "routing",
+                "real_time"
+              ],
+              "modeInfo": {
+                "alt": "Flinkster",
+                "color": {
+                  "blue": 27,
+                  "green": 13,
+                  "red": 252
+                },
+                "description": "Flinkster",
+                "identifier": "me_car-s_FLINK",
+                "localIcon": "car-share"
+              },
+              "title": "Flinkster",
+              "url": "https://www.flinkster.de"
+            }
+          ],
+          "modeInfo": {
+            "alt": "Car share",
+            "color": {
+              "blue": 243,
+              "green": 169,
+              "red": 115
+            },
+            "identifier": "me_car-s",
+            "localIcon": "car-share"
+          },
+          "title": "Car share"
+        },
+        "ps_tax": {
+          "lockedModes": [
+            {
+              "integrations": [
+                "routing"
+              ],
+              "modeInfo": {
+                "alt": "myDriver",
+                "color": {
+                  "blue": 0,
+                  "green": 0,
+                  "red": 0
+                },
+                "description": "myDriver",
+                "identifier": "ps_tax_MYDRIVER",
+                "localIcon": "taxi",
+                "remoteIcon": "mydriver"
+              },
+              "title": "myDriver",
+              "url": "https://mydriver.com"
+            }
+          ],
+          "modeInfo": {
+            "alt": "Taxi",
+            "color": {
+              "blue": 62,
+              "green": 202,
+              "red": 221
+            },
+            "identifier": "ps_tax",
+            "localIcon": "taxi"
+          },
+          "title": "Taxi"
+        },
+        "pt_pub": {
+          "modeInfo": {
+            "alt": "Public transport",
+            "color": {
+              "blue": 104,
+              "green": 197,
+              "red": 45
+            },
+            "identifier": "pt_pub",
+            "localIcon": "public"
+          },
+          "specificModes": [
+            {
+              "modeInfo": {
+                "alt": "train",
+                "identifier": "pt_pub_train",
+                "localIcon": "train"
+              },
+              "operators": [
+                "VGN",
+                "DPN"
+              ]
+            },
+            {
+              "modeInfo": {
+                "alt": "subway",
+                "color": {
+                  "blue": 165,
+                  "green": 103,
+                  "red": 0
+                },
+                "identifier": "pt_pub_subway",
+                "localIcon": "subway",
+                "remoteIcon": "subway-germany"
+              },
+              "operators": [
+                "VGN"
+              ]
+            },
+            {
+              "modeInfo": {
+                "alt": "tram",
+                "identifier": "pt_pub_tram",
+                "localIcon": "tram"
+              },
+              "operators": [
+                "VGN"
+              ]
+            },
+            {
+              "modeInfo": {
+                "alt": "bus",
+                "identifier": "pt_pub_bus",
+                "localIcon": "bus"
+              },
+              "operators": [
+                "VGN",
+                "FlixBus"
+              ]
+            }
+          ],
+          "title": "Public transport"
+        }
+      },
+      "operators": [
+        {
+          "modes": [
+            "pt_pub_train",
+            "pt_pub_tram",
+            "pt_pub_subway",
+            "pt_pub_bus"
+          ],
+          "name": "VGN",
+          "numberOfServices": 50056,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "train",
+              "identifier": "pt_pub_train",
+              "localIcon": "train"
+            },
+            {
+              "alt": "tram",
+              "identifier": "pt_pub_tram",
+              "localIcon": "tram"
+            },
+            {
+              "alt": "subway",
+              "color": {
+                "blue": 165,
+                "green": 103,
+                "red": 0
+              },
+              "identifier": "pt_pub_subway",
+              "localIcon": "subway",
+              "remoteIcon": "subway-germany"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "FlixBus",
+          "numberOfServices": 1597,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_train"
+          ],
+          "name": "DPN",
+          "numberOfServices": 201,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "train",
+              "identifier": "pt_pub_train",
+              "localIcon": "train"
+            }
+          ]
+        }
+      ],
+      "streetBicyclePaths": true,
+      "streetWheelchairAccessibility": true,
+      "supportsConcessionPricing": false,
+      "transitBicycleAccessibility": true,
+      "transitConcessionPricing": false,
+      "transitModes": [
+        {
+          "alt": "train",
+          "identifier": "pt_pub_train",
+          "localIcon": "train"
+        },
+        {
+          "alt": "subway",
+          "color": {
+            "blue": 165,
+            "green": 103,
+            "red": 0
+          },
+          "identifier": "pt_pub_subway",
+          "localIcon": "subway",
+          "remoteIcon": "subway-germany"
+        },
+        {
+          "alt": "tram",
+          "identifier": "pt_pub_tram",
+          "localIcon": "tram"
+        },
+        {
+          "alt": "bus",
+          "identifier": "pt_pub_bus",
+          "localIcon": "bus"
+        }
+      ],
+      "transitWheelchairAccessibility": true
+    },
+    {
+      "allowsBicyclesOnPublicTransport": true,
+      "bikeShare": [
+        {
+          "URL": "https://bikeshare.metro.net",
+          "color": {
+            "blue": 67,
+            "green": 231,
+            "red": 225
+          },
+          "icon": "metro-bikeshare",
+          "integrations": [
+            "routing",
+            "real_time"
+          ],
+          "modeIdentifier": "cy_bic-s_metro-bike-share",
+          "title": "Metro Bike Share"
+        },
+        {
+          "color": {
+            "blue": 99,
+            "green": 199,
+            "red": 30
+          },
+          "integrations": [
+            "routing",
+            "real_time"
+          ],
+          "modeIdentifier": "cy_bic-s_SoBi125",
+          "title": "Bruin Bike Share"
+        },
+        {
+          "URL": "http://www.santamonicabikeshare.com",
+          "color": {
+            "blue": 59,
+            "green": 211,
+            "red": 66
+          },
+          "icon": "santamonicabikeshare",
+          "integrations": [
+            "routing",
+            "real_time"
+          ],
+          "modeIdentifier": "cy_bic-s_SoBi42",
+          "title": "Breeze Bike Share"
+        },
+        {
+          "URL": "http://www.longbeachbikeshare.com",
+          "color": {
+            "blue": 217,
+            "green": 185,
+            "red": 23
+          },
+          "icon": "long-beach-bikeshare",
+          "integrations": [
+            "routing",
+            "real_time"
+          ],
+          "modeIdentifier": "cy_bic-s_SoBi63",
+          "title": "Long Beach CA Bikeshare"
+        },
+        {
+          "URL": "http://beverlyhillsbikeshare.com",
+          "color": {
+            "blue": 48,
+            "green": 151,
+            "red": 194
+          },
+          "icon": "beverly-hills-bikeshare",
+          "integrations": [
+            "routing",
+            "real_time"
+          ],
+          "modeIdentifier": "cy_bic-s_SoBi73",
+          "title": "Beverly Hills"
+        },
+        {
+          "URL": "http://wehopedals.com/",
+          "color": {
+            "blue": 217,
+            "green": 185,
+            "red": 23
+          },
+          "icon": "weho-pedals",
+          "integrations": [
+            "routing",
+            "real_time"
+          ],
+          "modeIdentifier": "cy_bic-s_SoBi89",
+          "title": "WeHo Pedals"
+        }
+      ],
+      "code": "US_CA_LosAngeles",
+      "extraModes": [
+        {
+          "color": {
+            "blue": 62,
+            "green": 202,
+            "red": 221
+          },
+          "integrations": [
+            "routing"
+          ],
+          "modeIdentifier": "ps_tax",
+          "title": "Taxi"
+        },
+        {
+          "URL": "https://www.uber.com",
+          "color": {
+            "blue": 213,
+            "green": 186,
+            "red": 47
+          },
+          "icon": "uber",
+          "integrations": [
+            "bookings",
+            "routing",
+            "real_time"
+          ],
+          "modeIdentifier": "ps_tnc_UBER",
+          "title": "Uber"
+        },
+        {
+          "color": {
+            "blue": 243,
+            "green": 169,
+            "red": 115
+          },
+          "integrations": [
+            "routing"
+          ],
+          "modeIdentifier": "me_car-r_SwiftFleet",
+          "title": "Car rental"
+        },
+        {
+          "URL": "https://bikeshare.metro.net",
+          "color": {
+            "blue": 67,
+            "green": 231,
+            "red": 225
+          },
+          "icon": "metro-bikeshare",
+          "integrations": [
+            "routing",
+            "real_time"
+          ],
+          "modeIdentifier": "cy_bic-s_metro-bike-share",
+          "title": "Metro Bike Share"
+        },
+        {
+          "color": {
+            "blue": 99,
+            "green": 199,
+            "red": 30
+          },
+          "integrations": [
+            "routing",
+            "real_time"
+          ],
+          "modeIdentifier": "cy_bic-s_SoBi125",
+          "title": "Bruin Bike Share"
+        },
+        {
+          "URL": "http://www.santamonicabikeshare.com",
+          "color": {
+            "blue": 59,
+            "green": 211,
+            "red": 66
+          },
+          "icon": "santamonicabikeshare",
+          "integrations": [
+            "routing",
+            "real_time"
+          ],
+          "modeIdentifier": "cy_bic-s_SoBi42",
+          "title": "Breeze Bike Share"
+        },
+        {
+          "URL": "http://www.longbeachbikeshare.com",
+          "color": {
+            "blue": 217,
+            "green": 185,
+            "red": 23
+          },
+          "icon": "long-beach-bikeshare",
+          "integrations": [
+            "routing",
+            "real_time"
+          ],
+          "modeIdentifier": "cy_bic-s_SoBi63",
+          "title": "Long Beach CA Bikeshare"
+        },
+        {
+          "URL": "http://beverlyhillsbikeshare.com",
+          "color": {
+            "blue": 48,
+            "green": 151,
+            "red": 194
+          },
+          "icon": "beverly-hills-bikeshare",
+          "integrations": [
+            "routing",
+            "real_time"
+          ],
+          "modeIdentifier": "cy_bic-s_SoBi73",
+          "title": "Beverly Hills"
+        },
+        {
+          "URL": "http://wehopedals.com/",
+          "color": {
+            "blue": 217,
+            "green": 185,
+            "red": 23
+          },
+          "icon": "weho-pedals",
+          "integrations": [
+            "routing",
+            "real_time"
+          ],
+          "modeIdentifier": "cy_bic-s_SoBi89",
+          "title": "WeHo Pedals"
+        }
+      ],
+      "hasSchoolServices": false,
+      "hasWheelchairInformation": true,
+      "modes": {
+        "cy_bic-s": {
+          "modeInfo": {
+            "alt": "Bike share",
+            "color": {
+              "blue": 99,
+              "green": 199,
+              "red": 30
+            },
+            "identifier": "cy_bic-s",
+            "localIcon": "bicycle-share"
+          },
+          "specificModes": [
+            {
+              "integrations": [
+                "routing",
+                "real_time"
+              ],
+              "minimumLocalCostForMembership": 20,
+              "modeInfo": {
+                "alt": "Metro Bike Share",
+                "color": {
+                  "blue": 67,
+                  "green": 231,
+                  "red": 225
+                },
+                "description": "Metro Bike Share",
+                "identifier": "cy_bic-s_metro-bike-share",
+                "localIcon": "bicycle-share",
+                "remoteIcon": "metro-bikeshare"
+              },
+              "title": "Metro Bike Share",
+              "url": "https://bikeshare.metro.net"
+            },
+            {
+              "integrations": [
+                "routing",
+                "real_time"
+              ],
+              "modeInfo": {
+                "alt": "Bruin Bike Share",
+                "color": {
+                  "blue": 99,
+                  "green": 199,
+                  "red": 30
+                },
+                "description": "Bruin Bike Share",
+                "identifier": "cy_bic-s_SoBi125",
+                "localIcon": "bicycle-share"
+              },
+              "title": "Bruin Bike Share"
+            },
+            {
+              "integrations": [
+                "routing",
+                "real_time"
+              ],
+              "minimumLocalCostForMembership": 0,
+              "modeInfo": {
+                "alt": "Breeze Bike Share",
+                "color": {
+                  "blue": 59,
+                  "green": 211,
+                  "red": 66
+                },
+                "description": "Breeze Bike Share",
+                "identifier": "cy_bic-s_SoBi42",
+                "localIcon": "bicycle-share",
+                "remoteIcon": "santamonicabikeshare"
+              },
+              "title": "Breeze Bike Share",
+              "url": "http://www.santamonicabikeshare.com"
+            },
+            {
+              "integrations": [
+                "routing",
+                "real_time"
+              ],
+              "minimumLocalCostForMembership": 0,
+              "modeInfo": {
+                "alt": "Long Beach CA Bikeshare",
+                "color": {
+                  "blue": 217,
+                  "green": 185,
+                  "red": 23
+                },
+                "description": "Long Beach CA Bikeshare",
+                "identifier": "cy_bic-s_SoBi63",
+                "localIcon": "bicycle-share",
+                "remoteIcon": "long-beach-bikeshare"
+              },
+              "title": "Long Beach CA Bikeshare",
+              "url": "http://www.longbeachbikeshare.com"
+            },
+            {
+              "integrations": [
+                "routing",
+                "real_time"
+              ],
+              "minimumLocalCostForMembership": 0,
+              "modeInfo": {
+                "alt": "Beverly Hills",
+                "color": {
+                  "blue": 48,
+                  "green": 151,
+                  "red": 194
+                },
+                "description": "Beverly Hills",
+                "identifier": "cy_bic-s_SoBi73",
+                "localIcon": "bicycle-share",
+                "remoteIcon": "beverly-hills-bikeshare"
+              },
+              "title": "Beverly Hills",
+              "url": "http://beverlyhillsbikeshare.com"
+            },
+            {
+              "integrations": [
+                "routing",
+                "real_time"
+              ],
+              "minimumLocalCostForMembership": 25,
+              "modeInfo": {
+                "alt": "WeHo Pedals",
+                "color": {
+                  "blue": 217,
+                  "green": 185,
+                  "red": 23
+                },
+                "description": "WeHo Pedals",
+                "identifier": "cy_bic-s_SoBi89",
+                "localIcon": "bicycle-share",
+                "remoteIcon": "weho-pedals"
+              },
+              "title": "WeHo Pedals",
+              "url": "http://wehopedals.com/"
+            }
+          ],
+          "title": "Bike share"
+        },
+        "me_car-r": {
+          "lockedModes": [
+            {
+              "integrations": [
+                "routing"
+              ],
+              "minimumLocalCostForMembership": 0,
+              "modeInfo": {
+                "alt": "Car rental",
+                "color": {
+                  "blue": 243,
+                  "green": 169,
+                  "red": 115
+                },
+                "identifier": "me_car-r_SwiftFleet",
+                "localIcon": "car-share"
+              },
+              "title": "Car rental"
+            }
+          ],
+          "modeInfo": {
+            "alt": "Car rental",
+            "color": {
+              "blue": 243,
+              "green": 169,
+              "red": 115
+            },
+            "identifier": "me_car-r",
+            "localIcon": "car-share"
+          },
+          "title": "Car rental"
+        },
+        "ps_tax": {
+          "modeInfo": {
+            "alt": "Taxi",
+            "color": {
+              "blue": 62,
+              "green": 202,
+              "red": 221
+            },
+            "identifier": "ps_tax",
+            "localIcon": "taxi"
+          },
+          "title": "Taxi"
+        },
+        "ps_tnc": {
+          "lockedModes": [
+            {
+              "integrations": [
+                "bookings",
+                "routing",
+                "real_time"
+              ],
+              "modeInfo": {
+                "alt": "Uber",
+                "color": {
+                  "blue": 213,
+                  "green": 186,
+                  "red": 47
+                },
+                "description": "Uber",
+                "identifier": "ps_tnc_UBER",
+                "localIcon": "tnc",
+                "remoteIcon": "uber"
+              },
+              "title": "Uber",
+              "url": "https://www.uber.com"
+            }
+          ],
+          "modeInfo": {
+            "alt": "Ride share",
+            "color": {
+              "blue": 243,
+              "green": 169,
+              "red": 115
+            },
+            "identifier": "ps_tnc",
+            "localIcon": "tnc"
+          },
+          "title": "Ride share"
+        },
+        "pt_pub": {
+          "modeInfo": {
+            "alt": "Public transport",
+            "color": {
+              "blue": 104,
+              "green": 197,
+              "red": 45
+            },
+            "identifier": "pt_pub",
+            "localIcon": "public"
+          },
+          "specificModes": [
+            {
+              "modeInfo": {
+                "alt": "train",
+                "identifier": "pt_pub_train",
+                "localIcon": "train"
+              },
+              "operators": [
+                "Metrolink Trains",
+                "Amtrak"
+              ]
+            },
+            {
+              "modeInfo": {
+                "alt": "subway",
+                "identifier": "pt_pub_subway",
+                "localIcon": "subway"
+              },
+              "operators": [
+                "Metro - Los Angeles"
+              ]
+            },
+            {
+              "modeInfo": {
+                "alt": "tram",
+                "identifier": "pt_pub_tram",
+                "localIcon": "tram"
+              },
+              "operators": [
+                "Metro - Los Angeles"
+              ]
+            },
+            {
+              "modeInfo": {
+                "alt": "bus",
+                "identifier": "pt_pub_bus",
+                "localIcon": "bus"
+              },
+              "operators": [
+                "Metro - Los Angeles",
+                "Long Beach Transit",
+                "Riverside Transit Agency",
+                "LADOT",
+                "Big Blue Bus",
+                "Orange County Transportation Authority",
+                "Foothill Transit",
+                "OMNITRANS",
+                "Culver CityBus",
+                "Anaheim Resort Transportation",
+                "Glendale Beeline",
+                "TORRANCE TRANSIT SYSTEM",
+                "Norwalk Transit System",
+                "LAX",
+                "Beaumont Pass Transit",
+                "Mountain Transit",
+                "Palos Verdes Peninsula Transit Authority",
+                "Corona Cruiser",
+                "Thousand Oaks Transit",
+                "Banning Pass Transit",
+                "Laguna Beach Transit",
+                "Amtrak California",
+                "Victor Valley Transit Authority",
+                "Sunline Transit Agency"
+              ]
+            },
+            {
+              "modeInfo": {
+                "alt": "cable car",
+                "identifier": "pt_pub_cablecar",
+                "localIcon": "cablecar"
+              },
+              "operators": [
+                "Mountain Transit"
+              ]
+            }
+          ],
+          "title": "Public transport"
+        }
+      },
+      "operators": [
+        {
+          "modes": [
+            "pt_pub_tram",
+            "pt_pub_subway",
+            "pt_pub_bus"
+          ],
+          "name": "Metro - Los Angeles",
+          "numberOfServices": 38300,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "tram",
+              "identifier": "pt_pub_tram",
+              "localIcon": "tram"
+            },
+            {
+              "alt": "subway",
+              "identifier": "pt_pub_subway",
+              "localIcon": "subway"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "Long Beach Transit",
+          "numberOfServices": 35548,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "Riverside Transit Agency",
+          "numberOfServices": 17633,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "LADOT",
+          "numberOfServices": 16124,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "Big Blue Bus",
+          "numberOfServices": 7723,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "Orange County Transportation Authority",
+          "numberOfServices": 7500,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "Foothill Transit",
+          "numberOfServices": 4223,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "OMNITRANS",
+          "numberOfServices": 4127,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "Culver CityBus",
+          "numberOfServices": 1345,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "Anaheim Resort Transportation",
+          "numberOfServices": 1208,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "Glendale Beeline",
+          "numberOfServices": 1001,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "TORRANCE TRANSIT SYSTEM",
+          "numberOfServices": 984,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "Norwalk Transit System",
+          "numberOfServices": 427,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "LAX",
+          "numberOfServices": 269,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_train"
+          ],
+          "name": "Metrolink Trains",
+          "numberOfServices": 235,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "train",
+              "identifier": "pt_pub_train",
+              "localIcon": "train"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "Beaumont Pass Transit",
+          "numberOfServices": 150,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_cablecar",
+            "pt_pub_bus"
+          ],
+          "name": "Mountain Transit",
+          "numberOfServices": 122,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "cable car",
+              "identifier": "pt_pub_cablecar",
+              "localIcon": "cablecar"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "Palos Verdes Peninsula Transit Authority",
+          "numberOfServices": 101,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "Corona Cruiser",
+          "numberOfServices": 84,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "Thousand Oaks Transit",
+          "numberOfServices": 83,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "Banning Pass Transit",
+          "numberOfServices": 59,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "Laguna Beach Transit",
+          "numberOfServices": 58,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "Amtrak California",
+          "numberOfServices": 39,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "Victor Valley Transit Authority",
+          "numberOfServices": 20,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_train"
+          ],
+          "name": "Amtrak",
+          "numberOfServices": 9,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "train",
+              "identifier": "pt_pub_train",
+              "localIcon": "train"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "Sunline Transit Agency",
+          "numberOfServices": 6,
+          "realTimeStatus": "INCAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        }
+      ],
+      "paratransit": {
+        "URL": "http://accessla.org/",
+        "name": "Access",
+        "number": "1.800.883.1295"
+      },
+      "streetBicyclePaths": true,
+      "streetWheelchairAccessibility": true,
+      "supportsConcessionPricing": false,
+      "transitBicycleAccessibility": true,
+      "transitConcessionPricing": false,
+      "transitModes": [
+        {
+          "alt": "train",
+          "identifier": "pt_pub_train",
+          "localIcon": "train"
+        },
+        {
+          "alt": "subway",
+          "identifier": "pt_pub_subway",
+          "localIcon": "subway"
+        },
+        {
+          "alt": "tram",
+          "identifier": "pt_pub_tram",
+          "localIcon": "tram"
+        },
+        {
+          "alt": "bus",
+          "identifier": "pt_pub_bus",
+          "localIcon": "bus"
+        },
+        {
+          "alt": "cable car",
+          "identifier": "pt_pub_cablecar",
+          "localIcon": "cablecar"
+        }
+      ],
+      "transitWheelchairAccessibility": true
+    },
+    {
+      "allowsBicyclesOnPublicTransport": true,
+      "bikeShare": [
+        {
+          "URL": "https://boulder.bcycle.com",
+          "color": {
+            "blue": 170,
+            "green": 93,
+            "red": 0
+          },
+          "darkIcon": "bcycle-dark",
+          "icon": "bcycle",
+          "integrations": [
+            "routing",
+            "real_time"
+          ],
+          "modeIdentifier": "cy_bic-s_boulder",
+          "title": "Boulder B-cycle"
+        },
+        {
+          "URL": "http://denver.bcycle.com/",
+          "color": {
+            "blue": 170,
+            "green": 93,
+            "red": 0
+          },
+          "darkIcon": "bcycle-dark",
+          "icon": "bcycle",
+          "integrations": [
+            "routing",
+            "real_time"
+          ],
+          "modeIdentifier": "cy_bic-s_denver",
+          "title": "Denver B-cycle"
+        }
+      ],
+      "code": "US_CO_Denver",
+      "extraModes": [
+        {
+          "color": {
+            "blue": 62,
+            "green": 202,
+            "red": 221
+          },
+          "integrations": [
+            "routing"
+          ],
+          "modeIdentifier": "ps_tax",
+          "title": "Taxi"
+        },
+        {
+          "URL": "https://www.uber.com",
+          "color": {
+            "blue": 213,
+            "green": 186,
+            "red": 47
+          },
+          "icon": "uber",
+          "integrations": [
+            "bookings",
+            "routing",
+            "real_time"
+          ],
+          "modeIdentifier": "ps_tnc_UBER",
+          "title": "Uber"
+        },
+        {
+          "color": {
+            "blue": 243,
+            "green": 169,
+            "red": 115
+          },
+          "integrations": [
+            "routing"
+          ],
+          "modeIdentifier": "me_car-r_SwiftFleet",
+          "title": "Car rental"
+        },
+        {
+          "URL": "https://boulder.bcycle.com",
+          "color": {
+            "blue": 170,
+            "green": 93,
+            "red": 0
+          },
+          "darkIcon": "bcycle-dark",
+          "icon": "bcycle",
+          "integrations": [
+            "routing",
+            "real_time"
+          ],
+          "modeIdentifier": "cy_bic-s_boulder",
+          "title": "Boulder B-cycle"
+        },
+        {
+          "URL": "http://denver.bcycle.com/",
+          "color": {
+            "blue": 170,
+            "green": 93,
+            "red": 0
+          },
+          "darkIcon": "bcycle-dark",
+          "icon": "bcycle",
+          "integrations": [
+            "routing",
+            "real_time"
+          ],
+          "modeIdentifier": "cy_bic-s_denver",
+          "title": "Denver B-cycle"
+        }
+      ],
+      "hasSchoolServices": false,
+      "hasWheelchairInformation": false,
+      "modes": {
+        "cy_bic-s": {
+          "modeInfo": {
+            "alt": "Bike share",
+            "color": {
+              "blue": 99,
+              "green": 199,
+              "red": 30
+            },
+            "identifier": "cy_bic-s",
+            "localIcon": "bicycle-share"
+          },
+          "specificModes": [
+            {
+              "integrations": [
+                "routing",
+                "real_time"
+              ],
+              "minimumLocalCostForMembership": 8,
+              "modeInfo": {
+                "alt": "Boulder B-cycle",
+                "color": {
+                  "blue": 170,
+                  "green": 93,
+                  "red": 0
+                },
+                "description": "Boulder B-cycle",
+                "identifier": "cy_bic-s_boulder",
+                "localIcon": "bicycle-share",
+                "remoteDarkIcon": "bcycle-dark",
+                "remoteIcon": "bcycle"
+              },
+              "title": "Boulder B-cycle",
+              "url": "https://boulder.bcycle.com"
+            },
+            {
+              "integrations": [
+                "routing",
+                "real_time"
+              ],
+              "minimumLocalCostForMembership": 9,
+              "modeInfo": {
+                "alt": "Denver B-cycle",
+                "color": {
+                  "blue": 170,
+                  "green": 93,
+                  "red": 0
+                },
+                "description": "Denver B-cycle",
+                "identifier": "cy_bic-s_denver",
+                "localIcon": "bicycle-share",
+                "remoteDarkIcon": "bcycle-dark",
+                "remoteIcon": "bcycle"
+              },
+              "title": "Denver B-cycle",
+              "url": "http://denver.bcycle.com/"
+            }
+          ],
+          "title": "Bike share"
+        },
+        "me_car-r": {
+          "lockedModes": [
+            {
+              "integrations": [
+                "routing"
+              ],
+              "minimumLocalCostForMembership": 0,
+              "modeInfo": {
+                "alt": "Car rental",
+                "color": {
+                  "blue": 243,
+                  "green": 169,
+                  "red": 115
+                },
+                "identifier": "me_car-r_SwiftFleet",
+                "localIcon": "car-share"
+              },
+              "title": "Car rental"
+            }
+          ],
+          "modeInfo": {
+            "alt": "Car rental",
+            "color": {
+              "blue": 243,
+              "green": 169,
+              "red": 115
+            },
+            "identifier": "me_car-r",
+            "localIcon": "car-share"
+          },
+          "title": "Car rental"
+        },
+        "ps_tax": {
+          "modeInfo": {
+            "alt": "Taxi",
+            "color": {
+              "blue": 62,
+              "green": 202,
+              "red": 221
+            },
+            "identifier": "ps_tax",
+            "localIcon": "taxi"
+          },
+          "title": "Taxi"
+        },
+        "ps_tnc": {
+          "lockedModes": [
+            {
+              "integrations": [
+                "bookings",
+                "routing",
+                "real_time"
+              ],
+              "modeInfo": {
+                "alt": "Uber",
+                "color": {
+                  "blue": 213,
+                  "green": 186,
+                  "red": 47
+                },
+                "description": "Uber",
+                "identifier": "ps_tnc_UBER",
+                "localIcon": "tnc",
+                "remoteIcon": "uber"
+              },
+              "title": "Uber",
+              "url": "https://www.uber.com"
+            }
+          ],
+          "modeInfo": {
+            "alt": "Ride share",
+            "color": {
+              "blue": 243,
+              "green": 169,
+              "red": 115
+            },
+            "identifier": "ps_tnc",
+            "localIcon": "tnc"
+          },
+          "title": "Ride share"
+        },
+        "pt_pub": {
+          "modeInfo": {
+            "alt": "Public transport",
+            "color": {
+              "blue": 104,
+              "green": 197,
+              "red": 45
+            },
+            "identifier": "pt_pub",
+            "localIcon": "public"
+          },
+          "specificModes": [
+            {
+              "modeInfo": {
+                "alt": "train",
+                "identifier": "pt_pub_train",
+                "localIcon": "train"
+              },
+              "operators": [
+                "Regional Transportation District"
+              ]
+            },
+            {
+              "modeInfo": {
+                "alt": "tram",
+                "identifier": "pt_pub_tram",
+                "localIcon": "tram"
+              },
+              "operators": [
+                "Regional Transportation District"
+              ]
+            },
+            {
+              "modeInfo": {
+                "alt": "bus",
+                "identifier": "pt_pub_bus",
+                "localIcon": "bus"
+              },
+              "operators": [
+                "Regional Transportation District",
+                "Bustang"
+              ]
+            }
+          ],
+          "title": "Public transport"
+        }
+      },
+      "operators": [
+        {
+          "modes": [
+            "pt_pub_tram",
+            "pt_pub_train",
+            "pt_pub_bus"
+          ],
+          "name": "Regional Transportation District",
+          "numberOfServices": 23869,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "tram",
+              "identifier": "pt_pub_tram",
+              "localIcon": "tram"
+            },
+            {
+              "alt": "train",
+              "identifier": "pt_pub_train",
+              "localIcon": "train"
+            },
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        },
+        {
+          "modes": [
+            "pt_pub_bus"
+          ],
+          "name": "Bustang",
+          "numberOfServices": 53,
+          "realTimeStatus": "CAPABLE",
+          "types": [
+            {
+              "alt": "bus",
+              "identifier": "pt_pub_bus",
+              "localIcon": "bus"
+            }
+          ]
+        }
+      ],
+      "paratransit": {
+        "URL": "http://www.rtd-denver.com/accessARide.shtml",
+        "name": "Access-A-Ride",
+        "number": "303.299.2960"
+      },
+      "streetBicyclePaths": true,
+      "streetWheelchairAccessibility": true,
+      "supportsConcessionPricing": true,
+      "transitBicycleAccessibility": true,
+      "transitConcessionPricing": true,
+      "transitModes": [
+        {
+          "alt": "train",
+          "identifier": "pt_pub_train",
+          "localIcon": "train"
+        },
+        {
+          "alt": "tram",
+          "identifier": "pt_pub_tram",
+          "localIcon": "tram"
+        },
+        {
+          "alt": "bus",
+          "identifier": "pt_pub_bus",
+          "localIcon": "bus"
+        }
+      ],
+      "transitWheelchairAccessibility": false
+    }
+  ],
+  "server": "192.168.1.13"
+}

--- a/Tests/parsing/TKBuzzInfoProviderTest.swift
+++ b/Tests/parsing/TKBuzzInfoProviderTest.swift
@@ -29,6 +29,14 @@ class TKBuzzInfoProviderTest: TKTestCase {
     XCTAssertEqual(sydney?.transitWheelchairAccessibility, true)
   }
   
+  func testRegionInformationList() throws {
+    let decoder = JSONDecoder()
+    let data = try dataFromJSON(named: "regionInfo-multi")
+    let response = try! decoder.decode(TKBuzzInfoProvider.RegionInfoResponse.self, from: data)
+    
+    XCTAssertEqual(response.regions.count, 6)
+  }
+  
   func testRegionInformationVancouver() throws {
     let decoder = JSONDecoder()
     let data = try dataFromJSON(named: "regionInfo-Vancouver")
@@ -37,7 +45,7 @@ class TKBuzzInfoProviderTest: TKTestCase {
     
     XCTAssertEqual(response.regions.count, 1)
     
-    XCTAssertEqual(vancouver?.modes.count, 4)
+    XCTAssertEqual(vancouver?.modes.count, 5)
     XCTAssertEqual(vancouver?.modes["me_car-s"]?.specificModes?.count, 1)
     XCTAssertEqual(vancouver?.specificModeDetails(for: "me_car-s_MODO")?.minimumLocalCostForMembership, 1)
 
@@ -54,10 +62,10 @@ class TKBuzzInfoProviderTest: TKTestCase {
     
     XCTAssertEqual(response.regions.count, 1)
     
-    XCTAssertEqual(nuremberg?.modes.count, 3)
+    XCTAssertEqual(nuremberg?.modes.count, 6)
     XCTAssertEqual(nuremberg?.modes["ps_tax"]?.lockedModes?.count, 1)
     XCTAssertEqual(nuremberg?.modes["ps_tax"]?.lockedModes?.first?.identifier, "ps_tax_MYDRIVER")
-
+    
     let norisbike = nuremberg?.specificModeDetails(for: "cy_bic-s_norisbike-nurnberg")
     XCTAssertEqual(norisbike?.url, URL(string: "http://www.norisbike.de"))
     XCTAssertEqual(norisbike?.title, "NorisBike")

--- a/Tests/parsing/TKBuzzInfoProviderTest.swift
+++ b/Tests/parsing/TKBuzzInfoProviderTest.swift
@@ -12,7 +12,7 @@ import XCTest
 
 class TKBuzzInfoProviderTest: TKTestCase {
     
-  func testRegionInformation() throws {
+  func testRegionInformationSydney() throws {
     let decoder = JSONDecoder()
     let data = try dataFromJSON(named: "regionInfo-Sydney")
     let response = try decoder.decode(TKBuzzInfoProvider.RegionInfoResponse.self, from: data)
@@ -27,6 +27,42 @@ class TKBuzzInfoProviderTest: TKTestCase {
     XCTAssertEqual(sydney?.transitBicycleAccessibility, true)
     XCTAssertEqual(sydney?.transitConcessionPricing, true)
     XCTAssertEqual(sydney?.transitWheelchairAccessibility, true)
+  }
+  
+  func testRegionInformationVancouver() throws {
+    let decoder = JSONDecoder()
+    let data = try dataFromJSON(named: "regionInfo-Vancouver")
+    let response = try! decoder.decode(TKBuzzInfoProvider.RegionInfoResponse.self, from: data)
+    let vancouver = response.regions.first
+    
+    XCTAssertEqual(response.regions.count, 1)
+    
+    XCTAssertEqual(vancouver?.modes.count, 4)
+    XCTAssertEqual(vancouver?.modes["me_car-s"]?.specificModes?.count, 1)
+    XCTAssertEqual(vancouver?.specificModeDetails(for: "me_car-s_MODO")?.minimumLocalCostForMembership, 1)
+
+    let modo = vancouver?.modes["me_car-s"]?.specificModes?.first
+    XCTAssertEqual(modo?.minimumLocalCostForMembership, 1)
+    XCTAssertEqual(modo?.integrations?.contains(.realTime), true)
+  }
+  
+  func testRegionInformationNuremberg() throws {
+    let decoder = JSONDecoder()
+    let data = try dataFromJSON(named: "regionInfo-Nuremberg")
+    let response = try decoder.decode(TKBuzzInfoProvider.RegionInfoResponse.self, from: data)
+    let nuremberg = response.regions.first
+    
+    XCTAssertEqual(response.regions.count, 1)
+    
+    XCTAssertEqual(nuremberg?.modes.count, 3)
+    XCTAssertEqual(nuremberg?.modes["ps_tax"]?.lockedModes?.count, 1)
+    XCTAssertEqual(nuremberg?.modes["ps_tax"]?.lockedModes?.first?.identifier, "ps_tax_MYDRIVER")
+
+    let norisbike = nuremberg?.specificModeDetails(for: "cy_bic-s_norisbike-nurnberg")
+    XCTAssertEqual(norisbike?.url, URL(string: "http://www.norisbike.de"))
+    XCTAssertEqual(norisbike?.title, "NorisBike")
+    XCTAssertEqual(norisbike?.minimumLocalCostForMembership, 0)
+    XCTAssertEqual(norisbike?.integrations?.count, 2)
   }
   
   func testPublicTransportModes() throws {

--- a/TripKit.xcodeproj/project.pbxproj
+++ b/TripKit.xcodeproj/project.pbxproj
@@ -43,6 +43,8 @@
 		3A6DAED320403CFD009282FE /* Loc+TripKitBookings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A6DAECE20402622009282FE /* Loc+TripKitBookings.swift */; };
 		3A6DAED5204040B2009282FE /* Loc+TripKitUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A6DAED4204040B2009282FE /* Loc+TripKitUI.swift */; };
 		3A6DAED620404374009282FE /* Loc+TripKitUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A6DAED4204040B2009282FE /* Loc+TripKitUI.swift */; };
+		3A6DAED92040985B009282FE /* regionInfo-Nuremberg.json in Resources */ = {isa = PBXBuildFile; fileRef = 3A6DAED72040985A009282FE /* regionInfo-Nuremberg.json */; };
+		3A6DAEDA2040985B009282FE /* regionInfo-Vancouver.json in Resources */ = {isa = PBXBuildFile; fileRef = 3A6DAED82040985B009282FE /* regionInfo-Vancouver.json */; };
 		3A6DF088202C8DA30084CB2C /* TripKitUI.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A6DF086202C8DA30084CB2C /* TripKitUI.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3A6DF0F8202C8EB80084CB2C /* SGTableCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A6DF097202C8EB80084CB2C /* SGTableCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3A6DF0F9202C8EB80084CB2C /* SGTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A6DF098202C8EB80084CB2C /* SGTableViewCell.m */; };
@@ -375,7 +377,6 @@
 		3AA3CECE202CD4D100E54859 /* departures-parentStop.json in Resources */ = {isa = PBXBuildFile; fileRef = 3AA3CEAA202CD4D100E54859 /* departures-parentStop.json */; };
 		3AA3CECF202CD4D100E54859 /* alertsTransit.json in Resources */ = {isa = PBXBuildFile; fileRef = 3AA3CEAB202CD4D100E54859 /* alertsTransit.json */; };
 		3AA3CED0202CD4D100E54859 /* SGCustomEventRecurrenceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA3CEAD202CD4D100E54859 /* SGCustomEventRecurrenceTest.swift */; };
-		3AA3CED1202CD4D100E54859 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3AA3CEAE202CD4D100E54859 /* Info.plist */; };
 		3AA3CEE2202CD70400E54859 /* TripKitModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 3AA3CEDB202CD70400E54859 /* TripKitModel.xcdatamodeld */; };
 		3AA3CEE3202CD70400E54859 /* TripKitModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 3AA3CEDB202CD70400E54859 /* TripKitModel.xcdatamodeld */; };
 		3AA77F621F76A913001D412D /* AlertAPIModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA77F611F76A913001D412D /* AlertAPIModels.swift */; };
@@ -920,6 +921,8 @@
 		3A6DAECE20402622009282FE /* Loc+TripKitBookings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Loc+TripKitBookings.swift"; sourceTree = "<group>"; };
 		3A6DAED020402686009282FE /* Loc+TripKitInterApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Loc+TripKitInterApp.swift"; sourceTree = "<group>"; };
 		3A6DAED4204040B2009282FE /* Loc+TripKitUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Loc+TripKitUI.swift"; sourceTree = "<group>"; };
+		3A6DAED72040985A009282FE /* regionInfo-Nuremberg.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "regionInfo-Nuremberg.json"; sourceTree = "<group>"; };
+		3A6DAED82040985B009282FE /* regionInfo-Vancouver.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "regionInfo-Vancouver.json"; sourceTree = "<group>"; };
 		3A6DF05E202C88E90084CB2C /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxSwift.framework; path = Carthage/Build/iOS/RxSwift.framework; sourceTree = "<group>"; };
 		3A6DF05F202C88E90084CB2C /* ASPolygonKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ASPolygonKit.framework; path = Carthage/Build/iOS/ASPolygonKit.framework; sourceTree = "<group>"; };
 		3A6DF062202C89180084CB2C /* RxCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxCocoa.framework; path = Carthage/Build/iOS/RxCocoa.framework; sourceTree = "<group>"; };
@@ -2194,16 +2197,16 @@
 		3AA3CE82202CD4D100E54859 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				3AA3CE83202CD4D100E54859 /* ttp */,
-				3AA3CE85202CD4D100E54859 /* sharing */,
-				3AA3CE87202CD4D100E54859 /* restoration */,
-				3AA3CE89202CD4D100E54859 /* searching */,
-				3AA3CE8E202CD4D100E54859 /* TKTestCase.swift */,
-				3AA3CE8F202CD4D100E54859 /* Tests-Bridging-Header.h */,
-				3AA3CE90202CD4D100E54859 /* routing */,
-				3AA3CE93202CD4D100E54859 /* parsing */,
 				3AA3CE9E202CD4D100E54859 /* Data */,
 				3AA3CEAC202CD4D100E54859 /* event */,
+				3AA3CE93202CD4D100E54859 /* parsing */,
+				3AA3CE87202CD4D100E54859 /* restoration */,
+				3AA3CE90202CD4D100E54859 /* routing */,
+				3AA3CE89202CD4D100E54859 /* searching */,
+				3AA3CE85202CD4D100E54859 /* sharing */,
+				3AA3CE83202CD4D100E54859 /* ttp */,
+				3AA3CE8F202CD4D100E54859 /* Tests-Bridging-Header.h */,
+				3AA3CE8E202CD4D100E54859 /* TKTestCase.swift */,
 				3AA3CEAE202CD4D100E54859 /* Info.plist */,
 			);
 			path = Tests;
@@ -2256,16 +2259,16 @@
 		3AA3CE93202CD4D100E54859 /* parsing */ = {
 			isa = PBXGroup;
 			children = (
-				3AA3CE94202CD4D100E54859 /* TKAlertModelTest.swift */,
-				3AA3CE95202CD4D100E54859 /* STKModeHelperTest.swift */,
-				3AA3CE96202CD4D100E54859 /* TKBookingDecodingTest.swift */,
-				3AA3CE97202CD4D100E54859 /* TKJSONSanitizerTest.swift */,
 				3AA3CE98202CD4D100E54859 /* PolylineDecoderTest.swift */,
+				3AA3CE95202CD4D100E54859 /* STKModeHelperTest.swift */,
+				3AA3CE94202CD4D100E54859 /* TKAlertModelTest.swift */,
+				3AA3CE96202CD4D100E54859 /* TKBookingDecodingTest.swift */,
+				3AA3CE9B202CD4D100E54859 /* TKBuzzInfoProviderTest.swift */,
+				3AA3CE9D202CD4D100E54859 /* TKDeparturesModelTest.swift */,
+				3AA3CE97202CD4D100E54859 /* TKJSONSanitizerTest.swift */,
+				3AA3CE9C202CD4D100E54859 /* TKLinkedAccountTest.swift */,
 				3AA3CE99202CD4D100E54859 /* TKLocationInfoTest.swift */,
 				3AA3CE9A202CD4D100E54859 /* TKRegionManagerTest.swift */,
-				3AA3CE9B202CD4D100E54859 /* TKBuzzInfoProviderTest.swift */,
-				3AA3CE9C202CD4D100E54859 /* TKLinkedAccountTest.swift */,
-				3AA3CE9D202CD4D100E54859 /* TKDeparturesModelTest.swift */,
 			);
 			path = parsing;
 			sourceTree = "<group>";
@@ -2273,19 +2276,21 @@
 		3AA3CE9E202CD4D100E54859 /* Data */ = {
 			isa = PBXGroup;
 			children = (
-				3AA3CE9F202CD4D100E54859 /* hornsbyToSkedGoService.json */,
-				3AA3CEA0202CD4D100E54859 /* locationInfo-carRental.json */,
-				3AA3CEA1202CD4D100E54859 /* regionInfo-Sydney.json */,
-				3AA3CEA2202CD4D100E54859 /* hornsbyToSkedGo.json */,
-				3AA3CEA3202CD4D100E54859 /* berowraToHornsbyService.json */,
-				3AA3CEA4202CD4D100E54859 /* geojson-nuremberg.json */,
-				3AA3CEA5202CD4D100E54859 /* routing-goget.json */,
-				3AA3CEA6202CD4D100E54859 /* regions.json */,
-				3AA3CEA7202CD4D100E54859 /* berowraToHornsby.json */,
-				3AA3CEA8202CD4D100E54859 /* locationInfo-bikePod.json */,
-				3AA3CEA9202CD4D100E54859 /* routing-pt-oldish.json */,
-				3AA3CEAA202CD4D100E54859 /* departures-parentStop.json */,
 				3AA3CEAB202CD4D100E54859 /* alertsTransit.json */,
+				3AA3CEA7202CD4D100E54859 /* berowraToHornsby.json */,
+				3AA3CEA3202CD4D100E54859 /* berowraToHornsbyService.json */,
+				3AA3CEAA202CD4D100E54859 /* departures-parentStop.json */,
+				3AA3CEA4202CD4D100E54859 /* geojson-nuremberg.json */,
+				3AA3CEA2202CD4D100E54859 /* hornsbyToSkedGo.json */,
+				3AA3CE9F202CD4D100E54859 /* hornsbyToSkedGoService.json */,
+				3AA3CEA8202CD4D100E54859 /* locationInfo-bikePod.json */,
+				3AA3CEA0202CD4D100E54859 /* locationInfo-carRental.json */,
+				3A6DAED72040985A009282FE /* regionInfo-Nuremberg.json */,
+				3AA3CEA1202CD4D100E54859 /* regionInfo-Sydney.json */,
+				3A6DAED82040985B009282FE /* regionInfo-Vancouver.json */,
+				3AA3CEA6202CD4D100E54859 /* regions.json */,
+				3AA3CEA5202CD4D100E54859 /* routing-goget.json */,
+				3AA3CEA9202CD4D100E54859 /* routing-pt-oldish.json */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -3310,9 +3315,10 @@
 				3AA3CECB202CD4D100E54859 /* berowraToHornsby.json in Resources */,
 				3AA3CECC202CD4D100E54859 /* locationInfo-bikePod.json in Resources */,
 				3AA3CEC3202CD4D100E54859 /* hornsbyToSkedGoService.json in Resources */,
-				3AA3CED1202CD4D100E54859 /* Info.plist in Resources */,
+				3A6DAEDA2040985B009282FE /* regionInfo-Vancouver.json in Resources */,
 				3AA3CECD202CD4D100E54859 /* routing-pt-oldish.json in Resources */,
 				3AA3CECE202CD4D100E54859 /* departures-parentStop.json in Resources */,
+				3A6DAED92040985B009282FE /* regionInfo-Nuremberg.json in Resources */,
 				3AA3CECA202CD4D100E54859 /* regions.json in Resources */,
 				3AA3CEC8202CD4D100E54859 /* geojson-nuremberg.json in Resources */,
 				3AA3CEC7202CD4D100E54859 /* berowraToHornsbyService.json in Resources */,

--- a/TripKit.xcodeproj/project.pbxproj
+++ b/TripKit.xcodeproj/project.pbxproj
@@ -718,6 +718,7 @@
 		3AEB43EC1F757C1F00FA3289 /* TKDeparturesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AEB43EB1F757C1E00FA3289 /* TKDeparturesProvider.swift */; };
 		3AF3F2621E04CA7C00A2EEC6 /* TKBookingTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AF3F2611E04CA7C00A2EEC6 /* TKBookingTypes.swift */; };
 		3AF3F2641E04CA8C00A2EEC6 /* TKLocationTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AF3F2631E04CA8C00A2EEC6 /* TKLocationTypes.swift */; };
+		3AF6FDF0204436D4003BA786 /* regionInfo-multi.json in Resources */ = {isa = PBXBuildFile; fileRef = 3AF6FDEF204436D3003BA786 /* regionInfo-multi.json */; };
 		3AF94B121F0BF79800500940 /* TKSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AF94B111F0BF79800500940 /* TKSettings.swift */; };
 		3AF94B1F1F0BFB9E00500940 /* Shape+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AF94B1D1F0BFB9D00500940 /* Shape+CoreDataClass.swift */; };
 		3AF94B201F0BFB9E00500940 /* Shape+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AF94B1E1F0BFB9E00500940 /* Shape+CoreDataProperties.swift */; };
@@ -1392,6 +1393,7 @@
 		3AEB43EB1F757C1E00FA3289 /* TKDeparturesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TKDeparturesProvider.swift; sourceTree = "<group>"; };
 		3AF3F2611E04CA7C00A2EEC6 /* TKBookingTypes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TKBookingTypes.swift; sourceTree = "<group>"; };
 		3AF3F2631E04CA8C00A2EEC6 /* TKLocationTypes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TKLocationTypes.swift; sourceTree = "<group>"; };
+		3AF6FDEF204436D3003BA786 /* regionInfo-multi.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "regionInfo-multi.json"; sourceTree = "<group>"; };
 		3AF94B111F0BF79800500940 /* TKSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TKSettings.swift; sourceTree = "<group>"; };
 		3AF94B1D1F0BFB9D00500940 /* Shape+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Shape+CoreDataClass.swift"; sourceTree = "<group>"; };
 		3AF94B1E1F0BFB9E00500940 /* Shape+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Shape+CoreDataProperties.swift"; sourceTree = "<group>"; };
@@ -2285,6 +2287,7 @@
 				3AA3CE9F202CD4D100E54859 /* hornsbyToSkedGoService.json */,
 				3AA3CEA8202CD4D100E54859 /* locationInfo-bikePod.json */,
 				3AA3CEA0202CD4D100E54859 /* locationInfo-carRental.json */,
+				3AF6FDEF204436D3003BA786 /* regionInfo-multi.json */,
 				3A6DAED72040985A009282FE /* regionInfo-Nuremberg.json */,
 				3AA3CEA1202CD4D100E54859 /* regionInfo-Sydney.json */,
 				3A6DAED82040985B009282FE /* regionInfo-Vancouver.json */,
@@ -3314,6 +3317,7 @@
 				3AA3CECF202CD4D100E54859 /* alertsTransit.json in Resources */,
 				3AA3CECB202CD4D100E54859 /* berowraToHornsby.json in Resources */,
 				3AA3CECC202CD4D100E54859 /* locationInfo-bikePod.json in Resources */,
+				3AF6FDF0204436D4003BA786 /* regionInfo-multi.json in Resources */,
 				3AA3CEC3202CD4D100E54859 /* hornsbyToSkedGoService.json in Resources */,
 				3A6DAEDA2040985B009282FE /* regionInfo-Vancouver.json in Resources */,
 				3AA3CECD202CD4D100E54859 /* routing-pt-oldish.json in Resources */,

--- a/TripKit/Classes/core/ServerKit/SVKTransportModes.h
+++ b/TripKit/Classes/core/ServerKit/SVKTransportModes.h
@@ -8,6 +8,8 @@
 
 #import "SGKCrossPlatform.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 FOUNDATION_EXPORT NSString *const SVKTransportModeIdentifierFlight;
 FOUNDATION_EXPORT NSString *const SVKTransportModeIdentifierRegularPublicTransport;
 FOUNDATION_EXPORT NSString *const SVKTransportModeIdentifierSchoolBuses;
@@ -52,6 +54,12 @@ FOUNDATION_EXPORT NSString *const SVKTransportModeIdentifierWheelchair;
 + (NSSet<NSSet<NSString *> *> *)groupedModeIdentifiers:(NSArray<NSString *> *)modeIdentifiers
                                     includeGroupForAll:(BOOL)addAllGroup;
 
+/**
+ @return The generic mode identifier part, e.g., `pt_pub` for `pt_pub_bus`,
+    which can be used as routing input
+ */
++ (NSString *)genericModeIdentifierForModeIdentifier:(NSString *)modeIdentifier;
+
 + (BOOL)modeIdentifierIsPublicTransport:(NSString *)modeIdentifier;
 + (BOOL)modeIdentifierIsWalking:(NSString *)modeIdentifier;
 + (BOOL)modeIdentifierIsWheelchair:(NSString *)modeIdentifier;
@@ -64,3 +72,5 @@ FOUNDATION_EXPORT NSString *const SVKTransportModeIdentifierWheelchair;
 + (BOOL)modeIdentifierIsExpensive:(NSString *)modeIdentifier;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/TripKit/Classes/core/ServerKit/SVKTransportModes.m
+++ b/TripKit/Classes/core/ServerKit/SVKTransportModes.m
@@ -138,6 +138,16 @@ NSString *const SVKTransportModeIdentifierWheelchair                = @"wa_whe";
   }
 }
 
++ (NSString *)genericModeIdentifierForModeIdentifier:(NSString *)modeIdentifier
+{
+  NSArray *components = [modeIdentifier componentsSeparatedByString:@"_"];
+  if (components.count > 1) {
+    return [NSString stringWithFormat:@"%@_%@", components[0], components[1]];
+  } else {
+    return modeIdentifier;
+  }
+}
+
 + (NSSet *)groupedModeIdentifiers:(NSArray *)modeIdentifiers
                includeGroupForAll:(BOOL)addAllGroup
 {

--- a/TripKit/Classes/model/API/RegionAPIModel.swift
+++ b/TripKit/Classes/model/API/RegionAPIModel.swift
@@ -19,6 +19,13 @@ extension API {
     public let transitConcessionPricing: Bool
     public let transitWheelchairAccessibility: Bool
     public let paratransit: Paratransit?
+    
+    /// Additional information for some of the modes in the region.
+    /// Dictionary of a generic mode identifier to the details.
+    ///
+    /// Use `SVKTransportModes.genericModeIdentifier` to get the
+    /// generic part of any mode identifier.
+    public let modes: [String: GenericModeDetails]
   }
 
   /// Informational class for paratransit information (i.e., transport for people with disabilities).
@@ -36,6 +43,80 @@ extension API {
       case url = "URL"
       case number
     }
+  }
+  
+  public enum Integrations: String, Codable {
+    case routing
+    case realTime = "real_time"
+    case bookings
+    case payments
+  }
+  
+  /// Additional details about a group of modes,
+  /// e.g., all bike or car share providers in a city
+  public struct GenericModeDetails: Codable {
+    /// Name of the group
+    public let title: String
+    
+    /// Additional info about the mode group
+    public let modeInfo: ModeInfo?
+    
+    /// The specific modes of this group that are
+    /// available for your API key.
+    public let specificModes: [SpecificModeDetails]?
+    
+    /// Additional specific modes that are available
+    /// on the platform, but not currently available
+    /// for your API key.
+    ///
+    /// See https://developer.tripgo.com/extensions/
+    /// for how to unlock them, or get in touch with
+    /// someone from the TripGo API team.
+    public let lockedModes: [SpecificModeDetails]?
+  }
+  
+  /// Additional details about a specific mode, where the
+  /// specific mode usually relates to a certain transport
+  /// provider, such as a car-sharing provider, bike-sharing
+  /// provider, limousine company, or TNC.
+  public struct SpecificModeDetails: Codable {
+    /// The specific identifier
+    public let identifier: String
+    
+    /// Name of thise mode
+    public let title: String?
+    
+    /// Additional info about the mode
+    public let modeInfo: ModeInfo?
+    
+    /// Available integrations for this mode that are available
+    /// through the TripGo API.
+    public let integrations: [Integrations]?
+    
+    /// URL of the primary transport provider of this mode.
+    public let url: URL?
+
+    /// Minimum cost for a membership for the provider
+    /// of this mode. Typically applies to car share
+    /// and bike share.
+    public let minimumLocalCostForMembership: Decimal?
+    
+    /// List of public transport operator names servicing
+    /// this mode. (Public transport modes only)
+    public let operators: [String]?
+  }
+  
+}
+
+extension API.RegionInfo {
+  
+  /// - Parameter modeIdentifier: A mode identifier
+  /// - Returns: The specific mode details for this this mode identifier
+  ///     (only returns something if it's a specific mode identifier, i.e.,
+  ///     one with two underscores in it.)
+  public func specificModeDetails(for modeIdentifier: String) -> API.SpecificModeDetails? {
+    let genericMode = SVKTransportModes.genericModeIdentifier(forModeIdentifier: modeIdentifier)
+    return modes[genericMode]?.specificModes?.first { modeIdentifier == $0.identifier }
   }
   
 }

--- a/TripKit/Classes/model/API/RegionAPIModel.swift
+++ b/TripKit/Classes/model/API/RegionAPIModel.swift
@@ -59,7 +59,7 @@ extension API {
     public let title: String
     
     /// Additional info about the mode group
-    public let modeInfo: ModeInfo?
+    public let modeInfo: ModeInfo
     
     /// The specific modes of this group that are
     /// available for your API key.
@@ -80,14 +80,11 @@ extension API {
   /// provider, such as a car-sharing provider, bike-sharing
   /// provider, limousine company, or TNC.
   public struct SpecificModeDetails: Codable {
-    /// The specific identifier
-    public let identifier: String
-    
     /// Name of thise mode
     public let title: String?
     
     /// Additional info about the mode
-    public let modeInfo: ModeInfo?
+    public let modeInfo: ModeInfo
     
     /// Available integrations for this mode that are available
     /// through the TripGo API.
@@ -104,6 +101,15 @@ extension API {
     /// List of public transport operator names servicing
     /// this mode. (Public transport modes only)
     public let operators: [String]?
+    
+    public var identifier: String {
+      if let id = modeInfo.identifier {
+        return id
+      } else {
+        assertionFailure("Specific mode details should always have an identifier. Missing for '\(String(describing:self))'.")
+        return ""
+      }
+    }
   }
   
 }


### PR DESCRIPTION
`TKBuzzInfoProvider.fetchRegionInformation` now returns a bunch more information about transport modes.

In particular `API.RegionInfo.modes` got added which has all the information. Call `regionInfo.specificDetails(for: ...)` to get information for a single mode.

Note that there's also a `lockedModes` array in there with information about transport modes which you first need to unlock in your 3scale developer settings.