### PR TITLE
Polygon union fixes

### DIFF
--- a/Sources/TripKit/helpers/TKRegionOverlayHelper.swift
+++ b/Sources/TripKit/helpers/TKRegionOverlayHelper.swift
@@ -194,6 +194,39 @@ extension TKRegionOverlayHelper {
       else { return }
     
     do {
+      #if DEBUG
+      // Output GeoJSON, too.
+      let secondary = FileManager.default
+        .urls(for: .cachesDirectory, in: .userDomainMask)
+        .first!.appendingPathComponent("regionOverlay.geojson")
+      
+      let features = polygons.map { wrapper -> [String: Any] in
+        let polygon = wrapper.polygon
+        var coordinates = [CLLocationCoordinate2D](repeating: kCLLocationCoordinate2DInvalid, count: polygon.pointCount)
+        let range = NSRange(location: 0, length: polygon.pointCount)
+        polygon.getCoordinates(&coordinates, range: range)
+
+        return [
+          "type": "Feature",
+          "geometry": [
+            "type": "Polygon",
+            "coordinates": [
+              coordinates.map {
+                [$0.longitude, $0.latitude]
+              }
+            ]
+          ]
+        ]
+      }
+      let geojson: [String: Any] = [
+        "type": "FeatureCollection",
+        "features": features
+      ]
+      let geojsonData = try JSONSerialization.data(withJSONObject: geojson, options: [])
+      try geojsonData.write(to: secondary)
+      print("Saved GeoJSON to \(secondary)")
+      #endif
+
       let archiver = NSKeyedArchiver(requiringSecureCoding: false)
       archiver.encode(polygons, forKey: "polygons")
       archiver.encode(regionsHash, forKey: "regionsHash")

--- a/Sources/TripKit/managers/TKRegionManager.swift
+++ b/Sources/TripKit/managers/TKRegionManager.swift
@@ -55,7 +55,7 @@ public class TKRegionManager: NSObject {
   
   @objc public var regionsHash: NSNumber? {
     if let hashCode = response?.hashCode {
-      return NSNumber(value: hashCode)
+      return NSNumber(value: hashCode + 2) // Force update after broken polygons
     } else {
       return nil;
     }

--- a/Sources/TripKit/vendor/ASPolygonKit/CLLocationCoordinate2D+EncodePolylineString.swift
+++ b/Sources/TripKit/vendor/ASPolygonKit/CLLocationCoordinate2D+EncodePolylineString.swift
@@ -1,0 +1,101 @@
+//
+//  CLLocationCoordinate2D+EncodePolylineString.swift
+//  TripKit
+//
+//  Created by Adrian Schönig on 5/11/21.
+//  Copyright © 2021 SkedGo Pty Ltd. All rights reserved.
+//
+
+import Foundation
+
+extension Polygon {
+  /// This function encodes an `Polygon` to a `String`
+  ///
+  /// - parameter precision: The precision used to encode coordinates (default: `1e5`)
+  ///
+  /// - returns: A `String` representing the encoded Polyline
+  func encodeCoordinates(precision: Double = 1e5) -> String {
+    let coordinates = points.map(\.coordinate)
+    return coordinates.encodeCoordinates(precision: precision)
+  }
+}
+
+extension Array where Element == CLLocationCoordinate2D {
+  /// This function encodes an `[CLLocationCoordinate2D]` to a `String`
+  ///
+  /// - parameter precision: The precision used to encode coordinates (default: `1e5`)
+  ///
+  /// - returns: A `String` representing the encoded Polyline
+  func encodeCoordinates(precision: Double = 1e5) -> String {
+    
+    var previousCoordinate = IntegerCoordinates(0, 0)
+    var encodedPolyline = ""
+    
+    for coordinate in self {
+      let intLatitude  = Int(round(coordinate.latitude * precision))
+      let intLongitude = Int(round(coordinate.longitude * precision))
+      
+      let coordinatesDifference = (intLatitude - previousCoordinate.latitude, intLongitude - previousCoordinate.longitude)
+      
+      encodedPolyline += Self.encodeCoordinate(coordinatesDifference)
+      
+      previousCoordinate = (intLatitude,intLongitude)
+    }
+    
+    return encodedPolyline
+  }
+
+  // MARK: - Private -
+  // MARK: Encode Coordinate
+  private static func encodeCoordinate(_ locationCoordinate: IntegerCoordinates) -> String {
+    
+    let latitudeString  = encodeSingleComponent(locationCoordinate.latitude)
+    let longitudeString = encodeSingleComponent(locationCoordinate.longitude)
+    
+    return latitudeString + longitudeString
+  }
+
+  private static func encodeSingleComponent(_ value: Int) -> String {
+    
+    var intValue = value
+    
+    if intValue < 0 {
+      intValue = intValue << 1
+      intValue = ~intValue
+    } else {
+      intValue = intValue << 1
+    }
+    
+    return encodeFiveBitComponents(intValue)
+  }
+
+  // MARK: Encode Levels
+  private static func encodeLevel(_ level: UInt32) -> String {
+    return encodeFiveBitComponents(Int(level))
+  }
+
+  private static func encodeFiveBitComponents(_ value: Int) -> String {
+    var remainingComponents = value
+    
+    var fiveBitComponent = 0
+    var returnString = String()
+    
+    repeat {
+      fiveBitComponent = remainingComponents & 0x1F
+      
+      if remainingComponents >= 0x20 {
+        fiveBitComponent |= 0x20
+      }
+      
+      fiveBitComponent += 63
+      
+      let char = UnicodeScalar(fiveBitComponent)!
+      returnString.append(String(char))
+      remainingComponents = remainingComponents >> 5
+    } while (remainingComponents != 0)
+    
+    return returnString
+  }
+
+  private typealias IntegerCoordinates = (latitude: Int, longitude: Int)
+}

--- a/Sources/TripKit/vendor/ASPolygonKit/Geometry.swift
+++ b/Sources/TripKit/vendor/ASPolygonKit/Geometry.swift
@@ -21,7 +21,7 @@ struct Point {
   var lng: Double { return ll.1 }
   
   var description: String {
-    return String(format: "(%.4f,%.4f)", lat, lng)
+    String(format: "(%.6f,%.6f)", lat, lng)
   }
   
   // MARK: Point as a x/y pair
@@ -55,7 +55,7 @@ struct Point {
 
 extension Point: Equatable {}
 func ==(lhs: Point, rhs: Point) -> Bool {
-  let epsilon = 0.0001
+  let epsilon = 0.000001
   return abs(lhs.lat - rhs.lat) < epsilon && abs(lhs.lng - rhs.lng) < epsilon
 }
 
@@ -116,7 +116,7 @@ struct Line {
       return inRange( (point.x, point.y) )
     }
     
-    let epsilon = 0.0001
+    let epsilon = 0.000001
     let y = m * point.x + b
     if abs(y - point.y) < epsilon {
       return inRange( (point.x, point.y) )
@@ -178,7 +178,7 @@ func ==(lhs: Line, rhs: Line) -> Bool {
 
 extension Double {
   func inBetween(_ some: Double, and another: Double) -> Bool {
-    let eps = 0.00001
+    let eps = 0.000001
     return self >= min(some, another) - eps && self <= max(some, another) + eps
   }
 }

--- a/Sources/TripKit/vendor/ASPolygonKit/MKPolygon+Union.swift
+++ b/Sources/TripKit/vendor/ASPolygonKit/MKPolygon+Union.swift
@@ -7,6 +7,50 @@
 
 import MapKit
 
+extension Polygon {
+  static func union(_ polygons: [Polygon]) throws -> [Polygon] {
+    let sorted = polygons.sorted { first, second in
+      if first.minY < second.minY {
+        return true
+      } else if second.minY < first.minY {
+        return false
+      } else {
+        return first.minX < second.minX
+      }
+    }
+    
+    return try sorted.reduce([]) { polygons, polygon in
+      try union(polygons, with: polygon)
+    }
+  }
+  
+  static func union(_ polygons: [Polygon], with polygon: Polygon) throws -> [Polygon] {
+    var grower = polygon.clockwise()
+    var newArray: [Polygon] = []
+    
+    for existing in polygons {
+      if existing.contains(grower) {
+        grower = existing
+        continue
+      }
+      let clockwise = existing.clockwise()
+      let intersections = grower.intersections(clockwise)
+      if intersections.count > 0 {
+        let merged = try grower.union(clockwise, with: intersections)
+        if !merged {
+          newArray.append(clockwise)
+        }
+      } else {
+        newArray.append(clockwise)
+      }
+    }
+    
+    newArray.append(grower)
+    return newArray
+  }
+  
+}
+
 extension MKPolygon {
   
   class func union(_ polygons: [MKPolygon], completion: @escaping (Result<[MKPolygon], Error>) -> Void) {
@@ -19,58 +63,10 @@ extension MKPolygon {
     }
   }
   
-  class func union(_ polygons: [MKPolygon]) throws -> [MKPolygon] {
-    let sorted = polygons.sorted(by: { first, second in
-      return first.boundingMapRect.distanceFromOrigin < second.boundingMapRect.distanceFromOrigin
-    })
-    
-    return try sorted.reduce([]) { polygons, polygon in
-      return try union(polygons, with: polygon)
-    }
-  }
-  
-  class func union(_ polygons: [MKPolygon], with polygon: MKPolygon) throws -> [MKPolygon] {
-    var grower = Polygon(polygon)
-    var newArray: [MKPolygon] = []
-    
-    for existing in polygons {
-      let existingStruct = Polygon(existing)
-      if existingStruct.contains(grower) {
-        grower = existingStruct
-        continue
-      }
-      let intersections = grower.intersections(existingStruct)
-      if intersections.count > 0 {
-        let merged = try grower.union(existingStruct, with: intersections)
-        if !merged {
-          newArray.append(existing)
-        }
-      } else {
-        newArray.append(existing)
-      }
-    }
-    
-    newArray.append(grower.polygon)
-    return newArray
-  }
-  
-  func contains(_ coordinate: CLLocationCoordinate2D) -> Bool {
-    if (!boundingMapRect.contains(MKMapPoint(coordinate))) {
-      return false
-    }
-    
-    // It's in the bounding rect, but is it in the detailed shape?
-    let polygon = Polygon(self)
-    let point = Point(ll: (coordinate.latitude, coordinate.longitude))
-    return polygon.contains(point, onLine: true)
-  }
-}
-
-extension MKMapRect {
-  
-  var distanceFromOrigin: Double {
-    return sqrt( origin.x * origin.x + origin.y * origin.y )
+  class func union(_ mkPolygons: [MKPolygon]) throws -> [MKPolygon] {
+    let polygons = mkPolygons.map(Polygon.init)
+    let union = try Polygon.union(polygons)
+    return union.map(\.polygon)
   }
   
 }
-

--- a/Tests/TripKitTests/polygon/ASPolygonKitTests.swift
+++ b/Tests/TripKitTests/polygon/ASPolygonKitTests.swift
@@ -25,6 +25,10 @@ class ASPolygonKitTests: XCTestCase {
     
     let merged = try MKPolygon.union(polygons)
     XCTAssertEqual(1, merged.count)
+    
+    XCTAssertEqual(merged.first.map(Polygon.init)?.encodeCoordinates(), """
+      iobcHyvps@j~cAoquEhgj@jWA{AxzAnCzgD~A@hDlpb@`w@_JehAjVoheDb{xCucAjqlBtpmHo`^`zyBtrAlvzA~|IfwsArvX?{iv@htlIuj`ChvB?~P{MqPcaRpP?saVk`aDyn~DeiXoy{D`gC?
+      """)
   }
   
   func testUK() throws {
@@ -33,6 +37,10 @@ class ASPolygonKitTests: XCTestCase {
     
     let merged = try MKPolygon.union(polygons)
     XCTAssertEqual(1, merged.count)
+    
+    XCTAssertEqual(merged.first.map(Polygon.init)?.encodeCoordinates(), """
+      _aisJ~nyo@?_oyo@~nh\\??`f{@nyo@lblH~tAboL~|bKs_kN?nh\\npxD??ovmHnxtI??~s`BnnqC??~m|Qn}}B??~hsXoezG??_ry@_ulL??_ulLo{vA??~dtBoljB??~{|FkkmCrkt@zoJz|x@i_@vaAxzbCgjiAnfrB??~qy@ntfG??ppHnaoA|z`BnpxDnl{U?~hbE_c{X??cro[_msCznqH?fdS
+      """)
   }
 
   func testScandinavia() throws {
@@ -41,14 +49,22 @@ class ASPolygonKitTests: XCTestCase {
     
     let merged = try MKPolygon.union(polygons)
     XCTAssertEqual(1, merged.count)
+    
+    XCTAssertEqual(merged.first.map(Polygon.init)?.encodeCoordinates(), """
+      {musLul~eCzizB}w|z@lxrGr|uD|diB~_uJd~zF{{_F|lq[cngJn`wFncpJyPvl@xdiGvtyK~yxA~olG||]l`nW`I`DiA~}DhA~y@aBi@w~E`k|P`{x@ubiA`z_G??j`mArwrFz|H?vqvE`bgClhtGnkuCnsqHnyo@~tiP_t`Boh\\odkA~wq@_{m@~tu@qrqB|juA?|ypAwapFzcn@hFf~|@_osCkF_}BcoDj|Ll_dEbiSnkkBfv{Ct~MlbLlxx\\{ftK_mEwdvD|x{@?tEcG_Cq_Cti@?}hBcv{Fsj{BempDyloH|VmfDanw^_jug@bRcxB
+      """)
   }
   
   func testStaya() throws {
     let polygons = try polygonsFromJSON(named: "polygons-au-211102")
-    XCTAssertEqual(13, polygons.count)
+    XCTAssertEqual(7, polygons.count)
     
     let merged = try MKPolygon.union(polygons)
-    XCTAssertEqual(7, merged.count)
+    XCTAssertEqual(1, merged.count)
+    
+    XCTAssertEqual(merged.first.map(Polygon.init)?.encodeCoordinates(), """
+      ~ghgCai|h[ykhBmhuOprjAecdOfjpc@nbq@w@yBxd@w|C|fkB}hRxwzLzbyAx`bF~j{AjBjcMnrzQ??vtyK`udMhq`Bw{DbbNh`_IjqqGyKns|Mwr~BfgaFbcMpsY}~t@`ym@~{xBfl~A`J~`gRovq]?`qd@eeqBctKww\\eMkb_AlpPq~j@rn^o_d@z_k@q|H~ab@_bOaoh@iyYbMirVpeTapJlrGwvn@vcVqpo@|vc@hhCj~d@apJd~@}re@daYewB`zi@mhtAzil@wr{@xkZghNttc@yn}@w_m@mu[{oJ}oU?inX{@?ym@wkcAzzXuyiArbMykx@sbM_`~@~aW}xeA}yJcyd@c}Ij}Hw|zHswg@do@mcxLuu~K?j}@reeGeunRg`]kButH
+      """)
   }
   
   func testInvariantToShuffling() throws {
@@ -59,9 +75,13 @@ class ASPolygonKitTests: XCTestCase {
       let shuffled = polygons.shuffle()
       let merged = try MKPolygon.union(shuffled)
       XCTAssertEqual(1, merged.count)
+      
+      XCTAssertEqual(merged.first.map(Polygon.init)?.encodeCoordinates(), """
+        _aisJ~nyo@?_oyo@~nh\\??`f{@nyo@lblH~tAboL~|bKs_kN?nh\\npxD??ovmHnxtI??~s`BnnqC??~m|Qn}}B??~hsXoezG??_ry@_ulL??_ulLo{vA??~dtBoljB??~{|FkkmCrkt@zoJz|x@i_@vaAxzbCgjiAnfrB??~qy@ntfG??ppHnaoA|z`BnpxDnl{U?~hbE_c{X??cro[_msCznqH?fdS
+        """)
     }
   }
-  
+
   func testOCFailure() throws {
     var grower = Polygon(pairs: [ (4,0), (4,3), (1,3), (1,0) ])
     let addition = Polygon(pairs: [ (5,1), (5,4), (3,4), (3,2), (2,2), (2,4), (0,4), (0,1) ])
@@ -151,8 +171,6 @@ extension MutableCollection where Index == Int {
     }
   }
 }
-
-
 
 extension MKPolygon {
   

--- a/Tests/TripKitTests/polygon/data/polygons-au-211102.json
+++ b/Tests/TripKitTests/polygon/data/polygons-au-211102.json
@@ -1,14 +1,8 @@
 {
     "polygons": [
-      "~{vvEwa}kYooxC??_pvBnoxC?",
-      "~nnqC_wlnX_etB??oljB~dtB?",
-      "~cviGolgqZourQ??o_vWnurQ?",
-      "~gmcC_mmvZ_sv^??_x_X~rv^?",
       "~pf{Eajgb[|Ef`]o{^z~[w|zHswg@tw@ygfOvuoDdPai@aocCnilMzebB_vvCfkcKyra@smTsrGblL}kGztAy~IpnBqtMngJu}K`{@oya@dwBsuWrmTu_Ll_d@||Jh`]u{Gh}LlrSt{Z",
-      "~ovmA_ho{W_g{C??_xnD~f{C?",
       "hfcnEgrj{Y`qd@eeqBctKww\\eMkb_AlpPq~j@rn^o_d@z_k@q|H~ab@_bOaoh@iyYbMirVpeTapJlrGwvn@vcVqpo@|vc@hhCj~d@apJd~@}re@daYewB`zi@mhtAzil@wr{@xkZghNttc@yn}@w_m@mu[{oJ}oU?sxXJzK`_cIwsAlrA`biAlie@ney@txn@}nDtip@{u`Ap`_@dbt@dgyB~t~A`J~`gR",
       "vk{gFqwfsZ{bp@pq`A{bo@tjDgpe@{iy@a`BwrrA`ds@ubiBfvfBr~iAxuJ}vQvsLogCdgD`eTrcFdwBkvAjqh@tea@fo_A{lu@ben@",
-      "~qtwE_sxvT_zwl@??_oyo@~ywl@?",
       "b{niFmgauZjvAcph@a}EugBw`DylTsgLteCiyJl_RctfBedjAs_s@nthBvJ~pHi`cIrfAym@wkcAzzXuyiArbMykx@sbM_`~@~aW}xeAaf[{byAk`Bi{fA~a\\}j_AxgvB_og@f}WzlPrzjCmkmJj_kI~y{GyKns|Mi}~B~yaF",
       "`e|pEggoq[?f``AaerM??mcjRnwyR??dbiP",
       "`x|pDamoh[aosh@_{KykhBmhuOprjAecdOdkpc@pbq@j[``A~TfNbUzTjIzEsCfCeF`PiBJcWr{@}`AzbDqT`w@zElTClEvEvj@bN|LldBfpAxS~T?tWfL|SfCvQpXfdAzb@v`@d_@nj@ju@rm@xSlq@|a@pd@fo@|i@xd@nU|Pa@hpQhea@lcEtov@pFx}q@mgGb}b@hfm@nvoAjwqAhdPxtp@pxqBo|NvhpQ",

--- a/TripKit.xcodeproj/project.pbxproj
+++ b/TripKit.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		3A5B655526CF52620072DE07 /* TGCardViewController in Frameworks */ = {isa = PBXBuildFile; productRef = 3A5B655426CF52620072DE07 /* TGCardViewController */; };
 		3AA1092126FABC6000C52879 /* TKReporter+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA1092026FABC6000C52879 /* TKReporter+Rx.swift */; };
 		3AB3A60826E84A7E006C2AD1 /* DatadogSDKTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 3AB3A60726E84A7E006C2AD1 /* DatadogSDKTesting */; };
+		3AB424DF2734F7D800AA0CF1 /* CLLocationCoordinate2D+EncodePolylineString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB424DE2734F7D800AA0CF1 /* CLLocationCoordinate2D+EncodePolylineString.swift */; };
+		3AB424E02734F7D800AA0CF1 /* CLLocationCoordinate2D+EncodePolylineString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB424DE2734F7D800AA0CF1 /* CLLocationCoordinate2D+EncodePolylineString.swift */; };
 		3AB6C62B1D1CD0060089F687 /* TripKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3AB6C6201D1CD0060089F687 /* TripKit.framework */; };
 		3ACD91D726CCC47B0075CCF3 /* TKUIShareHelperTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ACD91A126CCC47B0075CCF3 /* TKUIShareHelperTest.swift */; };
 		3ACD91D926CCC47B0075CCF3 /* TKUIRoutingQueryInputViewModelTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ACD91A326CCC47B0075CCF3 /* TKUIRoutingQueryInputViewModelTest.swift */; };
@@ -957,6 +959,7 @@
 		3AA1092026FABC6000C52879 /* TKReporter+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TKReporter+Rx.swift"; sourceTree = "<group>"; };
 		3AA3CC8B202CABE900E54859 /* TripKitInterApp.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; path = TripKitInterApp.podspec; sourceTree = "<group>"; };
 		3AACB4942643771300DE5665 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		3AB424DE2734F7D800AA0CF1 /* CLLocationCoordinate2D+EncodePolylineString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CLLocationCoordinate2D+EncodePolylineString.swift"; sourceTree = "<group>"; };
 		3AB4A2DD235DEE2500C0E195 /* TripKitUIExample.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TripKitUIExample.entitlements; sourceTree = "<group>"; };
 		3AB6C6201D1CD0060089F687 /* TripKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TripKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3AB6C62A1D1CD0060089F687 /* TripKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TripKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2257,6 +2260,7 @@
 			isa = PBXGroup;
 			children = (
 				3AFF26E226C6975F007809CD /* CLLocationCoordinate2D+DecodePolylineString.swift */,
+				3AB424DE2734F7D800AA0CF1 /* CLLocationCoordinate2D+EncodePolylineString.swift */,
 				3AFF26DF26C6975F007809CD /* Geometry.swift */,
 				3AFF26E126C6975F007809CD /* MKPolygon+Union.swift */,
 				3AFF26E326C6975F007809CD /* Polygon.swift */,
@@ -3536,6 +3540,7 @@
 				3AFF296F26C6981E007809CD /* TKRealTimeFetcher.swift in Sources */,
 				3AFF296A26C6981E007809CD /* TKError.swift in Sources */,
 				3AFF28DF26C697D9007809CD /* TKInfoIcon.swift in Sources */,
+				3AB424E02734F7D800AA0CF1 /* CLLocationCoordinate2D+EncodePolylineString.swift in Sources */,
 				3AFF28AC26C697D9007809CD /* Service+Visits.swift in Sources */,
 				3AFF28BA26C697D9007809CD /* TKSegment.swift in Sources */,
 				3AFF283C26C6977C007809CD /* TKShareHelper.swift in Sources */,
@@ -3847,6 +3852,7 @@
 				3AFF292126C697DA007809CD /* TripGroup+CoreDataProperties.swift in Sources */,
 				3AFF298926C6984F007809CD /* DefaultTrue.swift in Sources */,
 				3A1AABB826CB7BB100FDDB06 /* TKVehicular.swift in Sources */,
+				3AB424DF2734F7D800AA0CF1 /* CLLocationCoordinate2D+EncodePolylineString.swift in Sources */,
 				3AFF28E826C697DA007809CD /* Shape+Data.swift in Sources */,
 				3AFF295A26C6981D007809CD /* TKRoutingParser.swift in Sources */,
 				3AFF285F26C697A3007809CD /* TripRequest+Classify.swift in Sources */,


### PR DESCRIPTION
1. Allow intersections that are right on a polygon corner
2. Increase precision of point equality checks
3. Make sure polygons are clockwise before unifying

Also: Refactoring, debugging help, turning polygons into encoded polylines and more details for tests