### PR TITLE
Regression fix for mode picker not working on Mac Catalyst

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build
-      run: swift build -v --target TripKit
+      run: swift build --target TripKit
 
   build_xcode:
     runs-on: macos-11
@@ -24,11 +24,11 @@ jobs:
         xcode-version: '13.0' # latest-stable
     - uses: actions/checkout@v2
     - name: Build TripKit Mac
-      run: xcodebuild build -project TripKit.xcodeproj -scheme "TripKit-macOS"
+      run: xcodebuild build -quiet -project TripKit.xcodeproj -scheme "TripKit-macOS"
     - name: Build TripKitUI iOS
-      run: xcodebuild build -project TripKit.xcodeproj -scheme "TripKitUI-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 8'
+      run: xcodebuild build -quiet -project TripKit.xcodeproj -scheme "TripKitUI-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 8'
     - name: Build TripKitInterApp iOS
-      run: xcodebuild build -project TripKit.xcodeproj -scheme "TripKitInterApp-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 8'
+      run: xcodebuild build -quiet -project TripKit.xcodeproj -scheme "TripKitInterApp-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 8'
 
   test_xcode:
     runs-on: macos-11
@@ -46,7 +46,7 @@ jobs:
         DD_ENV: ci
         DD_SERVICE: tripkit-ios
       run: |
-        xcodebuild test -project TripKit.xcodeproj -scheme "TripKit-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 12' -resultBundlePath TestResults
+        xcodebuild test -quiet -project TripKit.xcodeproj -scheme "TripKit-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 12' -resultBundlePath TestResults
     - uses: kishikawakatsumi/xcresulttool@v1.0.3
       with:
         path: TestResults.xcresult
@@ -63,12 +63,12 @@ jobs:
         xcode-version: '13.0' # latest-stable
     - uses: actions/checkout@v2
     - name: Build TripKitUIExample
-      run: xcodebuild build -project TripKit.xcodeproj -scheme TripKitUIExample -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 8'
+      run: xcodebuild build -quiet -project TripKit.xcodeproj -scheme TripKitUIExample -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 8'
     - name: Build MiniMap
       run: |
         cd Examples/MiniMap
         pod install
-        xcodebuild build -workspace MiniMap.xcworkspace -scheme MiniMap
+        xcodebuild build -quiet -workspace MiniMap.xcworkspace -scheme MiniMap
     # - name: Build CocoaPodsTest
     #   run: |
     #     cd Examples/CocoaPodsTest

--- a/Sources/TripKitUI/views/TKUIModePicker.swift
+++ b/Sources/TripKitUI/views/TKUIModePicker.swift
@@ -84,11 +84,13 @@ public class TKUIModePicker<Item>: UIView where Item: TKUIModePickerItem {
       trailingAnchor.constraint(equalTo: collectionView.trailingAnchor),
       bottomAnchor.constraint(equalTo: collectionView.bottomAnchor)
     ])
-    
+
+    #if !targetEnvironment(macCatalyst)
     let longTap = UILongPressGestureRecognizer(target: self, action: #selector(handleLongTap))
     longTap.delaysTouchesBegan = true
     longTap.minimumPressDuration = 0.25
     collectionView.addGestureRecognizer(longTap)
+    #endif
     
     self.collectionView = collectionView
     
@@ -343,6 +345,21 @@ extension TKUIModePicker: TKUIModePickerLayoutHelperDelegate {
     }
     
     self.tap.onNext(())
+  }
+  
+  func hoverChanged(isActive: Bool, at indexPath: IndexPath?, in collectionView: UICollectionView) {
+    if isActive, let indexPath = indexPath {
+      let tappedItem = visibleModes[indexPath.row]
+      if let lastTapped = self.lastTappedItem, lastTapped != tappedItem {
+        hide(item: lastTapped)
+      }
+      if let cell = collectionView.cellForItem(at: indexPath) {
+        show(item: tappedItem, above: cell)
+      }
+      self.lastTappedItem = tappedItem
+    } else if let lastTapped = self.lastTappedItem {
+      hide(item: lastTapped)
+    }
   }
   
 }


### PR DESCRIPTION
Fixes regression from #123

Also re-adds info on hover (rather than long-tap)