### PR TITLE
Add departure-level platform information

### DIFF
--- a/Sources/TripKit/Resources/TripKitModel.xcdatamodeld/7-CleanUp.xcdatamodel/contents
+++ b/Sources/TripKit/Resources/TripKitModel.xcdatamodeld/7-CleanUp.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="18154" systemVersion="20G80" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="TripKit">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19461" systemVersion="21A559" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="TripKit">
     <entity name="Alert" representedClassName="Alert" syncable="YES">
         <attribute name="action" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSDictionary"/>
         <attribute name="endTime" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
@@ -24,7 +24,9 @@
         </fetchIndex>
     </entity>
     <entity name="DLSEntry" representedClassName="DLSEntry" parentEntity="StopVisits" syncable="YES">
+        <attribute name="endPlatform" optional="YES" attributeType="String"/>
         <attribute name="pairIdentifier" attributeType="String"/>
+        <attribute name="timetableEndPlatform" optional="YES" attributeType="String"/>
         <relationship name="endStop" maxCount="1" deletionRule="Nullify" destinationEntity="StopLocation" inverseName="endVisits" inverseEntity="StopLocation"/>
         <fetchIndex name="byPairIdentifierIndex">
             <fetchIndexElement property="pairIdentifier" type="Binary" order="ascending"/>
@@ -152,6 +154,8 @@
         <attribute name="originalTime" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="regionDay" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="searchString" optional="YES" attributeType="String"/>
+        <attribute name="startPlatform" optional="YES" attributeType="String"/>
+        <attribute name="timetableStartPlatform" optional="YES" attributeType="String"/>
         <relationship name="service" maxCount="1" deletionRule="Nullify" destinationEntity="Service" inverseName="visits" inverseEntity="Service"/>
         <relationship name="shapes" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Shape" inverseName="visits" inverseEntity="Shape"/>
         <relationship name="stop" maxCount="1" deletionRule="Nullify" destinationEntity="StopLocation" inverseName="visits" inverseEntity="StopLocation"/>
@@ -250,13 +254,13 @@
     </entity>
     <elements>
         <element name="Alert" positionX="952" positionY="324" width="128" height="209"/>
-        <element name="DLSEntry" positionX="124" positionY="539" width="128" height="73"/>
+        <element name="DLSEntry" positionX="124" positionY="539" width="128" height="89"/>
         <element name="SegmentReference" positionX="511" positionY="-117" width="128" height="224"/>
         <element name="SegmentTemplate" positionX="952" positionY="-234" width="128" height="28"/>
         <element name="Service" positionX="317.046875" positionY="215.6796875" width="128" height="28"/>
         <element name="Shape" positionX="637" positionY="531" width="128" height="194"/>
         <element name="StopLocation" positionX="-117.2578125" positionY="330.36328125" width="128" height="28"/>
-        <element name="StopVisits" positionX="124" positionY="243" width="128" height="209"/>
+        <element name="StopVisits" positionX="124" positionY="243" width="128" height="239"/>
         <element name="Trip" positionX="315" positionY="-252" width="128" height="418"/>
         <element name="TripGroup" positionX="99" positionY="-186" width="128" height="164"/>
         <element name="TripRequest" positionX="-153" positionY="-234" width="128" height="194"/>

--- a/Sources/TripKit/categories/String+NonEmpty.swift
+++ b/Sources/TripKit/categories/String+NonEmpty.swift
@@ -1,0 +1,32 @@
+//
+//  String+NonEmpty.swift
+//  TripKit
+//
+//  Created by Adrian Schönig on 2/12/21.
+//  Copyright © 2021 SkedGo Pty Ltd. All rights reserved.
+//
+
+import Foundation
+
+extension String {
+  var nonEmpty: String? {
+    return isEmpty ? nil : self
+  }
+  
+  var trimmedNonEmpty: String? {
+    trimmingCharacters(in: .whitespaces).nonEmpty
+  }
+}
+
+extension Optional where Wrapped == String {
+  var isEmpty: Bool {
+    switch self {
+    case .none: return true
+    case .some(let string): return string.isEmpty
+    }
+  }
+  
+  var nonEmpty: String? {
+    return isEmpty ? nil : self
+  }
+}

