### PR TITLE
Real-time related fixes

### DIFF
--- a/Sources/TripKit/model/CoreData/Trip+CoreDataClass.swift
+++ b/Sources/TripKit/model/CoreData/Trip+CoreDataClass.swift
@@ -464,11 +464,13 @@ extension Trip {
 /// :nodoc:
 extension Trip: TKRealTimeUpdatable {
   public var wantsRealTimeUpdates: Bool {
+    // We need a URL to update the trip
+    guard updateURLString != nil else { return false }
+
     if segments.contains(where: { $0.bookingConfirmation != nil }) {
       return true // booking confirmations can update at any time
     }
     
-    guard updateURLString != nil else { return false }
     return wantsRealTimeUpdates(forStart: departureTime, end: arrivalTime, forPreplanning: true)
   }
 }

--- a/Sources/TripKit/server/TKTripFetcher.swift
+++ b/Sources/TripKit/server/TKTripFetcher.swift
@@ -64,7 +64,7 @@ public enum TKTripFetcher {
     let url = url ?? trip.updateURLString.flatMap( { URL(string: $0) })
     guard let updateURL = url else {
       completion(.failure(FetcherError.invalidURL))
-      return assertionFailure()
+      return
     }
     
     self.downloadTripData(from: updateURL, includeStops: false) { result in

--- a/Sources/TripKitUI/view model/TKUITripOverviewViewModel+Content.swift
+++ b/Sources/TripKitUI/view model/TKUITripOverviewViewModel+Content.swift
@@ -45,7 +45,9 @@ extension TKUITripOverviewViewModel {
   
   struct TerminalItem: Equatable {
     static func == (lhs: TKUITripOverviewViewModel.TerminalItem, rhs: TKUITripOverviewViewModel.TerminalItem) -> Bool {
-      return lhs.segment == rhs.segment
+      // Check the segment, plus anything that can change with real-time data
+      return lhs.segment.templateHashCode == rhs.segment.templateHashCode
+          && lhs.time == rhs.time
     }
     
     let title: String
@@ -64,7 +66,13 @@ extension TKUITripOverviewViewModel {
   
   struct StationaryItem: Equatable {
     static func == (lhs: TKUITripOverviewViewModel.StationaryItem, rhs: TKUITripOverviewViewModel.StationaryItem) -> Bool {
-      return lhs.segment == rhs.segment
+      // Check the segment, plus anything that can change with real-time data
+      // Note: Platforms go into subtitles and can change in real-time, too
+      return lhs.segment.templateHashCode == rhs.segment.templateHashCode
+          && lhs.startTime == rhs.startTime
+          && lhs.endTime == rhs.endTime
+          && lhs.subtitle == rhs.subtitle
+          && lhs.endSubtitle == rhs.endSubtitle
     }
     
     let title: String
@@ -87,7 +95,7 @@ extension TKUITripOverviewViewModel {
   struct MovingItem: Equatable {
     static func == (lhs: TKUITripOverviewViewModel.MovingItem, rhs: TKUITripOverviewViewModel.MovingItem) -> Bool {
       // Check the segment, plus anything that can change with real-time data
-      return lhs.segment == rhs.segment
+      return lhs.segment.templateHashCode == rhs.segment.templateHashCode
           && lhs.accessories == rhs.accessories
     }
     


### PR DESCRIPTION
- Fix equality check of trip overview items to include things that
  can change with real-time data (times and platforms)
- Use template hash-code for equality checks in case that a TKSegment
  gets re-created but for the same hash-code
- Don't call real-time update if there's no update URL

Also:
- Allow running tests pointing at local files for any HTTP call