### PR TITLE
Make sure mode picker is visible above error view

### DIFF
--- a/Sources/TripKitUI/cards/TKUIRoutingResultsCard+Errors.swift
+++ b/Sources/TripKitUI/cards/TKUIRoutingResultsCard+Errors.swift
@@ -49,7 +49,14 @@ extension TKUIRoutingResultsCard {
     
     let allowRequest = TKUIRoutingResultsCard.config.contactCustomerSupport != nil
 
-    let supportView = TKUIRoutingSupportView.show(with: error, for: request, in: parentView, aboveSubview: tableView, allowRequest: allowRequest)
+    let supportView = TKUIRoutingSupportView.show(
+      with: error,
+      for: request,
+      in: parentView,
+      aboveSubview: tableView,
+      topPadding: tableView.tableHeaderView?.frame.height ?? 0,
+      allowRequest: allowRequest
+    )
     
     if allowRequest {
       supportView.requestSupportButton.rx.tap
@@ -72,7 +79,14 @@ extension TKUIRoutingResultsCard {
     let allowRequest = TKUIRoutingResultsCard.config.contactCustomerSupport != nil
     let actionTitle = allowRequest ? Loc.ContactSupport : nil
 
-    let tripBoy = TKUITripBoyView.show(error: error, title: "Trips not available".localizedCapitalized, in: parentView, aboveSubview: tableView, actionTitle: actionTitle)
+    let tripBoy = TKUITripBoyView.show(
+      error: error,
+      title: "Trips not available".localizedCapitalized,
+      in: parentView,
+      aboveSubview: tableView,
+      topPadding: tableView.tableHeaderView?.frame.height ?? 0,
+      actionTitle: actionTitle
+    )
 
     if allowRequest {
       tripBoy.actionButton.rx.tap

--- a/Sources/TripKitUI/cards/TKUIRoutingResultsCard+Errors.swift
+++ b/Sources/TripKitUI/cards/TKUIRoutingResultsCard+Errors.swift
@@ -22,22 +22,20 @@ extension TKUIRoutingResultsCard {
       for request: TripRequest,
       cardView: TGCardView,
       tableView: UITableView
-    ) {
+    ) -> UIView {
 
     let parent = (cardView as? TGScrollCardView)?.scrollViewWrapper ?? cardView
 
     switch (error as NSError).code {
     case 1001...1003:
-      showRoutingSupportView(with: error, for: request, parentView: parent, tableView: tableView)
+      return showRoutingSupportView(with: error, for: request, parentView: parent, tableView: tableView)
     default:
-      showErrorView(with: error, for: request, parentView: parent, tableView: tableView)
+      return showErrorView(with: error, for: request, parentView: parent, tableView: tableView)
     }
   }
   
-  func clearError(in cardView: TGCardView) {
-    let parent = (cardView as? TGScrollCardView)?.scrollViewWrapper ?? cardView
-    TKUIRoutingSupportView.clear(from: parent)
-    TKUITripBoyView.clear(from: parent)
+  func clear(_ errorView: UIView) {
+    errorView.removeFromSuperview()
   }
   
   private func showRoutingSupportView(
@@ -45,7 +43,7 @@ extension TKUIRoutingResultsCard {
       for request: TripRequest,
       parentView: UIView,
       tableView: UITableView
-  ) {
+  ) -> TKUIRoutingSupportView {
     
     let allowRequest = TKUIRoutingResultsCard.config.contactCustomerSupport != nil
 
@@ -68,6 +66,8 @@ extension TKUIRoutingResultsCard {
     
     // Can plan trip right from results card, no need to have a button
     supportView.planNewTripButton.isHidden = true
+    
+    return supportView
   }
   
   private func showErrorView(
@@ -75,7 +75,7 @@ extension TKUIRoutingResultsCard {
     for request: TripRequest,
     parentView: UIView,
     tableView: UITableView
-  ) {
+  ) -> TKUITripBoyView {
     let allowRequest = TKUIRoutingResultsCard.config.contactCustomerSupport != nil
     let actionTitle = allowRequest ? Loc.ContactSupport : nil
 
@@ -95,6 +95,8 @@ extension TKUIRoutingResultsCard {
         })
         .disposed(by: disposeBag)
     }
+    
+    return tripBoy
   }
   
 }

--- a/Sources/TripKitUI/cards/TKUIRoutingResultsCard.swift
+++ b/Sources/TripKitUI/cards/TKUIRoutingResultsCard.swift
@@ -257,7 +257,14 @@ public class TKUIRoutingResultsCard: TKUITableCard {
       .disposed(by: disposeBag)
     
     viewModel.availableModes
-      .drive(onNext: { [weak self] in self?.updateModePicker($0, in: tableView) })
+      .drive(onNext: { [weak self] in
+        self?.updateModePicker($0, in: tableView)
+        // When available modes change, e.g., from toggling the Transport button on and off,
+        // an error view may be sitting above the table view, covering the mode picker. This
+        // repositions it so the mode picker is always visible. See this ticket for details
+        // https://redmine.buzzhives.com/issues/15305
+        self?.repositionErrorView(sittingAbove: tableView, in: cardView)
+      })
       .disposed(by: disposeBag)
     
     // Monitor progress (note: without this, we won't fetch!)
@@ -630,6 +637,11 @@ private extension TKUIRoutingResultsCard {
       .disposed(by: disposeBag)
     
     return modePicker
+  }
+  
+  func repositionErrorView(sittingAbove tableView: UITableView, in cardView: TGCardView) {
+    let parent = (cardView as? TGScrollCardView)?.scrollViewWrapper ?? cardView
+    TKUITripBoyView.addTopPadding(tableView.tableHeaderView?.frame.height ?? 0, from: parent)
   }
   
 }

--- a/Sources/TripKitUI/views/TKUITripBoyView.swift
+++ b/Sources/TripKitUI/views/TKUITripBoyView.swift
@@ -53,9 +53,16 @@ public class TKUITripBoyView: UIView {
       .filter { $0 is TKUITripBoyView }
       .forEach { $0.removeFromSuperview() }
   }
+  
+  public static func addTopPadding(_ padding: CGFloat, from parent: UIView) {
+    guard let tripBoyView = parent.subviews.first(where: { $0 is TKUITripBoyView }) as? TKUITripBoyView else {
+      return
+    }
+    tripBoyView.frame.origin.y = padding
+  }
 
   @discardableResult
-  public static func show(error: Error, title: String? = nil, in view: UIView, aboveSubview: UIView? = nil, actionTitle: String? = nil) -> TKUITripBoyView {
+  public static func show(error: Error, title: String? = nil, in view: UIView, aboveSubview: UIView? = nil, topPadding: CGFloat = 0, actionTitle: String? = nil) -> TKUITripBoyView {
     self.clear(from: view)
 
     let tripBoy = TKUITripBoyView.newInstance()
@@ -69,7 +76,7 @@ public class TKUITripBoyView: UIView {
       view.addSubview(tripBoy)
     }
     
-    tripBoy.topAnchor.constraint(equalTo: view.topAnchor, constant: 0).isActive = true
+    tripBoy.topAnchor.constraint(equalTo: view.topAnchor, constant: topPadding).isActive = true
     tripBoy.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
     view.trailingAnchor.constraint(equalTo: tripBoy.trailingAnchor).isActive = true
     view.bottomAnchor.constraint(equalTo: tripBoy.bottomAnchor).isActive = true


### PR DESCRIPTION
This addresses the issue that when an error view is presented in the `TKUIRoutingResultsCard`, tapping on the Transport button appears to do nothing, i.e., the mode picker does not appear. 