### PR TITLE
working with changes in purchase json

### DIFF
--- a/Sources/TripKit/model/TKBookingTypes.swift
+++ b/Sources/TripKit/model/TKBookingTypes.swift
@@ -81,17 +81,18 @@ public enum TKBooking {
   
   
   public struct Purchase: Codable, Hashable {
-    public let id:                  String
-    private let rawPrice:           Double?
-    public let currency:            String?
-    public let budgetPoints:        Int?
-    public let productName:         String?
-    public let productType:         String?
-    private let explicitValidity:   Bool?
-    public let validFor:            TimeInterval?
-    public let validFrom:           Date?
-    public let branding:            TSPBranding?
-    public let attribution:         TKAPI.DataAttribution?
+    public let id: String
+    private let rawPrice: Double?
+    public let currency: String?
+    public let budgetPoints: Int?
+    public let productName: String?
+    public let productType: String?
+    private let explicitValidity:  Bool?
+    public let validFor: TimeInterval?
+    public let branding: TSPBranding?
+    public let attribution: TKAPI.DataAttribution?
+    @OptionalISO8601OrSecondsSince1970 public var validFrom: Date?
+    @OptionalISO8601OrSecondsSince1970 public var paymentDate: Date?
     
     private enum CodingKeys: String, CodingKey {
       case id
@@ -102,9 +103,10 @@ public enum TKBooking {
       case productType
       case explicitValidity = "valid"
       case validFor
-      case validFrom
+      case validFrom = "validFromTimestamp"
       case branding = "brand"
       case attribution = "source"
+      case paymentDate = "paymentTimestamp"
     }
     
     public var price: NSDecimalNumber? {

--- a/Sources/TripKit/model/TKBookingTypes.swift
+++ b/Sources/TripKit/model/TKBookingTypes.swift
@@ -87,7 +87,7 @@ public enum TKBooking {
     public let budgetPoints: Int?
     public let productName: String?
     public let productType: String?
-    private let explicitValidity:  Bool?
+    private let explicitValidity: Bool?
     public let validFor: TimeInterval?
     public let branding: TSPBranding?
     public let attribution: TKAPI.DataAttribution?


### PR DESCRIPTION
We have made a few changes to the `Confirmation.Purchase` JSON:

1. `validFromTimestamp` (ISO 8601) replacing `validFrom` and `timezone`
2. `paymentTimestamp` in the future, will not appear for now