### PR TITLE
Preparing for "hop" and "dismount" shapes

### DIFF
--- a/TripKit.xcodeproj/project.pbxproj
+++ b/TripKit.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3A04C9AB206D39320015D9E5 /* TKPathFriendliness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A04C9AA206D39320015D9E5 /* TKPathFriendliness.swift */; };
+		3A04C9AC206D39320015D9E5 /* TKPathFriendliness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A04C9AA206D39320015D9E5 /* TKPathFriendliness.swift */; };
 		3A096E1E1F20DAD500666E59 /* SVKServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A096E1D1F20DAD500666E59 /* SVKServer.swift */; };
 		3A096E221F20DC5D00666E59 /* SGKConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A096E211F20DC5D00666E59 /* SGKConfig.swift */; };
 		3A096E241F20DD5300666E59 /* TripKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A096E231F20DD5300666E59 /* TripKit.swift */; };
@@ -888,6 +890,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		3A04C9AA206D39320015D9E5 /* TKPathFriendliness.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TKPathFriendliness.swift; sourceTree = "<group>"; };
 		3A096E1D1F20DAD500666E59 /* SVKServer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SVKServer.swift; sourceTree = "<group>"; };
 		3A096E211F20DC5D00666E59 /* SGKConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SGKConfig.swift; sourceTree = "<group>"; };
 		3A096E231F20DD5300666E59 /* TripKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TripKit.swift; sourceTree = "<group>"; };
@@ -2491,6 +2494,7 @@
 				3AF94B231F0C061500500940 /* TKColoredRoute.swift */,
 				3A51402C1DEE62EE002DB39F /* TKDLSTable.swift */,
 				3AF3F2631E04CA8C00A2EEC6 /* TKLocationTypes.swift */,
+				3A04C9AA206D39320015D9E5 /* TKPathFriendliness.swift */,
 				3AB6C6841D1CD08E0089F687 /* TKPlainCell.h */,
 				3AB6C6851D1CD08E0089F687 /* TKPlainCell.m */,
 				3AB6C6861D1CD08E0089F687 /* TKSegment.h */,
@@ -3477,6 +3481,7 @@
 				3ABBDABC2032135400205042 /* SGKGeocodable.swift in Sources */,
 				3ABBDA952032134900205042 /* SGKNamedCoordinate+SVKRegion.swift in Sources */,
 				3ABBDA662032132D00205042 /* TKSegment.swift in Sources */,
+				3A04C9AC206D39320015D9E5 /* TKPathFriendliness.swift in Sources */,
 				3ABBDA1F2032132400205042 /* TKBuzzRouter.m in Sources */,
 				3A922066205FD393004E6C34 /* SGAutocompletionDataSource.swift in Sources */,
 				3ABBDA2F2032132400205042 /* TKRouter.m in Sources */,
@@ -3859,6 +3864,7 @@
 				3AFFAB991F06854F00147990 /* NSError+customError.swift in Sources */,
 				3AB6C6F71D1CD08E0089F687 /* TKSegment.m in Sources */,
 				3AB6C6ED1D1CD08E0089F687 /* Vehicle.m in Sources */,
+				3A04C9AB206D39320015D9E5 /* TKPathFriendliness.swift in Sources */,
 				3A51402F1DEE62EE002DB39F /* TKSegment.swift in Sources */,
 				3AFFABB41F06854F00147990 /* SGKCrossPlatform.swift in Sources */,
 				3A9FF6D71DE79FA700DB4647 /* Alert.swift in Sources */,

--- a/TripKit/Classes/Loc+TripKit.swift
+++ b/TripKit/Classes/Loc+TripKit.swift
@@ -50,6 +50,10 @@ extension Loc {
     return NSLocalizedString("Unfriendly", tableName: "TripKit", bundle: .tripKit, comment: "Indicating a path is wheelchair/cycyling unfriendly")
   }
   
+  public static var Dismount: String {
+    return NSLocalizedString("Dismount", tableName: "TripKit", bundle: .tripKit, comment: "Indicating a path requires you to dismount and push your bicycle")
+  }
+  
   public static var UnknownPathFriendliness: String {
     return NSLocalizedString("Unknown", tableName: "TripKit", bundle: .tripKit, comment: "Indicating the wheelchair/cycling friendliness of a path is unknown")
   }

--- a/TripKit/Classes/model/CoreData/SegmentTemplate.h
+++ b/TripKit/Classes/model/CoreData/SegmentTemplate.h
@@ -32,6 +32,7 @@
 @property (nonatomic, retain) NSNumber * metres;
 @property (nonatomic, retain) NSNumber * metresFriendly;
 @property (nonatomic, retain) NSNumber * metresUnfriendly;
+@property (nonatomic, retain) NSNumber * metresDismount;
 @property (nonatomic, strong) NSString * modeIdentifier;
 @property (nonatomic, strong) NSString * notesRaw;
 @property (nonatomic, strong) NSString * scheduledStartStopCode;

--- a/TripKit/Classes/model/CoreData/SegmentTemplate.m
+++ b/TripKit/Classes/model/CoreData/SegmentTemplate.m
@@ -28,7 +28,7 @@ typedef NSUInteger SGSegmentTemplateFlag;
 @dynamic data;
 @dynamic flags;
 @dynamic durationWithoutTraffic;
