### PR TITLE
A number of VoiceOver tweaks

### DIFF
--- a/Sources/TripKit/core/Loc+TripKitUI.swift
+++ b/Sources/TripKit/core/Loc+TripKitUI.swift
@@ -69,6 +69,10 @@ extension Loc {
   @objc public static var Route: String {
     return NSLocalizedString("Route", tableName: "TripKit", bundle: .tripKit, comment: "Action button title to plan a route")
   }
+  
+  public static var ChangeRoute: String {
+    return NSLocalizedString("Change Route", tableName: "TripKit", bundle: .tripKit, comment: "Title of page to change the from/to of the routing results")
+  }
 
   @objc public static var Trips: String {
     return NSLocalizedString("Trips", tableName: "TripKit", bundle: .tripKit, comment: "Title of page that shows routing results")

--- a/Sources/TripKitUI/cards/TKUIRoutingResultsCard.swift
+++ b/Sources/TripKitUI/cards/TKUIRoutingResultsCard.swift
@@ -165,7 +165,7 @@ public class TKUIRoutingResultsCard: TKUITableCard {
     
     let searchTriggers = Observable.merge([
         showSearch,
-        titleView?.locationTapped.asObservable().map { _ in }
+        titleView?.locationTapped.asObservable()
       ].compactMap { $0 }
     )
     

--- a/Sources/TripKitUI/view model/TKUIRoutingQueryInputViewModel.swift
+++ b/Sources/TripKitUI/view model/TKUIRoutingQueryInputViewModel.swift
@@ -22,6 +22,7 @@ class TKUIRoutingQueryInputViewModel {
   struct UIInput {
     let searchText: Observable<(String, forced: Bool)>
     let tappedRoute: Signal<Void>
+    var tappedKeyboardDone: Signal<TKUIRoutingResultsViewModel.SearchMode> = .empty()
     var selected: Signal<Item> = .empty()
     var selectedSearchMode: Signal<TKUIRoutingResultsViewModel.SearchMode> = .empty()
     var tappedSwap: Signal<Void> = .empty()

--- a/Sources/TripKitUI/view model/TKUIRoutingQueryInputViewModel.swift
+++ b/Sources/TripKitUI/view model/TKUIRoutingQueryInputViewModel.swift
@@ -21,7 +21,7 @@ class TKUIRoutingQueryInputViewModel {
 
   struct UIInput {
     let searchText: Observable<(String, forced: Bool)>
-    let tappedDone: Signal<Void>
+    let tappedRoute: Signal<Void>
     var selected: Signal<Item> = .empty()
     var selectedSearchMode: Signal<TKUIRoutingResultsViewModel.SearchMode> = .empty()
     var tappedSwap: Signal<Void> = .empty()
@@ -63,14 +63,14 @@ class TKUIRoutingQueryInputViewModel {
       .map { $0.origin != nil && $0.destination != nil }
       .asDriver(onErrorJustReturn: false)
 
-    selections = inputs.tappedDone.asObservable()
+    selections = inputs.tappedRoute.asObservable()
       .withLatestFrom(state)
       .filter { $0.origin != nil && $0.destination != nil }
       .map { ($0.origin!, $0.destination!) }
       .asSignal(onErrorSignalWith: .empty())
 }
   
-  let activeMode: Driver<TKUIRoutingResultsViewModel.SearchMode>
+  let activeMode: Driver<TKUIRoutingResultsViewModel.SearchMode?>
   
   let originDestination: Driver<(origin: String, destination: String)>
   

--- a/Sources/TripKitUI/views/TKUITripSegmentsView.swift
+++ b/Sources/TripKitUI/views/TKUITripSegmentsView.swift
@@ -349,8 +349,10 @@ public class TKUITripSegmentsView : UIView {
     
     self.segmentXValues = newSegmentXValues
     
-    self.accessibilityElements = accessibileElements
-    self.isAccessibilityElement = false
+    if segmentIndexToSelect != nil {
+      self.accessibilityElements = accessibileElements
+      self.isAccessibilityElement = false
+    }
   }
   
 }

--- a/Sources/TripKitUI/views/results/TKUIResultsTitleView.xib
+++ b/Sources/TripKitUI/views/results/TKUIResultsTitleView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -82,6 +82,7 @@
                 <outlet property="accessoryViewContainer" destination="wVw-MU-IHq" id="IbM-WR-LGz"/>
                 <outlet property="destinationLabel" destination="Kdn-Jf-NxY" id="GJR-GX-frB"/>
                 <outlet property="dismissButton" destination="88I-7o-sPz" id="rff-vn-tPJ"/>
+                <outlet property="fromToStack" destination="NF7-bE-gIz" id="mJe-C2-Phn"/>
                 <outlet property="originLabel" destination="vmK-Ou-na6" id="t3Y-Gg-AY3"/>
                 <outlet property="topLevelStack" destination="zUI-JE-7Nv" id="7zd-zR-WFO"/>
                 <outlet property="topLevelStackBottomSpacing" destination="jM5-Kn-XF3" id="GRX-7r-2I4"/>

--- a/Sources/TripKitUI/views/results/TKUIRoutingQueryInputTitleView.xib
+++ b/Sources/TripKitUI/views/results/TKUIRoutingQueryInputTitleView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -16,23 +16,29 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dfT-wK-Gum">
-                    <rect key="frame" x="16" y="16" width="43" height="44"/>
+                    <rect key="frame" x="16" y="0.0" width="37" height="44"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="44" id="M0F-Rj-abK"/>
                     </constraints>
                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                     <state key="normal" title="Close"/>
                 </button>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="toE-WF-qqw">
+                    <rect key="frame" x="193" y="13.5" width="28.5" height="17"/>
+                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5jL-GH-X0k">
-                    <rect key="frame" x="353" y="16" width="45" height="44"/>
+                    <rect key="frame" x="360" y="0.0" width="38" height="44"/>
                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                     <state key="normal" title="Route"/>
                 </button>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Tmf-j3-lbN" userLabel="Top view">
-                    <rect key="frame" x="0.0" y="60" width="414" height="112"/>
+                    <rect key="frame" x="0.0" y="44" width="414" height="128"/>
                     <subviews>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6Y6-YD-smf">
-                            <rect key="frame" x="367" y="30" width="44" height="44"/>
+                        <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6Y6-YD-smf">
+                            <rect key="frame" x="367" y="35.5" width="44" height="44"/>
                             <accessibility key="accessibilityConfiguration" label="Swap from and to"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="44" id="Q38-Hl-UKZ"/>
@@ -47,24 +53,24 @@
                                 <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </state>
                         </button>
-                        <searchBar contentMode="redraw" placeholder="From" translatesAutoresizingMaskIntoConstraints="NO" id="wgQ-BO-Jvl">
-                            <rect key="frame" x="36" y="8" width="339" height="44"/>
+                        <searchBar contentMode="redraw" verticalCompressionResistancePriority="751" ambiguous="YES" placeholder="From" translatesAutoresizingMaskIntoConstraints="NO" id="wgQ-BO-Jvl">
+                            <rect key="frame" x="36" y="8" width="339" height="51"/>
                             <constraints>
                                 <constraint firstAttribute="height" priority="999" constant="44" id="LH6-0O-jvm"/>
                             </constraints>
                             <color key="tintColor" systemColor="tableCellGroupedBackgroundColor"/>
                             <textInputTraits key="textInputTraits" autocapitalizationType="words" autocorrectionType="no" returnKeyType="route" textContentType="street-address"/>
                         </searchBar>
-                        <searchBar contentMode="redraw" placeholder="To" translatesAutoresizingMaskIntoConstraints="NO" id="xeq-Fa-HHu">
-                            <rect key="frame" x="36" y="52" width="339" height="44"/>
+                        <searchBar contentMode="redraw" ambiguous="YES" placeholder="To" translatesAutoresizingMaskIntoConstraints="NO" id="xeq-Fa-HHu">
+                            <rect key="frame" x="36" y="59" width="339" height="45"/>
                             <constraints>
                                 <constraint firstAttribute="height" priority="999" constant="44" id="xdM-r2-qB1"/>
                             </constraints>
                             <color key="tintColor" systemColor="tableCellGroupedBackgroundColor"/>
                             <textInputTraits key="textInputTraits" autocapitalizationType="words" autocorrectionType="no" returnKeyType="route" textContentType="street-address"/>
                         </searchBar>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NhZ-YN-85N">
-                            <rect key="frame" x="6" y="8" width="44" height="44"/>
+                        <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NhZ-YN-85N">
+                            <rect key="frame" x="6" y="11.5" width="44" height="44"/>
                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <accessibility key="accessibilityConfiguration" label="From Location"/>
                             <constraints>
@@ -75,8 +81,8 @@
                             <state key="selected" image="trip-point-highlighted"/>
                             <state key="highlighted" image="trip-point-active"/>
                         </button>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8ip-Px-sit">
-                            <rect key="frame" x="6" y="52" width="44" height="44"/>
+                        <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8ip-Px-sit">
+                            <rect key="frame" x="6" y="59.5" width="44" height="44"/>
                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <accessibility key="accessibilityConfiguration" label="To Location"/>
                             <constraints>
@@ -87,8 +93,8 @@
                             <state key="selected" image="trip-point-highlighted"/>
                             <state key="highlighted" image="trip-point-active"/>
                         </button>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Qrd-x7-0WT">
-                            <rect key="frame" x="27" y="41" width="2" height="22"/>
+                        <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Qrd-x7-0WT">
+                            <rect key="frame" x="27" y="44.5" width="2" height="26"/>
                             <color key="backgroundColor" systemColor="systemGreenColor"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="2" id="6lV-Uw-BOu"/>
@@ -134,11 +140,13 @@
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="Tmf-j3-lbN" firstAttribute="leading" secondItem="f22-KJ-UKp" secondAttribute="leading" id="4gZ-HV-sp5"/>
-                <constraint firstItem="dfT-wK-Gum" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="16" id="B0y-9t-OCs"/>
+                <constraint firstItem="dfT-wK-Gum" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="B0y-9t-OCs"/>
                 <constraint firstItem="dfT-wK-Gum" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="16" id="Bwp-Nq-u03"/>
                 <constraint firstItem="5jL-GH-X0k" firstAttribute="centerY" secondItem="dfT-wK-Gum" secondAttribute="centerY" id="Nbg-4x-sST"/>
+                <constraint firstItem="toE-WF-qqw" firstAttribute="centerX" secondItem="f22-KJ-UKp" secondAttribute="centerX" id="PWo-NW-60u"/>
                 <constraint firstItem="f22-KJ-UKp" firstAttribute="bottom" secondItem="Tmf-j3-lbN" secondAttribute="bottom" id="QeV-YX-afp"/>
                 <constraint firstItem="Tmf-j3-lbN" firstAttribute="top" secondItem="5jL-GH-X0k" secondAttribute="bottom" id="afE-At-RKf"/>
+                <constraint firstItem="toE-WF-qqw" firstAttribute="centerY" secondItem="5jL-GH-X0k" secondAttribute="centerY" id="jTp-8g-EjV"/>
                 <constraint firstItem="5jL-GH-X0k" firstAttribute="height" secondItem="dfT-wK-Gum" secondAttribute="height" id="nED-ss-Cj6"/>
                 <constraint firstItem="f22-KJ-UKp" firstAttribute="trailing" secondItem="Tmf-j3-lbN" secondAttribute="trailing" id="obh-8n-ghd"/>
                 <constraint firstItem="f22-KJ-UKp" firstAttribute="trailing" secondItem="5jL-GH-X0k" secondAttribute="trailing" constant="16" id="qGa-CX-lck"/>
@@ -151,6 +159,7 @@
                 <outlet property="fromSearchBar" destination="wgQ-BO-Jvl" id="WFB-Hm-thF"/>
                 <outlet property="routeButton" destination="5jL-GH-X0k" id="vN1-uO-uJF"/>
                 <outlet property="swapButton" destination="6Y6-YD-smf" id="5w8-zX-4Dn"/>
+                <outlet property="titleLabel" destination="toE-WF-qqw" id="ESq-9R-Aat"/>
                 <outlet property="toButton" destination="8ip-Px-sit" id="PwF-CO-Ilp"/>
                 <outlet property="toSearchBar" destination="xeq-Fa-HHu" id="02d-FM-aQZ"/>
             </connections>

--- a/Sources/TripKitUI/views/results/TKUITimePickerSheet.swift
+++ b/Sources/TripKitUI/views/results/TKUITimePickerSheet.swift
@@ -211,7 +211,7 @@ public class TKUITimePickerSheet: TKUISheet {
       
       self.timeTypeSelector = selector
       self.doneSelector = doneSelector
-      self.accessibilityElements = [selector, timePicker, doneSelector]
+      self.accessibilityElements = [selector, timePicker, doneSelector].compactMap { $0 }
     }
     
     self.frame = .init(x: 0, y: 0, width: timePicker.frame.width, height: systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).height)

--- a/Tests/TripKitUITests/TKUIRoutingQueryInputViewModelTest.swift
+++ b/Tests/TripKitUITests/TKUIRoutingQueryInputViewModelTest.swift
@@ -132,12 +132,10 @@ class TKUIRoutingQueryInputViewModelTest: XCTestCase {
     let results = run([
         .type("B"),
         .select("Bahia Blanca", index: 0),
-        .type("N"),
-        .select("Nuremberg", index: 0),
         .route
       ]).last
     
-    XCTAssertEqual(results, "✅ Nuremberg -- Bahia Blanca")
+    XCTAssertEqual(results, "✅ Current Location -- Bahia Blanca")
   }
   
   func testSwapping() throws {

--- a/Tests/TripKitUITests/TKUIRoutingQueryInputViewModelTest.swift
+++ b/Tests/TripKitUITests/TKUIRoutingQueryInputViewModelTest.swift
@@ -210,7 +210,7 @@ extension TKUIRoutingQueryInputViewModelTest {
 
     let viewModel = TKUIRoutingQueryInputViewModel(inputs: TKUIRoutingQueryInputViewModel.UIInput(
       searchText: scheduler.createHotObservable(searches).asObservable(),
-      tappedDone: scheduler.createHotObservable(routes).asSignal(onErrorSignalWith: .empty()),
+      tappedRoute: scheduler.createHotObservable(routes).asSignal(onErrorSignalWith: .empty()),
       selected: scheduler.createHotObservable(selections).asSignal(onErrorSignalWith: .empty()),
       selectedSearchMode: scheduler.createHotObservable(modes).asSignal(onErrorSignalWith: .empty()),
       tappedSwap: scheduler.createHotObservable(swaps).asSignal(onErrorSignalWith: .empty())
@@ -257,7 +257,7 @@ fileprivate extension MKPointAnnotation {
 fileprivate extension TKUIRoutingQueryInputViewModel.UIInput {
   static let dummy = TKUIRoutingQueryInputViewModel.UIInput(
     searchText: .empty(),
-    tappedDone: .empty()
+    tappedRoute: .empty()
   )
 }
 

--- a/TripKit.xcodeproj/project.pbxproj
+++ b/TripKit.xcodeproj/project.pbxproj
@@ -2404,7 +2404,6 @@
 				3AFF275626C6975F007809CD /* alerts */,
 				3AFF278E26C6975F007809CD /* map annotations */,
 				3AFF276226C6975F007809CD /* results */,
-				3AFF275426C6975F007809CD /* routing input */,
 				3AFF274826C6975F007809CD /* segment cards */,
 				3AFF279D26C6975F007809CD /* timetable */,
 				3AFF277A26C6975F007809CD /* trip overview */,
@@ -2448,14 +2447,6 @@
 			path = "segment cards";
 			sourceTree = "<group>";
 		};
-		3AFF275426C6975F007809CD /* routing input */ = {
-			isa = PBXGroup;
-			children = (
-				3AFF275526C6975F007809CD /* TKUIRoutingQueryInputTitleView.swift */,
-			);
-			path = "routing input";
-			sourceTree = "<group>";
-		};
 		3AFF275626C6975F007809CD /* alerts */ = {
 			isa = PBXGroup;
 			children = (
@@ -2485,6 +2476,7 @@
 				3AFF277026C6975F007809CD /* TKUIResultsSectionHeaderView.swift */,
 				3AFF276726C6975F007809CD /* TKUIResultsTitleView.swift */,
 				3AFF276D26C6975F007809CD /* TKUIResultsTitleView.xib */,
+				3AFF275526C6975F007809CD /* TKUIRoutingQueryInputTitleView.swift */,
 				3AFF276426C6975F007809CD /* TKUIRoutingQueryInputTitleView.xib */,
 				3AFF276F26C6975F007809CD /* TKUIRoutingSupportView.swift */,
 				3AFF276326C6975F007809CD /* TKUIRoutingSupportView.xib */,


### PR DESCRIPTION
Routing results:

- Adjust title and make it one combined accessibility element
  rather than a separate one for from+to
- Adjust order to first be title, then close button
- Made the segment view not accessible as the cell already has all
  the trip details

Routing query input:

- Adjust order to be close, new title, route, from, swap, to
- Fix initial selection to be on (origin) search bar
- After selecting a location, focus on the other search (if that is
  is still missing), or the route button

Also a small style tweak to the query input title view

Addresses RM16010