### PR TITLE
Consistent VoiceOver ordering for routing results screen

### DIFF
--- a/Sources/TripKitUI/cards/TKUIRoutingResultsCard.swift
+++ b/Sources/TripKitUI/cards/TKUIRoutingResultsCard.swift
@@ -163,7 +163,7 @@ public class TKUIRoutingResultsCard: TKUITableCard {
   public override var preferredView: UIView? {
     // See if we have an overlay; if so, don't say we have a preferred view
     // to not read out something from VoiceOver that has an overlay on top.
-    return findOverlay() != nil ? nil : titleView
+    return findOverlay() != nil ? nil : titleView?.preferredView
   }
   
   override public func didBuild(tableView: UITableView, cardView: TGCardView) {

--- a/Sources/TripKitUI/views/results/TKUIResultsTitleView.swift
+++ b/Sources/TripKitUI/views/results/TKUIResultsTitleView.swift
@@ -15,7 +15,7 @@ import RxCocoa
 
 import TripKit
 
-class TKUIResultsTitleView: UIView {
+class TKUIResultsTitleView: UIView, TGPreferrableView {
   
   @IBOutlet weak var originLabel: UILabel!
   @IBOutlet weak var destinationLabel: UILabel!
@@ -32,6 +32,10 @@ class TKUIResultsTitleView: UIView {
   private let locationSearchPublisher = PublishSubject<Void>()
   var locationTapped: Signal<Void> {
     return locationSearchPublisher.asSignal(onErrorSignalWith: .empty())
+  }
+  
+  public var preferredView: UIView? {
+    fromToStack
   }
   
   var accessoryView: UIView? {
@@ -128,7 +132,7 @@ class TKUIResultsTitleView: UIView {
     fromToStack.accessibilityTraits = .button
     
     accessibilityElements = [
-      fromToStack, dismissButton, accessoryView
+      dismissButton, fromToStack, accessoryView
     ].compactMap { $0 }
   }
   


### PR DESCRIPTION
Now focuses on from/to of title, with close button at negative swipe.