### PR TITLE
Date should be treated as either ISO or 1970

### DIFF
--- a/Sources/TripKit/model/API/ShareCarAPIModel.swift
+++ b/Sources/TripKit/model/API/ShareCarAPIModel.swift
@@ -21,11 +21,11 @@ extension TKAPI {
     
     public struct Interval: Codable, Hashable {
       public let status: Status
-      public let start: Date?
-      public let end: Date?
+      @OptionalISO8601OrSecondsSince1970 public var start: Date?
+      @OptionalISO8601OrSecondsSince1970 public var end: Date?
     }
     
-    public let lastUpdated: Date
+    @ISO8601OrSecondsSince1970 public var lastUpdated: Date
     public let intervals: [Interval]
   }
   


### PR DESCRIPTION
This issue was identified when testing the new GoGet realtime API. The dates in `BookingAvailability` weren't marked with the new property wrapper, which caused the decoding to fail.