-@dynamic metres, metresFriendly, metresUnfriendly;
+@dynamic metres, metresFriendly, metresUnfriendly, metresDismount;
 @dynamic hashCode;
 @dynamic modeIdentifier;
 @dynamic scheduledStartStopCode, scheduledEndStopCode;

--- a/TripKit/Classes/model/CoreData/Shape+CoreDataClass.swift
+++ b/TripKit/Classes/model/CoreData/Shape+CoreDataClass.swift
@@ -107,6 +107,20 @@ public class Shape: NSManagedObject {
   }
 }
 
+extension Shape {
+  
+  public var friendliness: TKPathFriendliness {
+    if isDismount {
+      return .dismount
+    } else if let friendly = isSafe {
+      return friendly ? .friendly : .unfriendly
+    } else {
+      return .unknown
+    }
+  }
+  
+}
+
 
 extension Shape {
   @objc(fetchTravelledShapeForTemplate:atStart:)
@@ -139,21 +153,11 @@ extension Shape: STKDisplayableRoute {
       return color
     }
     
-    if isDismount {
-      return #colorLiteral(red: 0, green: 0, blue: 0, alpha: 1)
-    }
-    if let friendly = isSafe {
-      if friendly {
-        return #colorLiteral(red: 0.2862745098, green: 0.862745098, blue: 0.3882352941, alpha: 1)
-      } else {
-        return #colorLiteral(red: 1, green: 0.9058823529, blue: 0.2862745098, alpha: 1)
-      }
-    }
-    
-    if let color = segment?.color() {
-      return color
-    } else {
-      return #colorLiteral(red: 0.5607843137, green: 0.5450980392, blue: 0.5411764706, alpha: 1)
+    switch friendliness {
+    case .friendly, .unfriendly, .dismount:
+      return friendliness.color
+    case .unknown:
+      return segment?.color() ?? friendliness.color
     }
   }
   
@@ -168,8 +172,6 @@ extension Shape: STKDisplayableRoute {
   public var routeDashPattern: [NSNumber]? {
     if isHop {
       return [1, 15] // dots
-    } else if isDismount {
-      return [7, 15] // dashes
     } else {
       return nil
     }

--- a/TripKit/Classes/model/CoreData/Shape+CoreDataClass.swift
+++ b/TripKit/Classes/model/CoreData/Shape+CoreDataClass.swift
@@ -13,6 +13,13 @@ import MapKit
 
 @objc(Shape)
 public class Shape: NSManagedObject {
+  
+  private enum Flag: Int32 {
+    case isSafe     = 1
+    case isNotSafe  = 2
+    case dismount   = 4
+    case isHop      = 8
+  }
 
   fileprivate var _sortedCoordinates: [SGKNamedCoordinate]?
   
@@ -28,24 +35,76 @@ public class Shape: NSManagedObject {
   
   @objc public weak var segment: TKSegment? = nil
   
-  @objc public var start: MKAnnotation? {
-    guard let first = sortedCoordinates?.first else { return nil }
-    
-    return first
-  }
-
-  @objc public var end: MKAnnotation? {
-    guard let last = sortedCoordinates?.last else { return nil }
-    
-    return last
-  }
-  
   public override func didTurnIntoFault() {
     super.didTurnIntoFault()
     _sortedCoordinates = nil
     segment = nil
   }
   
+  @objc public var start: MKAnnotation? {
+    return sortedCoordinates?.first
+  }
+
+  @objc public var end: MKAnnotation? {
+    return sortedCoordinates?.last
+  }
+  
+  @objc
+  public var isDismount: Bool {
+    get {
+      return has(.dismount)
+    }
+    set {
+      set(.dismount, to: newValue)
+    }
+  }
+  
+  @objc
+  public var isHop: Bool {
+    get {
+      return has(.isHop)
+    }
+    set {
+      set(.isHop, to: newValue)
+    }
+  }
+  
+  public var isSafe: Bool? {
+    if has(.isSafe) {
+      return true
+    } else if has(.isNotSafe) {
+      return false
+    } else {
+      return nil
+    }
+  }
+  
+  @objc
+  public func setSafety(_ value: NSNumber?) {
+    switch value?.boolValue {
+    case true?:
+      set(.isSafe, to: true)
+      set(.isNotSafe, to: false)
+    case false?:
+      set(.isSafe, to: false)
+      set(.isNotSafe, to: true)
+    case nil:
+      set(.isSafe, to: false)
+      set(.isNotSafe, to: false)
+    }
+  }
+  
+  private func has(_ flag: Flag) -> Bool {
+    return (flags & flag.rawValue) != 0
+  }
+  
+  private func set(_ flag: Flag, to value: Bool) {
+    if value {
+      flags = flags | flag.rawValue
+    } else {
+      flags = flags & ~flag.rawValue
+    }
+  }
 }
 
 
@@ -80,8 +139,11 @@ extension Shape: STKDisplayableRoute {
       return color
     }
     
-    if let friendly = friendly {
-      if friendly.boolValue {
+    if isDismount {
+      return #colorLiteral(red: 0, green: 0, blue: 0, alpha: 1)
+    }
+    if let friendly = isSafe {
+      if friendly {
         return #colorLiteral(red: 0.2862745098, green: 0.862745098, blue: 0.3882352941, alpha: 1)
       } else {
         return #colorLiteral(red: 1, green: 0.9058823529, blue: 0.2862745098, alpha: 1)
@@ -104,7 +166,13 @@ extension Shape: STKDisplayableRoute {
   }
   
   public var routeDashPattern: [NSNumber]? {
-    return nil
+    if isHop {
+      return [1, 15] // dots
+    } else if isDismount {
+      return [7, 15] // dashes
+    } else {
+      return nil
+    }
   }
     
   

--- a/TripKit/Classes/model/CoreData/Shape+CoreDataProperties.swift
+++ b/TripKit/Classes/model/CoreData/Shape+CoreDataProperties.swift
@@ -2,8 +2,8 @@
 //  Shape+CoreDataProperties.swift
 //  TripKit
 //
-//  Created by Adrian Schoenig on 4/7/17.
-//  Copyright © 2017 SkedGo. All rights reserved.
+//  Created by Adrian Schönig on 06.11.17.
+//
 //
 
 import Foundation
@@ -17,11 +17,12 @@ extension Shape {
     }
 
     @NSManaged public var encodedWaypoints: String?
-    @NSManaged public var friendly: NSNumber?
-    @NSManaged public var index: NSNumber?
+    @NSManaged public var index: Int16
     @NSManaged public var title: String?
-    @NSManaged public var toDelete: NSNumber?
+    @NSManaged public var toDelete: Bool
     @NSManaged public var travelled: NSNumber?
+    @NSManaged public var flags: Int32
+    @NSManaged public var metres: NSNumber?
     @NSManaged public var services: NSSet?
     @NSManaged public var template: SegmentTemplate?
     @NSManaged public var visits: NSSet?

--- a/TripKit/Classes/model/TKPathFriendliness.swift
+++ b/TripKit/Classes/model/TKPathFriendliness.swift
@@ -1,0 +1,35 @@
+//
+//  TKPathFriendliness.swift
+//  TripKit
+//
+//  Created by Adrian Schönig on 29.03.18.
+//  Copyright © 2018 SkedGo. All rights reserved.
+//
+
+import Foundation
+
+public enum TKPathFriendliness {
+  case friendly
+  case unfriendly
+  case dismount
+  case unknown
+  
+  public var color: SGKColor {
+    switch self {
+    case .friendly:   return #colorLiteral(red: 0.2862745098, green: 0.862745098, blue: 0.3882352941, alpha: 1)
+    case .unfriendly: return #colorLiteral(red: 1, green: 0.9058823529, blue: 0.2862745098, alpha: 1)
+    case .dismount:   return #colorLiteral(red: 0.9254902005, green: 0.2352941185, blue: 0.1019607857, alpha: 1)
+    case .unknown:    return #colorLiteral(red: 0.5607843137, green: 0.5450980392, blue: 0.5411764706, alpha: 1)
+    }
+  }
+  
+  public var title: String {
+    switch self {
+    case .friendly:   return Loc.FriendlyPath
+    case .unfriendly: return Loc.UnfriendlyPath
+    case .dismount:   return Loc.Dismount
+    case .unknown:    return Loc.UnknownPathFriendliness
+    }
+  }
+}
+

--- a/TripKit/Classes/server/TKParserHelper.m
+++ b/TripKit/Classes/server/TKParserHelper.m
@@ -134,11 +134,14 @@
     
     // create the new shape
     Shape *shape = [NSEntityDescription insertNewObjectForEntityForName:NSStringFromClass([Shape class]) inManagedObjectContext:context];
-    shape.index = @(waypointGroupCount++);
+    shape.index = waypointGroupCount++;
     shape.travelled = shapeDict[@"travelled"];
     shape.title = shapeDict[@"name"];
     shape.encodedWaypoints = encodedWaypoints;
-    shape.friendly = shapeDict[@"safe"];
+    shape.isDismount = [shapeDict[@"dismount"] boolValue];
+    shape.isHop = [shapeDict[@"hop"] boolValue];
+    shape.metres = shapeDict[@"metres"];
+    [shape setSafety: shapeDict[@"safe"]];
     if (nil == shape.travelled)
       shape.travelled = @(YES);
     

--- a/TripKit/Classes/server/TKRoutingParser.m
+++ b/TripKit/Classes/server/TKRoutingParser.m
@@ -55,6 +55,7 @@
   template.metres           = dict[@"metres"];
   template.metresFriendly   = dict[@"metresSafe"];
   template.metresUnfriendly = dict[@"metresUnsafe"];
+  template.metresDismount   = dict[@"metresDismount"];
   
   if (template.segmentType.integerValue == TKSegmentTypeScheduled) {
     template.scheduledStartStopCode = dict[@"stopCode"];

--- a/TripKitModel.xcdatamodeld/6-SegmentRealTimeVehicle.xcdatamodel/contents
+++ b/TripKitModel.xcdatamodeld/6-SegmentRealTimeVehicle.xcdatamodel/contents
@@ -135,11 +135,12 @@
     </entity>
     <entity name="Shape" representedClassName="Shape" syncable="YES">
         <attribute name="encodedWaypoints" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="friendly" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
-        <attribute name="index" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="flags" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="index" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="metres" optional="YES" attributeType="Integer 32" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="title" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="toDelete" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
-        <attribute name="travelled" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="toDelete" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="travelled" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES" syncable="YES"/>
         <relationship name="services" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Service" inverseName="shape" inverseEntity="Service" syncable="YES"/>
         <relationship name="template" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="SegmentTemplate" inverseName="shapes" inverseEntity="SegmentTemplate" syncable="YES"/>
         <relationship name="visits" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="StopVisits" inverseName="shapes" inverseEntity="StopVisits" syncable="YES"/>
@@ -311,7 +312,7 @@
         <element name="SegmentReference" positionX="511" positionY="-117" width="128" height="238"/>
         <element name="SegmentTemplate" positionX="952" positionY="-234" width="128" height="388"/>
         <element name="Service" positionX="315" positionY="149" width="128" height="298"/>
-        <element name="Shape" positionX="637" positionY="531" width="128" height="180"/>
+        <element name="Shape" positionX="637" positionY="531" width="128" height="195"/>
         <element name="StopLocation" positionX="-101" positionY="369" width="128" height="283"/>
         <element name="StopVisits" positionX="124" positionY="243" width="128" height="238"/>
         <element name="Trip" positionX="315" positionY="-252" width="128" height="390"/>

--- a/TripKitModel.xcdatamodeld/6-SegmentRealTimeVehicle.xcdatamodel/contents
+++ b/TripKitModel.xcdatamodeld/6-SegmentRealTimeVehicle.xcdatamodel/contents
@@ -80,6 +80,7 @@
         <attribute name="flags" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="hashCode" attributeType="Integer 32" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="metres" optional="YES" attributeType="Integer 32" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="metresDismount" optional="YES" attributeType="Integer 32" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="metresFriendly" optional="YES" attributeType="Integer 32" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="metresUnfriendly" optional="YES" attributeType="Integer 32" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="modeIdentifier" optional="YES" attributeType="String" syncable="YES"/>
@@ -310,7 +311,7 @@
         <element name="Cell" positionX="-99" positionY="131" width="128" height="165"/>
         <element name="DLSEntry" positionX="124" positionY="539" width="128" height="73"/>
         <element name="SegmentReference" positionX="511" positionY="-117" width="128" height="238"/>
-        <element name="SegmentTemplate" positionX="952" positionY="-234" width="128" height="388"/>
+        <element name="SegmentTemplate" positionX="952" positionY="-234" width="128" height="405"/>
         <element name="Service" positionX="315" positionY="149" width="128" height="298"/>
         <element name="Shape" positionX="637" positionY="531" width="128" height="195"/>
         <element name="StopLocation" positionX="-101" positionY="369" width="128" height="283"/>

--- a/TripKitUI/views/TKPathFriendlinessView.swift
+++ b/TripKitUI/views/TKPathFriendlinessView.swift
@@ -12,23 +12,29 @@ public class TKPathFriendlinessView: UIView {
   // Bar chart
   @IBOutlet weak var friendlyBarView: UIView!
   @IBOutlet weak var unfriendlyBarView: UIView!
+  @IBOutlet weak var dismountBarView: UIView!
   @IBOutlet weak var unknownBarView: UIView!
   
   // Chart label
   @IBOutlet weak var friendlyMetreLabel: UILabel!
   @IBOutlet weak var unfriendlyMetreLabel: UILabel!
+  @IBOutlet weak var dismountMetreLabel: UILabel!
   @IBOutlet weak var unknownMetreLabel: UILabel!
   
   // Legend
-  @IBOutlet var friendlyLegendLabel: UILabel!
-  @IBOutlet var unfriendlyLegendLabel: UILabel!
-  @IBOutlet var unknownLegendLabel: UILabel!
+  @IBOutlet weak var friendlyLegendLabel: UILabel!
+  @IBOutlet weak var unfriendlyLegendLabel: UILabel!
+  @IBOutlet weak var dismountLegendLabel: UILabel!
+  @IBOutlet weak var unknownLegendLabel: UILabel!
   @IBOutlet weak var friendlyLegendDot: UIView!
   @IBOutlet weak var unfriendlyLegendDot: UIView!
+  @IBOutlet weak var dismountLegendDot: UIView!
   @IBOutlet weak var unknownLegendDot: UIView!
   
-  @IBOutlet weak var friendlyToUnfriendlySpacing: NSLayoutConstraint!
-  @IBOutlet weak var unfriendlyToUnknownSpacing: NSLayoutConstraint!
+  // Spacers
+  @IBOutlet weak var friendlyToUnfriendlySpacingConstraint: NSLayoutConstraint!
+  @IBOutlet weak var unfriendlyToDismountSpacingConstraint: NSLayoutConstraint!
+  @IBOutlet weak var dismountToUnknownSpacingConstraint: NSLayoutConstraint!
   
   public var segment: TKSegment? {
     didSet {
@@ -36,7 +42,7 @@ public class TKPathFriendlinessView: UIView {
     }
   }
   
-  public typealias PathFriedliness = (friendly: CGFloat, unfriendly: CGFloat, unknown: CGFloat)
+  public typealias PathFriedliness = (friendly: CGFloat, unfriendly: CGFloat, dismount: CGFloat, unknown: CGFloat)
   
   public override init(frame: CGRect) {
     super.init(frame: frame)
@@ -49,39 +55,58 @@ public class TKPathFriendlinessView: UIView {
   public override func awakeFromNib() {
     super.awakeFromNib()
     
-    friendlyLegendLabel.text = Loc.FriendlyPath
-    unfriendlyLegendLabel.text = Loc.UnfriendlyPath
-    unknownLegendLabel.text = Loc.UnknownPathFriendliness
+    friendlyLegendLabel.text   = TKPathFriendliness.friendly.title
+    unfriendlyLegendLabel.text = TKPathFriendliness.unfriendly.title
+    dismountLegendLabel.text   = TKPathFriendliness.dismount.title
+    unknownLegendLabel.text    = TKPathFriendliness.unknown.title
   }
   
   fileprivate func update() {
     guard
-      let segment = self.segment,
-      segment.template != nil,
-      let metres = segment.template.metres
+      let template = self.segment?.template,
+      let totalMetres = template.metres?.doubleValue
       else { return }
     
-    let friendlyMetres = segment.template?.metresFriendly?.doubleValue ?? Double(0)
-    let friendlyRatio = friendlyMetres / metres.doubleValue
+    let friendlyMetres = template.metresFriendly?.doubleValue ?? Double(0)
+    let friendlyRatio = friendlyMetres / totalMetres
     
-    let unfriendlyMetres = segment.template?.metresUnfriendly?.doubleValue ?? Double(0)
-    let unfriendlyRatio = unfriendlyMetres / metres.doubleValue
-    
-    let unknownMetres = metres.doubleValue - friendlyMetres - unfriendlyMetres
-    let unknownRatio = unknownMetres / metres.doubleValue
+    let unfriendlyMetres = template.metresUnfriendly?.doubleValue ?? Double(0)
+    let unfriendlyRatio = unfriendlyMetres / totalMetres
+
+    let dismountMetres = template.metresDismount?.doubleValue ?? Double(0)
+    let dismountRatio = dismountMetres / totalMetres
+
+    let unknownMetres = totalMetres - friendlyMetres - dismountMetres - unfriendlyMetres - 1 // -1 for rounding issues
+    let unknownRatio = unknownMetres / totalMetres
     
     let formatter = NumberFormatter()
     formatter.numberStyle = .percent
     
     // Legend
-    friendlyLegendLabel.text = Loc.FriendlyPath
-    unfriendlyLegendLabel.text = Loc.UnfriendlyPath
-    unknownLegendLabel.text = Loc.UnknownPathFriendliness
+    friendlyLegendLabel.text   = TKPathFriendliness.friendly.title
+    unfriendlyLegendLabel.text = TKPathFriendliness.unfriendly.title
+    dismountLegendLabel.text   = TKPathFriendliness.dismount.title
+    unknownLegendLabel.text    = TKPathFriendliness.unknown.title
     
+    // Colors
+    friendlyLegendDot.backgroundColor = TKPathFriendliness.friendly.color
+    unfriendlyLegendDot.backgroundColor = TKPathFriendliness.unfriendly.color
+    dismountLegendDot.backgroundColor = TKPathFriendliness.dismount.color
+    unknownLegendDot.backgroundColor = TKPathFriendliness.unknown.color
+    friendlyBarView.backgroundColor = TKPathFriendliness.friendly.color
+    unfriendlyBarView.backgroundColor = TKPathFriendliness.unfriendly.color
+    dismountBarView.backgroundColor = TKPathFriendliness.dismount.color
+    unknownBarView.backgroundColor = TKPathFriendliness.unknown.color
+    friendlyMetreLabel.textColor = TKPathFriendliness.friendly.color
+    unfriendlyMetreLabel.textColor = TKPathFriendliness.unfriendly.color
+    dismountMetreLabel.textColor = TKPathFriendliness.dismount.color
+    unknownMetreLabel.textColor = TKPathFriendliness.unknown.color
+
     // Update bar chart.
     let widthConstraints = [
         friendlyBarView.widthAnchor.constraint(equalTo: widthAnchor, multiplier: CGFloat(friendlyRatio)),
         unfriendlyBarView.widthAnchor.constraint(equalTo: widthAnchor, multiplier: CGFloat(unfriendlyRatio)),
+        dismountBarView.widthAnchor.constraint(equalTo: widthAnchor, multiplier: CGFloat(dismountRatio)),
         unknownBarView.widthAnchor.constraint(equalTo: widthAnchor, multiplier: CGFloat(unknownRatio))
       ]
     
@@ -95,30 +120,33 @@ public class TKPathFriendlinessView: UIView {
     // Update labels
     friendlyMetreLabel.text = distanceFormatter.string(fromDistance: friendlyMetres)
     unfriendlyMetreLabel.text = distanceFormatter.string(fromDistance: unfriendlyMetres)
+    dismountMetreLabel.text = distanceFormatter.string(fromDistance: dismountMetres)
     unknownMetreLabel.text = distanceFormatter.string(fromDistance: unknownMetres)
     
     // Hide labels if required
     friendlyMetreLabel.isHidden = friendlyMetres < 0.5
     unfriendlyMetreLabel.isHidden = unfriendlyMetres < 0.5
+    dismountMetreLabel.isHidden = dismountMetres < 0.5
     unknownMetreLabel.isHidden = unknownMetres < 0.5
     friendlyLegendLabel.isHidden = friendlyMetreLabel.isHidden
     unfriendlyLegendLabel.isHidden = unfriendlyMetreLabel.isHidden
+    dismountLegendLabel.isHidden = dismountMetreLabel.isHidden
     unknownLegendLabel.isHidden = unknownMetreLabel.isHidden
     friendlyLegendDot.isHidden = friendlyMetreLabel.isHidden
     unfriendlyLegendDot.isHidden = unfriendlyMetreLabel.isHidden
+    dismountLegendDot.isHidden = dismountMetreLabel.isHidden
     unknownLegendDot.isHidden = unknownMetreLabel.isHidden
 
     // Account for non-zero width of hidden labels
-    let friendlyLabelWidth = friendlyMetreLabel.widthAnchor.constraint(equalToConstant: 0)
-    let unfriendlyLabelWidthConstraint = unfriendlyMetreLabel.widthAnchor.constraint(equalToConstant: 0)
-    let unknownLabelWidthConstraint = unknownMetreLabel.widthAnchor.constraint(equalToConstant: 0)
+    friendlyMetreLabel.widthAnchor.constraint(equalToConstant: 0).isActive = friendlyMetreLabel.isHidden
+    unfriendlyMetreLabel.widthAnchor.constraint(equalToConstant: 0).isActive = unfriendlyMetreLabel.isHidden
+    dismountMetreLabel.widthAnchor.constraint(equalToConstant: 0).isActive = dismountMetreLabel.isHidden
+    unknownMetreLabel.widthAnchor.constraint(equalToConstant: 0).isActive = unknownMetreLabel.isHidden
     
-    friendlyLabelWidth.isActive = friendlyMetreLabel.isHidden
-    unfriendlyLabelWidthConstraint.isActive = unfriendlyMetreLabel.isHidden
-    unknownLabelWidthConstraint.isActive = unknownMetreLabel.isHidden
-    
-    friendlyToUnfriendlySpacing.constant = friendlyMetres < 0.5 ? 0 : 8
-    unfriendlyToUnknownSpacing.constant = unknownMetres < 0.5 ? 0 : 8
+    // Spacing
+    friendlyToUnfriendlySpacingConstraint.constant = friendlyMetreLabel.isHidden ? 0 : 8
+    unfriendlyToDismountSpacingConstraint.constant = dismountMetreLabel.isHidden ? 0 : 8
+    dismountToUnknownSpacingConstraint.constant = unfriendlyMetreLabel.isHidden ? 0 : 8
   }
   
 }

--- a/TripKitUI/views/TKPathFriendlinessView.xib
+++ b/TripKitUI/views/TKPathFriendlinessView.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13526" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13524"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -18,7 +18,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="6a0-Cz-EtD" userLabel="Legend">
-                    <rect key="frame" x="0.0" y="0.0" width="244" height="30.5"/>
+                    <rect key="frame" x="0.0" y="0.0" width="329.5" height="30.5"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="x9a-TJ-Yxi">
                             <rect key="frame" x="0.0" y="8" width="69" height="14.5"/>
@@ -68,11 +68,11 @@
                             </subviews>
                         </stackView>
                         <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="VVs-pu-hF0">
-                            <rect key="frame" x="167.5" y="8" width="76.5" height="14.5"/>
+                            <rect key="frame" x="167.5" y="8" width="77.5" height="14.5"/>
                             <subviews>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ONZ-M1-JNZ">
                                     <rect key="frame" x="0.0" y="1.5" width="12" height="12"/>
-                                    <color key="backgroundColor" red="0.84705882349999995" green="0.84705882349999995" blue="0.84705882349999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <color key="backgroundColor" cocoaTouchSystemColor="darkTextColor"/>
                                     <constraints>
                                         <constraint firstAttribute="width" secondItem="ONZ-M1-JNZ" secondAttribute="height" multiplier="1:1" id="3el-OU-rWH"/>
                                         <constraint firstAttribute="width" constant="12" id="Rjg-pw-kPq"/>
@@ -83,7 +83,30 @@
                                         </userDefinedRuntimeAttribute>
                                     </userDefinedRuntimeAttributes>
                                 </view>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="#Unknown" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ErG-er-iIm">
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="#Dismount" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ErG-er-iIm">
+                                    <rect key="frame" x="16" y="0.0" width="61.5" height="14.5"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                            </subviews>
+                        </stackView>
+                        <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="Dqu-Mc-ko9">
+                            <rect key="frame" x="253" y="8" width="76.5" height="14.5"/>
+                            <subviews>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WFP-SO-5Kl">
+                                    <rect key="frame" x="0.0" y="1.5" width="12" height="12"/>
+                                    <color key="backgroundColor" red="0.84705882349999995" green="0.84705882349999995" blue="0.84705882349999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" secondItem="WFP-SO-5Kl" secondAttribute="height" multiplier="1:1" id="Xm9-kq-NbD"/>
+                                        <constraint firstAttribute="width" constant="12" id="fjP-Va-vPw"/>
+                                    </constraints>
+                                    <userDefinedRuntimeAttributes>
+                                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                            <integer key="value" value="6"/>
+                                        </userDefinedRuntimeAttribute>
+                                    </userDefinedRuntimeAttributes>
+                                </view>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="#Unknown" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QNf-gF-kro">
                                     <rect key="frame" x="16" y="0.0" width="60.5" height="14.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                     <nil key="highlightedColor"/>
@@ -95,23 +118,28 @@
                 <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="U0R-7C-Vbc" userLabel="Bar Chart">
                     <rect key="frame" x="0.0" y="38.5" width="375" height="8"/>
                     <subviews>
-                        <view contentMode="scaleToFill" placeholderIntrinsicWidth="125" placeholderIntrinsicHeight="8" translatesAutoresizingMaskIntoConstraints="NO" id="pE2-0a-GuL">
-                            <rect key="frame" x="0.0" y="0.0" width="125" height="8"/>
+                        <view contentMode="scaleToFill" horizontalCompressionResistancePriority="751" placeholderIntrinsicWidth="250" placeholderIntrinsicHeight="8" translatesAutoresizingMaskIntoConstraints="NO" id="pE2-0a-GuL">
+                            <rect key="frame" x="0.0" y="0.0" width="250" height="8"/>
                             <color key="backgroundColor" red="0.0" green="0.60784313729999995" blue="0.87450980389999999" alpha="1" colorSpace="calibratedRGB"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="8" id="FYs-1y-jQy"/>
                             </constraints>
                         </view>
-                        <view contentMode="scaleToFill" placeholderIntrinsicWidth="125" placeholderIntrinsicHeight="8" translatesAutoresizingMaskIntoConstraints="NO" id="I7L-ZV-BRP">
-                            <rect key="frame" x="125" y="0.0" width="125" height="8"/>
+                        <view contentMode="scaleToFill" horizontalCompressionResistancePriority="752" placeholderIntrinsicWidth="100" placeholderIntrinsicHeight="8" translatesAutoresizingMaskIntoConstraints="NO" id="I7L-ZV-BRP">
+                            <rect key="frame" x="250" y="0.0" width="100" height="8"/>
                             <color key="backgroundColor" red="1" green="0.71372549019607845" blue="0.094117647058823528" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         </view>
-                        <view contentMode="scaleToFill" placeholderIntrinsicWidth="125" placeholderIntrinsicHeight="8" translatesAutoresizingMaskIntoConstraints="NO" id="oU9-U2-5m6">
-                            <rect key="frame" x="250" y="0.0" width="125" height="8"/>
+                        <view contentMode="scaleToFill" horizontalCompressionResistancePriority="751" placeholderIntrinsicWidth="20" placeholderIntrinsicHeight="8" translatesAutoresizingMaskIntoConstraints="NO" id="fHS-tC-35v">
+                            <rect key="frame" x="350" y="0.0" width="20" height="8"/>
+                            <color key="backgroundColor" cocoaTouchSystemColor="darkTextColor"/>
+                        </view>
+                        <view contentMode="scaleToFill" placeholderIntrinsicWidth="5" placeholderIntrinsicHeight="8" translatesAutoresizingMaskIntoConstraints="NO" id="oU9-U2-5m6">
+                            <rect key="frame" x="370" y="0.0" width="5" height="8"/>
                             <color key="backgroundColor" red="0.84705882352941175" green="0.84705882352941175" blue="0.84705882352941175" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         </view>
                     </subviews>
                     <constraints>
+                        <constraint firstItem="fHS-tC-35v" firstAttribute="height" secondItem="pE2-0a-GuL" secondAttribute="height" id="6L2-LJ-yEf"/>
                         <constraint firstItem="oU9-U2-5m6" firstAttribute="height" secondItem="pE2-0a-GuL" secondAttribute="height" id="EEc-fw-v4i"/>
                         <constraint firstItem="I7L-ZV-BRP" firstAttribute="height" secondItem="pE2-0a-GuL" secondAttribute="height" id="b2e-2D-Zvk"/>
                     </constraints>
@@ -123,7 +151,7 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="#75m" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zTx-Fx-qGq" userLabel="#186m (Unfriendly)">
-                    <rect key="frame" x="125" y="50.5" width="125" height="14.5"/>
+                    <rect key="frame" x="250" y="50.5" width="32.5" height="14.5"/>
                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                     <color key="textColor" red="1" green="0.71372549019607845" blue="0.094117647058823528" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <nil key="highlightedColor"/>
@@ -134,6 +162,12 @@
                     <color key="textColor" red="0.60784313725490191" green="0.60784313725490191" blue="0.60784313725490191" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="#75m" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dS2-hZ-VlU" userLabel="#186m (Dismount)">
+                    <rect key="frame" x="301" y="50.5" width="32.5" height="14.5"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
@@ -142,33 +176,40 @@
                 <constraint firstItem="U0R-7C-Vbc" firstAttribute="top" secondItem="6a0-Cz-EtD" secondAttribute="bottom" constant="8" id="BH2-UO-3xa"/>
                 <constraint firstItem="U0R-7C-Vbc" firstAttribute="trailing" secondItem="vUN-kp-3ea" secondAttribute="trailing" id="Bqu-5v-Y6i"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="top" secondItem="6a0-Cz-EtD" secondAttribute="top" id="Cv9-Ua-8KS"/>
+                <constraint firstItem="zTx-Fx-qGq" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="ovk-wO-7Wo" secondAttribute="trailing" constant="8" id="GJU-fH-6z2"/>
                 <constraint firstItem="U0R-7C-Vbc" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="MhQ-bA-EBk"/>
                 <constraint firstItem="zTx-Fx-qGq" firstAttribute="leading" secondItem="I7L-ZV-BRP" secondAttribute="leading" priority="749" id="N7d-Fq-PJB"/>
+                <constraint firstItem="dS2-hZ-VlU" firstAttribute="centerY" secondItem="ovk-wO-7Wo" secondAttribute="centerY" id="Qs3-EF-qrg"/>
                 <constraint firstItem="zTx-Fx-qGq" firstAttribute="centerY" secondItem="ovk-wO-7Wo" secondAttribute="centerY" id="Rc4-mA-d1R"/>
-                <constraint firstItem="LCm-DB-pzD" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="zTx-Fx-qGq" secondAttribute="trailing" constant="8" id="Ro2-9K-rOn"/>
                 <constraint firstItem="ovk-wO-7Wo" firstAttribute="top" secondItem="U0R-7C-Vbc" secondAttribute="bottom" constant="4" id="cXl-H8-vhY"/>
-                <constraint firstItem="zTx-Fx-qGq" firstAttribute="trailing" secondItem="I7L-ZV-BRP" secondAttribute="trailing" priority="748" id="eKr-Vc-A3h"/>
-                <constraint firstItem="zTx-Fx-qGq" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="ovk-wO-7Wo" secondAttribute="trailing" constant="8" id="gW0-5W-1Ee"/>
+                <constraint firstItem="dS2-hZ-VlU" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="zTx-Fx-qGq" secondAttribute="trailing" constant="8" id="ck7-ML-Xf3"/>
+                <constraint firstItem="LCm-DB-pzD" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="dS2-hZ-VlU" secondAttribute="trailing" constant="8" id="jHu-2N-DI3"/>
                 <constraint firstItem="6a0-Cz-EtD" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="kAL-JW-mkM"/>
                 <constraint firstItem="LCm-DB-pzD" firstAttribute="centerY" secondItem="ovk-wO-7Wo" secondAttribute="centerY" id="qBj-1C-OS8"/>
                 <constraint firstItem="LCm-DB-pzD" firstAttribute="trailing" secondItem="oU9-U2-5m6" secondAttribute="trailing" id="xx6-8m-EYY"/>
+                <constraint firstItem="dS2-hZ-VlU" firstAttribute="leading" secondItem="fHS-tC-35v" secondAttribute="leading" priority="748" id="yYY-nn-yCs"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <connections>
+                <outlet property="dismountBarView" destination="fHS-tC-35v" id="cRG-wW-bp5"/>
+                <outlet property="dismountLegendDot" destination="ONZ-M1-JNZ" id="bbP-Vt-iXD"/>
+                <outlet property="dismountLegendLabel" destination="ErG-er-iIm" id="OXD-25-DyT"/>
+                <outlet property="dismountMetreLabel" destination="dS2-hZ-VlU" id="qTc-LY-Vei"/>
+                <outlet property="dismountToUnknownSpacingConstraint" destination="jHu-2N-DI3" id="JuL-Pl-hOc"/>
                 <outlet property="friendlyBarView" destination="pE2-0a-GuL" id="dyy-OG-0wZ"/>
                 <outlet property="friendlyLegendDot" destination="TV2-Od-H8b" id="OpN-YQ-6gf"/>
                 <outlet property="friendlyLegendLabel" destination="iXP-5z-5RP" id="bs5-cL-G1n"/>
                 <outlet property="friendlyMetreLabel" destination="ovk-wO-7Wo" id="Py0-Eh-zkE"/>
-                <outlet property="friendlyToUnfriendlySpacing" destination="gW0-5W-1Ee" id="8dn-Ni-cn9"/>
+                <outlet property="friendlyToUnfriendlySpacingConstraint" destination="GJU-fH-6z2" id="t7K-yP-kCs"/>
                 <outlet property="unfriendlyBarView" destination="I7L-ZV-BRP" id="wyb-vK-wMN"/>
                 <outlet property="unfriendlyLegendDot" destination="8Ch-SE-UCV" id="hqR-Rj-CWd"/>
                 <outlet property="unfriendlyLegendLabel" destination="sOL-qe-m0p" id="lbJ-uL-9ec"/>
                 <outlet property="unfriendlyMetreLabel" destination="zTx-Fx-qGq" id="Cf3-SS-NYm"/>
-                <outlet property="unfriendlyToUnknownSpacing" destination="Ro2-9K-rOn" id="i5n-bc-RAC"/>
+                <outlet property="unfriendlyToDismountSpacingConstraint" destination="ck7-ML-Xf3" id="cf4-6d-ivp"/>
                 <outlet property="unknownBarView" destination="oU9-U2-5m6" id="gy6-zm-01y"/>
-                <outlet property="unknownLegendDot" destination="ONZ-M1-JNZ" id="wmh-di-uQm"/>
-                <outlet property="unknownLegendLabel" destination="ErG-er-iIm" id="52h-xe-RTt"/>
+                <outlet property="unknownLegendDot" destination="WFP-SO-5Kl" id="5Nn-JE-ENB"/>
+                <outlet property="unknownLegendLabel" destination="QNf-gF-kro" id="O2c-jA-9bH"/>
                 <outlet property="unknownMetreLabel" destination="LCm-DB-pzD" id="xPf-hs-icw"/>
             </connections>
             <point key="canvasLocation" x="-469.5" y="-370.5"/>


### PR DESCRIPTION
- Added `TKPathFriendliness` enum, which now includes "dismount"
- Updated `TKPathFriendlinessView` to also include "dismount" section where appropriate
- Adjusts path colouring and dash pattern according to friendliness

Related API PR: https://github.com/skedgo/tripgo-api/pull/90