### PR TITLE
Persist change in transport mode selection in routing results card

### DIFF
--- a/Sources/TripKitUI/view model/TKUIRoutingResultsViewModel+ToggleModes.swift
+++ b/Sources/TripKitUI/view model/TKUIRoutingResultsViewModel+ToggleModes.swift
@@ -73,7 +73,9 @@ extension TKUIRoutingResultsViewModel {
     case (false, true): newWheelchairOn = false
     }
     guard newWheelchairOn != oldWheelchairOn else {
-      return nil // no need to update toggler
+      // no changes in wheelchair preference, so just return the
+      // existing `enabled`.
+      return AvailableModes(available: all, enabled: Set(enabled))
     }
     
     TKUserProfileHelper.showWheelchairInformation = newWheelchairOn


### PR DESCRIPTION
Addressing this ticket: https://redmine.buzzhives.com/issues/15535.

**Steps to reproduce.**

1. Plan a trip, open the transport selector by tapping "Transport"
2. Try to disable a mode that is currently enabled.
3. Close the transport mode selector, and open it again.

**Expected behaviour**
The mode remains disabled

**Actual behaviour**
The mode is still enabled
