### PR TITLE
Fixed ghosting in autocomplete cell

### DIFF
--- a/Sources/TripKitUI/views/TKUIAutocompletionResultCell.swift
+++ b/Sources/TripKitUI/views/TKUIAutocompletionResultCell.swift
@@ -22,8 +22,9 @@ class TKUIAutocompletionResultCell: UITableViewCell {
   override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
     super.init(style: .subtitle, reuseIdentifier: reuseIdentifier)
 
-    // Shouldn't have its own background color
-    backgroundColor = .clear
+    // We set a background colour here to avoid ghosting.
+    // reported here: https://redmine.buzzhives.com/issues/15589
+    backgroundColor = .tkBackground
   }
   
   required init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
This is first reported in this ticket: https://redmine.buzzhives.com/issues/15589

Symptom: As the table view animates the autocompletion results, some cells appear to go on top of the other.