--- a/Sources/TripKit/model/API/ServiceAPIModel.swift
+++ b/Sources/TripKit/model/API/ServiceAPIModel.swift
@@ -47,20 +47,24 @@ extension TKAPI {
     @DefaultEmptyArray public var alertHashCodes: [Int]
     public let bicycleAccessible: Bool?
     public let wheelchairAccessible: Bool?
-    
-    // real-time information
-    public let realTimeStatus: RealTimeStatus?
-    @OptionalISO8601OrSecondsSince1970 public var realTimeDeparture: Date?
-    @OptionalISO8601OrSecondsSince1970 public var realTimeArrival: Date?
-    public let primaryVehicle: Vehicle?
-    @DefaultEmptyArray public var alternativeVehicles: [Vehicle]
 
     // static information about the departure
     public let frequency: Int?
     public let searchString: String?
     @OptionalISO8601OrSecondsSince1970 public var startTime: Date?
     @OptionalISO8601OrSecondsSince1970 public var endTime: Date?
+    public let timetableStartPlatform: String?
+    public let timetableEndPlatform: String?
     public let endStopCode: String?
+
+    // real-time information
+    public let realTimeStatus: RealTimeStatus?
+    @OptionalISO8601OrSecondsSince1970 public var realTimeDeparture: Date?
+    @OptionalISO8601OrSecondsSince1970 public var realTimeArrival: Date?
+    public let primaryVehicle: Vehicle?
+    @DefaultEmptyArray public var alternativeVehicles: [Vehicle]
+    public let startPlatform: String?
+    public let endPlatform: String?
     
     private enum CodingKeys: String, CodingKey {
       case serviceTripID
@@ -88,6 +92,10 @@ extension TKAPI {
       
       case startTime
       case endTime
+      case timetableStartPlatform
+      case timetableEndPlatform
+      case startPlatform
+      case endPlatform
       case endStopCode
     }
   }

--- a/Sources/TripKit/model/CoreData/DLSEntry+CoreDataClass.swift
+++ b/Sources/TripKit/model/CoreData/DLSEntry+CoreDataClass.swift
@@ -68,4 +68,9 @@ extension DLSEntry {
       let arrival = maybeArrival else { return false }
     return wantsRealTimeUpdates(forStart: departure, end: arrival, forPreplanning: false)
   }
+  
+  public var arrivalPlatform: String? {
+    endPlatform?.trimmedNonEmpty ?? endStop.shortName?.trimmedNonEmpty
+  }
+
 }

--- a/Sources/TripKit/model/CoreData/DLSEntry+CoreDataProperties.swift
+++ b/Sources/TripKit/model/CoreData/DLSEntry+CoreDataProperties.swift
@@ -25,4 +25,7 @@ extension DLSEntry {
   /// - See `StopVisits` superclass
   @NSManaged public var endStop: StopLocation
   
+  @NSManaged public var endPlatform: String?
+  @NSManaged public var timetableEndPlatform: String?
+  
 }

--- a/Sources/TripKit/model/CoreData/StopVisits+CoreDataClass.swift
+++ b/Sources/TripKit/model/CoreData/StopVisits+CoreDataClass.swift
@@ -67,6 +67,10 @@ extension StopVisits {
     }
   }
   
