### PR TITLE
Fixes missing prompt for time picker

### DIFF
--- a/Sources/TripKitUI/cards/TKUIHomeCard.swift
+++ b/Sources/TripKitUI/cards/TKUIHomeCard.swift
@@ -339,8 +339,7 @@ extension TKUIHomeCard {
 
 extension TKUIHomeCard: TKUIRoutingQueryInputCardDelegate {
   public func routingQueryInput(card: TKUIRoutingQueryInputCard, selectedOrigin origin: MKAnnotation, destination: MKAnnotation) {
-    let request = TripRequest.insert(from: origin, to: destination, for: nil, timeType: .leaveASAP, into: TripKit.shared.tripKitContext)
-    let routingResultsCard = TKUIRoutingResultsCard(request: request)
+    let routingResultsCard = TKUIRoutingResultsCard(destination: destination, origin: origin)
     
     // We don't want the query input card anymore as it's accessible from the results card
     controller?.swap(for: routingResultsCard, animated: true)

--- a/Sources/TripKitUI/cards/TKUIRoutingResultsCard.swift
+++ b/Sources/TripKitUI/cards/TKUIRoutingResultsCard.swift
@@ -44,6 +44,7 @@ public class TKUIRoutingResultsCard: TKUITableCard {
   public var onSelection: ((Trip) -> Bool)? = nil
   
   private let destination: MKAnnotation?
+  private let origin: MKAnnotation?
   private var request: TripRequest? // Updated for debugging purposes
   private let editable: Bool
 
@@ -77,10 +78,12 @@ public class TKUIRoutingResultsCard: TKUITableCard {
   ///
   /// - Parameters:
   ///   - destination: The destination of the routing request.
+  ///   - origin: Optionally, the origin lf the routing request. if not supplied, will use current location.
   ///   - zoomToDestination: Whether the map should zoom to `destination` immediately. (Defaults to `true` if not provided.)
   ///   - initialPosition: The initial position at which the card is placed when it's displayed.
-  public init(destination: MKAnnotation, zoomToDestination: Bool = true, initialPosition: TGCardPosition? = nil) {
+  public init(destination: MKAnnotation, origin: MKAnnotation? = nil, zoomToDestination: Bool = true, initialPosition: TGCardPosition? = nil) {
     self.destination = destination
+    self.origin = origin
     self.request = nil
     self.editable = true
     
@@ -109,6 +112,7 @@ public class TKUIRoutingResultsCard: TKUITableCard {
   
   public init(request: TripRequest, editable: Bool = true) {
     self.destination = nil
+    self.origin = nil
     self.request = request
     self.editable = editable
     
@@ -195,7 +199,7 @@ public class TKUIRoutingResultsCard: TKUITableCard {
     
     let viewModel: TKUIRoutingResultsViewModel
     if let destination = self.destination {
-      viewModel = TKUIRoutingResultsViewModel(destination: destination, limitTo: Self.config.limitToModes, inputs: inputs, mapInput: mapInput)
+      viewModel = TKUIRoutingResultsViewModel(destination: destination, origin: origin, limitTo: Self.config.limitToModes, inputs: inputs, mapInput: mapInput)
     } else if let request = self.request {
       viewModel = TKUIRoutingResultsViewModel(request: request, editable: editable, limitTo: Self.config.limitToModes, inputs: inputs, mapInput: mapInput)
     } else {

--- a/Sources/TripKitUI/view model/TKUIRoutingResultsViewModel+CalculateRoutes.swift
+++ b/Sources/TripKitUI/view model/TKUIRoutingResultsViewModel+CalculateRoutes.swift
@@ -52,9 +52,9 @@ extension TKUIRoutingResultsViewModel {
       case arriveBefore(Date)
     }
     
-    init(destination: MKAnnotation) {
-      self.mode = .origin
-      self.origin = nil
+    init(destination: MKAnnotation, origin: MKAnnotation? = nil) {
+      self.mode = origin == nil ? .origin : .destination
+      self.origin = origin.map(TKNamedCoordinate.namedCoordinate(for:))
       self.destination = TKNamedCoordinate.namedCoordinate(for: destination)
       self.time = TKUIRoutingResultsCard.config.timePickerConfig.allowsASAP ? .leaveASAP : nil
     }

--- a/Sources/TripKitUI/view model/TKUIRoutingResultsViewModel.swift
+++ b/Sources/TripKitUI/view model/TKUIRoutingResultsViewModel.swift
@@ -44,8 +44,8 @@ class TKUIRoutingResultsViewModel {
     droppedPin: Signal<CLLocationCoordinate2D>  // => call dropPin()
   )
   
-  convenience init(destination: MKAnnotation, limitTo modes: Set<String>? = nil, inputs: UIInput, mapInput: MapInput) {
-    let builder = RouteBuilder(destination: destination)
+  convenience init(destination: MKAnnotation, origin: MKAnnotation? = nil, limitTo modes: Set<String>? = nil, inputs: UIInput, mapInput: MapInput) {
+    let builder = RouteBuilder(destination: destination, origin: origin)
     self.init(builder: builder, editable: false, limitTo: modes, inputs: inputs, mapInput: mapInput)
   }
   


### PR DESCRIPTION
Came across this today, while testing the Mi Ride app:

Setting TKUIRoutingResultsCard.config.timePickerConfig.allowsASAP to false and then navigating from home card, to query input, to routing results did not bring up the time picker.

This PR fixes that, by extending the results card constructor that takes a destination, to take an optional origin.