### PR TITLE
Don't use interregional when from and to are in the same region

### DIFF
--- a/Sources/TripKit/model/CoreData/TripRequest+CoreDataClass.swift
+++ b/Sources/TripKit/model/CoreData/TripRequest+CoreDataClass.swift
@@ -195,7 +195,13 @@ extension TripRequest {
   
   
   public var applicableModeIdentifiers: [String] {
-    let touched = Set(TKRegionManager.shared.localRegions(start: fromLocation.coordinate, end: toLocation.coordinate))
+    let touched: Set<TKRegion> = {
+      var regions = Set(TKRegionManager.shared.localRegions(start: fromLocation.coordinate, end: toLocation.coordinate))
+      if regions.count > 1 {
+        regions.insert(.international)
+      }
+      return regions
+    }()
     
     if touched.count == 1, let first = touched.first {
       return first.modeIdentifiers

--- a/Sources/TripKit/model/CoreData/TripRequest+CoreDataClass.swift
+++ b/Sources/TripKit/model/CoreData/TripRequest+CoreDataClass.swift
@@ -195,14 +195,7 @@ extension TripRequest {
   
   
   public var applicableModeIdentifiers: [String] {
-    let touched: Set<TKRegion> = {
-      var regions = TKRegionManager.shared.localRegions(containing: fromLocation.coordinate)
-      regions.formUnion(TKRegionManager.shared.localRegions(containing: toLocation.coordinate))
-      if regions.count > 1 {
-        regions.insert(.international)
-      }
-      return regions
-    }()
+    let touched = Set(TKRegionManager.shared.localRegions(start: fromLocation.coordinate, end: toLocation.coordinate))
     
     if touched.count == 1, let first = touched.first {
       return first.modeIdentifiers


### PR DESCRIPTION
As discussed, when both from and to are in the same region, don't use interregional when one of them falls in the overlap of two regions.