+  public var departurePlatform: String? {
+    startPlatform?.trimmedNonEmpty ?? stop.shortName?.trimmedNonEmpty
+  }
+
   /// :nodoc:
   public var smsString: String? {
     guard let serviceId = service.shortIdentifier else {
@@ -144,8 +148,6 @@ extension StopVisits {
     
     return label
   }
-  
-
   
 }
 

--- a/Sources/TripKit/model/CoreData/StopVisits+CoreDataProperties.swift
+++ b/Sources/TripKit/model/CoreData/StopVisits+CoreDataProperties.swift
@@ -36,6 +36,10 @@ extension StopVisits {
     @NSManaged public var regionDay: Date?
     @NSManaged public var searchString: String?
     @NSManaged public var service: Service!
+
+    @NSManaged public var startPlatform: String?
+    @NSManaged public var timetableStartPlatform: String?
+  
     @NSManaged public var shapes: Set<Shape>?
     @NSManaged public var stop: StopLocation!
 

--- a/Sources/TripKit/model/TKSegment+TKTripSegment.swift
+++ b/Sources/TripKit/model/TKSegment+TKTripSegment.swift
@@ -358,16 +358,3 @@ extension Alert {
     }
   }
 }
-
-extension Optional where Wrapped == String {
-  fileprivate var isEmpty: Bool {
-    switch self {
-    case .none: return true
-    case .some(let string): return string.isEmpty
-    }
-  }
-  
-  fileprivate var nonEmpty: String? {
-    return isEmpty ? self : nil
-  }
-}

--- a/Sources/TripKit/server/parsing/TKAPIToCoreDataConverter.swift
+++ b/Sources/TripKit/server/parsing/TKAPIToCoreDataConverter.swift
@@ -79,10 +79,7 @@ extension TKAPIToCoreDataConverter {
 extension Service {
   convenience init(from model: TKAPI.Departure, into context: NSManagedObjectContext) {
     self.init(context: context)
-//    update(from: model)
-//  }
-//
-//  func update(from model: TKAPI.Service) {
+
     frequency = model.frequency != nil ? NSNumber(value: model.frequency!) : nil
     number = model.number
     lineName = model.name
@@ -91,6 +88,7 @@ extension Service {
     color = model.color?.color
     modeInfo = model.modeInfo
     operatorName = model.operatorName
+    
     wheelchairAccessibility = TKWheelchairAccessibility(bool: model.wheelchairAccessible)
     
     isBicycleAccessible = model.bicycleAccessible ?? false
@@ -141,6 +139,14 @@ extension Service {
     }
     
     visit.searchString = model.searchString
+    visit.startPlatform = model.startPlatform
+    visit.timetableStartPlatform = model.timetableStartPlatform
+    
+    if let dls = visit as? DLSEntry {
+      dls.endPlatform = model.endPlatform
+      dls.timetableEndPlatform = model.timetableEndPlatform
+    }
+
     visit.service = self
     visit.stop = stop
     

--- a/Sources/TripKitUI/cards/TKUITimetableCard+Content.swift
+++ b/Sources/TripKitUI/cards/TKUITimetableCard+Content.swift
@@ -111,7 +111,7 @@ extension StopVisits {
     var text = ""
     
     // platforms
-    if let standName = stop.shortName?.trimmingCharacters(in: .whitespaces), !standName.isEmpty {
+    if let standName = departurePlatform {
       if !text.isEmpty {
         text += " ⋅ "
       }
@@ -130,3 +130,4 @@ extension StopVisits {
   }
   
 }
+

--- a/TripKit.xcodeproj/project.pbxproj
+++ b/TripKit.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		3AB3A60826E84A7E006C2AD1 /* DatadogSDKTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 3AB3A60726E84A7E006C2AD1 /* DatadogSDKTesting */; };
 		3AB424DF2734F7D800AA0CF1 /* CLLocationCoordinate2D+EncodePolylineString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB424DE2734F7D800AA0CF1 /* CLLocationCoordinate2D+EncodePolylineString.swift */; };
 		3AB424E02734F7D800AA0CF1 /* CLLocationCoordinate2D+EncodePolylineString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB424DE2734F7D800AA0CF1 /* CLLocationCoordinate2D+EncodePolylineString.swift */; };
+		3AB4E58127584632006D2363 /* String+NonEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB4E58027584632006D2363 /* String+NonEmpty.swift */; };
+		3AB4E58227584632006D2363 /* String+NonEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB4E58027584632006D2363 /* String+NonEmpty.swift */; };
 		3AB6C62B1D1CD0060089F687 /* TripKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3AB6C6201D1CD0060089F687 /* TripKit.framework */; };
 		3ACD91D726CCC47B0075CCF3 /* TKUIShareHelperTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ACD91A126CCC47B0075CCF3 /* TKUIShareHelperTest.swift */; };
 		3ACD91D926CCC47B0075CCF3 /* TKUIRoutingQueryInputViewModelTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ACD91A326CCC47B0075CCF3 /* TKUIRoutingQueryInputViewModelTest.swift */; };
