### PR TITLE
allow optional transit color coding in segment view

### DIFF
--- a/TripKitUI/core/TransportKitUI/SGTripSegmentsView.h
+++ b/TripKitUI/core/TransportKitUI/SGTripSegmentsView.h
@@ -25,7 +25,7 @@
 /**
  This property determines if the transit icon in the view should be color coded.
  */
-@property (nonatomic, assign) BOOL colorCodingTransit;
+@property (nonatomic, assign) BOOL colorCodingTransitIcon;
 
 - (void)configureForSegments:(NSArray<id<STKTripSegmentDisplayable>> *)segments
               allowSubtitles:(BOOL)allowSubtitles

--- a/TripKitUI/core/TransportKitUI/SGTripSegmentsView.h
+++ b/TripKitUI/core/TransportKitUI/SGTripSegmentsView.h
@@ -22,6 +22,11 @@
 
 @property (nonatomic, assign) BOOL allowWheelchairIcon;
 
+/**
+ This property determines if the transit icon in the view should be color coded.
+ */
+@property (nonatomic, assign) BOOL colorCodingTransit;
+
 - (void)configureForSegments:(NSArray<id<STKTripSegmentDisplayable>> *)segments
               allowSubtitles:(BOOL)allowSubtitles
               allowInfoIcons:(BOOL)allowInfoIcons;

--- a/TripKitUI/core/TransportKitUI/SGTripSegmentsView.m
+++ b/TripKitUI/core/TransportKitUI/SGTripSegmentsView.m
@@ -104,13 +104,17 @@
 		}
 		
 		// for the coloured strip
-		UIColor *color = (allowSubtitles && [segment respondsToSelector:@selector(tripSegmentModeColor)])
-      ? [segment tripSegmentModeColor]
-      : nil;
+//    UIColor *color = (allowSubtitles && [segment respondsToSelector:@selector(tripSegmentModeColor)])
+//      ? [segment tripSegmentModeColor]
+//      : nil;
+    
+    UIColor *color = (self.colorCodingTransit && [segment respondsToSelector:@selector(tripSegmentModeColor)])
+    ? [segment tripSegmentModeColor]
+    : nil;
 		
 		// the mode image
     UIImageView * modeImageView = [[UIImageView alloc] initWithImage:image];
-    modeImageView.tintColor = [SGStyleManager darkTextColor];
+    modeImageView.tintColor = color ?: [SGStyleManager darkTextColor];
     modeImageView.alpha = SEGMENT_ITEM_ALPHA;
 
     NSURL *modeImageURL = [segment respondsToSelector:@selector(tripSegmentModeImageURL)]
@@ -224,7 +228,7 @@
       [self addSubview:titleLabel];
       
       modeSideWidth = (CGFloat) fmax(modeSideWidth, modeTitleSize.width);
-    } else if (color) {
+    } else if (color && allowSubtitles) {
       // add the color underneath
       CGFloat y = (CGRectGetHeight(self.frame) - modeSubtitleSize.height - modeTitleSize.height) / 2;
       UIView *stripe = [[UIView alloc] initWithFrame:CGRectMake(x, y, modeTitleSize.width, modeTitleSize.height)];

--- a/TripKitUI/core/TransportKitUI/SGTripSegmentsView.m
+++ b/TripKitUI/core/TransportKitUI/SGTripSegmentsView.m
@@ -104,17 +104,11 @@
 		}
 		
 		// for the coloured strip
-//    UIColor *color = (allowSubtitles && [segment respondsToSelector:@selector(tripSegmentModeColor)])
-//      ? [segment tripSegmentModeColor]
-//      : nil;
-    
-    UIColor *color = (self.colorCodingTransit && [segment respondsToSelector:@selector(tripSegmentModeColor)])
-    ? [segment tripSegmentModeColor]
-    : nil;
+    UIColor *color = [segment respondsToSelector:@selector(tripSegmentModeColor)] ? [segment tripSegmentModeColor] : nil;
 		
 		// the mode image
     UIImageView * modeImageView = [[UIImageView alloc] initWithImage:image];
