### PR TITLE
Improve VoiceOver support for time picker and sheet

### DIFF
--- a/Sources/TripKitUI/views/results/TKUITimePickerSheet.swift
+++ b/Sources/TripKitUI/views/results/TKUITimePickerSheet.swift
@@ -211,6 +211,7 @@ public class TKUITimePickerSheet: TKUISheet {
       
       self.timeTypeSelector = selector
       self.doneSelector = doneSelector
+      self.accessibilityElements = [selector, timePicker, doneSelector]
     }
     
     self.frame = .init(x: 0, y: 0, width: timePicker.frame.width, height: systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).height)


### PR DESCRIPTION
1. Time picker order is now: now/leave at/leaver after, then the
   time picker, and then "Done", rather than "Done" being in the middle
2. Temporary make all elements behind the overlay non accessible while
   the sheet is being displayed.

Addresses RM16034