@@ -963,6 +965,7 @@
 		3AACB4942643771300DE5665 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		3AB424DE2734F7D800AA0CF1 /* CLLocationCoordinate2D+EncodePolylineString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CLLocationCoordinate2D+EncodePolylineString.swift"; sourceTree = "<group>"; };
 		3AB4A2DD235DEE2500C0E195 /* TripKitUIExample.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TripKitUIExample.entitlements; sourceTree = "<group>"; };
+		3AB4E58027584632006D2363 /* String+NonEmpty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+NonEmpty.swift"; sourceTree = "<group>"; };
 		3AB6C6201D1CD0060089F687 /* TripKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TripKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3AB6C62A1D1CD0060089F687 /* TripKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TripKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3ABA80AB204F1AC100E67BC7 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
@@ -2203,6 +2206,7 @@
 				3AFF26BE26C6975F007809CD /* NSManagedObjectContext+Fetch.swift */,
 				3AFF26BD26C6975F007809CD /* NSNumber+Formatter.swift */,
 				3AFF26C126C6975F007809CD /* NSUserDefaults+SharedDefaults.swift */,
+				3AB4E58027584632006D2363 /* String+NonEmpty.swift */,
 			);
 			path = categories;
 			sourceTree = "<group>";
@@ -3547,6 +3551,7 @@
 				3AFF296C26C6981E007809CD /* TKRoutingServer.swift in Sources */,
 				3AFF287D26C697AB007809CD /* TKRegionManager.swift in Sources */,
 				3AFF288A26C697CA007809CD /* RoutingAPIModel.swift in Sources */,
+				3AB4E58227584632006D2363 /* String+NonEmpty.swift in Sources */,
 				3AFF2A0626C69994007809CD /* NSDate+Formatting.swift in Sources */,
 				3AFF299226C69850007809CD /* ISO8601OrSecondsSince1970.swift in Sources */,
 				3AFF28D626C697D9007809CD /* SegmentTemplate+Data.swift in Sources */,
@@ -3911,6 +3916,7 @@
 				3AFF294826C6981D007809CD /* TKQuickBookingHelper.swift in Sources */,
 				3AFF290C26C697DA007809CD /* TKLocationTypes.swift in Sources */,
 				3AFF295726C6981D007809CD /* TKReporter.swift in Sources */,
+				3AB4E58127584632006D2363 /* String+NonEmpty.swift in Sources */,
 				3AFF290826C697DA007809CD /* SegmentReference+CoreDataProperties.swift in Sources */,
 				3AFF293926C6980D007809CD /* TKGeoJSON.swift in Sources */,
 				3AFF28A126C697CB007809CD /* OpeningHoursAPIModel.swift in Sources */,


### PR DESCRIPTION
Adds platform information when it was returned on a per-departure
rather than on a per-stop level from `departures.json` or `service.json`.

Also: Fix for String.nonEmpty

---

Example for Leicester, UK, note the "Stand EA" entries:

<img width="901" alt="Screen Shot 2021-12-02 at 11 30 56" src="https://user-images.githubusercontent.com/22646/144336038-1b695eb5-5137-482c-aa23-fdaccf769fb8.png">