-    modeImageView.tintColor = color ?: [SGStyleManager darkTextColor];
+    modeImageView.tintColor = (color != nil && self.colorCodingTransitIcon) ? color : [SGStyleManager darkTextColor];
     modeImageView.alpha = SEGMENT_ITEM_ALPHA;
 
     NSURL *modeImageURL = [segment respondsToSelector:@selector(tripSegmentModeImageURL)]

--- a/TripKitUI/core/TransportKitUI/SGTripSummaryCell.h
+++ b/TripKitUI/core/TransportKitUI/SGTripSummaryCell.h
@@ -38,6 +38,11 @@ typedef void(^SGTripSummaryCellActionBlock)(UIControl *sender);
 @property (nonatomic, assign) BOOL allowWheelchairIcon;
 @property (nonatomic, assign) BOOL simpleTimes;
 @property (nonatomic, assign) BOOL preferNoPaddings;
+
+/**
+ This property indicates whether the transit modes in the trip segment
+ should be colored.
+ */
 @property (nonatomic, assign) BOOL colorCodingTransit;
 
 @property (nullable, nonatomic, strong) NSTimeZone *relativeTimeZone;

--- a/TripKitUI/core/TransportKitUI/SGTripSummaryCell.h
+++ b/TripKitUI/core/TransportKitUI/SGTripSummaryCell.h
@@ -40,10 +40,10 @@ typedef void(^SGTripSummaryCellActionBlock)(UIControl *sender);
 @property (nonatomic, assign) BOOL preferNoPaddings;
 
 /**
- This property indicates whether the transit modes in the trip segment
+ This property indicates whether the transit mode icons in the trip segment
  should be colored.
  */
-@property (nonatomic, assign) BOOL colorCodingTransit;
+@property (nonatomic, assign) BOOL colorCodingTransitIcon;
 
 @property (nullable, nonatomic, strong) NSTimeZone *relativeTimeZone;
 

--- a/TripKitUI/core/TransportKitUI/SGTripSummaryCell.h
+++ b/TripKitUI/core/TransportKitUI/SGTripSummaryCell.h
@@ -38,6 +38,7 @@ typedef void(^SGTripSummaryCellActionBlock)(UIControl *sender);
 @property (nonatomic, assign) BOOL allowWheelchairIcon;
 @property (nonatomic, assign) BOOL simpleTimes;
 @property (nonatomic, assign) BOOL preferNoPaddings;
+@property (nonatomic, assign) BOOL colorCodingTransit;
 
 @property (nullable, nonatomic, strong) NSTimeZone *relativeTimeZone;
 

--- a/TripKitUI/core/TransportKitUI/SGTripSummaryCell.swift
+++ b/TripKitUI/core/TransportKitUI/SGTripSummaryCell.swift
@@ -99,6 +99,7 @@ extension SGTripSummaryCell {
   
   private func updateSegments(nano: Bool) {
     segmentView?.allowWheelchairIcon = allowWheelchairIcon
+    segmentView?.colorCodingTransit = colorCodingTransit
     segmentView?.configure(forSegments: _trip.segments(with: .inSummary), allowSubtitles: !nano, allowInfoIcons: !nano)
   }
   

--- a/TripKitUI/core/TransportKitUI/SGTripSummaryCell.swift
+++ b/TripKitUI/core/TransportKitUI/SGTripSummaryCell.swift
@@ -99,7 +99,7 @@ extension SGTripSummaryCell {
   
   private func updateSegments(nano: Bool) {
     segmentView?.allowWheelchairIcon = allowWheelchairIcon
-    segmentView?.colorCodingTransit = colorCodingTransit
+    segmentView?.colorCodingTransitIcon = colorCodingTransitIcon
     segmentView?.configure(forSegments: _trip.segments(with: .inSummary), allowSubtitles: !nano, allowInfoIcons: !nano)
   }
   


### PR DESCRIPTION
This PR focuses on exposing an entry point for `SGTripSegmentView` to configure optional coloring of public transport modes.