### PR TITLE
Feature/16558 hide durations

### DIFF
--- a/Sources/TripKit/model/API/RoutingAPIModel.swift
+++ b/Sources/TripKit/model/API/RoutingAPIModel.swift
@@ -142,6 +142,7 @@ extension TKAPI {
     public var notes: String?
     @UnknownNil public var localCost: TKLocalCost? // Backend is sometimes sending this invalid without currency as of 2021-08-17
     var mini: TKMiniInstruction?
+    @DefaultFalse var hideExactTimes: Bool
 
     // stationary
     public var location: TKNamedCoordinate?
@@ -187,6 +188,7 @@ extension TKAPI {
       case localCost
       case mapTiles
       case mini
+      case hideExactTimes
       case turnByTurn = "turn-by-turn"
       case streets
       case stopCode

--- a/Sources/TripKit/model/CoreData/SegmentTemplate+Flags.swift
+++ b/Sources/TripKit/model/CoreData/SegmentTemplate+Flags.swift
@@ -19,14 +19,20 @@ extension SegmentTemplate {
     get { has(.isContinuation) }
     set { set(.isContinuation, to: newValue) }
   }
-  
+
+  var hideExactTimes: Bool {
+    get { has(.hideExactTimes) }
+    set { set(.hideExactTimes, to: newValue) }
+  }
+
   // MARK: -
   
   private struct FlagOptions: OptionSet {
     let rawValue: Int16
     
-    static let isContinuation   = FlagOptions(rawValue: 1 << 0)
-    static let hasCarParks    = FlagOptions(rawValue: 1 << 1)
+    static let isContinuation     = FlagOptions(rawValue: 1 << 0)
+    static let hasCarParks        = FlagOptions(rawValue: 1 << 1)
+    static let hideExactTimes     = FlagOptions(rawValue: 1 << 2)
   }
   
   private func set(_ option: FlagOptions, to value: Bool) {

--- a/Sources/TripKit/model/CoreData/Trip+Flags.swift
+++ b/Sources/TripKit/model/CoreData/Trip+Flags.swift
@@ -30,7 +30,6 @@ extension Trip {
     set { set(.hideExactTimes, to: newValue) }
   }
   
-  @objc // TEMP
   public var isCanceled: Bool {
     get { has(.isCanceled) }
     set { set(.isCanceled, to: newValue) }

--- a/Sources/TripKit/model/TKSegment+TKTripSegment.swift
+++ b/Sources/TripKit/model/TKSegment+TKTripSegment.swift
@@ -34,7 +34,7 @@ extension TKSegment {
     if timesAreRealTime {
       return isPublicTransport ? Loc.RealTime : Loc.LiveTraffic
 
-    } else if !trip.isMixedModal(ignoreWalking: false), !isPublicTransport {
+    } else if !trip.isMixedModal(ignoreWalking: false), !isPublicTransport, template?.hideExactTimes != true {
       let final = finalSegmentIncludingContinuation()
       return final.arrivalTime.durationSince(departureTime)
 

--- a/Sources/TripKit/server/parsing/SegmentTemplate+Parsing.swift
+++ b/Sources/TripKit/server/parsing/SegmentTemplate+Parsing.swift
@@ -56,6 +56,7 @@ extension SegmentTemplate {
     
     template.isContinuation = model.isContinuation
     template.hasCarParks = model.hasCarParks
+    template.hideExactTimes = model.hideExactTimes
     
     if template.isStationary {
       // stationary segments just have a single location

--- a/Sources/TripKitUI/Resources/TripKitUI.xcassets/Code/icon-signal-bars1.imageset/Contents.json
+++ b/Sources/TripKitUI/Resources/TripKitUI.xcassets/Code/icon-signal-bars1.imageset/Contents.json
@@ -1,23 +1,26 @@
 {
   "images" : [
     {
-      "idiom" : "universal",
       "filename" : "icon-signal-mini-one-bar.png",
+      "idiom" : "universal",
       "scale" : "1x"
     },
     {
-      "idiom" : "universal",
       "filename" : "icon-signal-mini-one-bar@2x.png",
+      "idiom" : "universal",
       "scale" : "2x"
     },
     {
-      "idiom" : "universal",
       "filename" : "icon-signal-mini-one-bar@3x.png",
+      "idiom" : "universal",
       "scale" : "3x"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/Sources/TripKitUI/Resources/TripKitUI.xcassets/Code/icon-signal-bars2.imageset/Contents.json
+++ b/Sources/TripKitUI/Resources/TripKitUI.xcassets/Code/icon-signal-bars2.imageset/Contents.json
@@ -1,23 +1,26 @@
 {
   "images" : [
     {
-      "idiom" : "universal",
       "filename" : "icon-signal-mini-two-bars.png",
+      "idiom" : "universal",
       "scale" : "1x"
     },
     {
-      "idiom" : "universal",
       "filename" : "icon-signal-mini-two-bars@2x.png",
+      "idiom" : "universal",
       "scale" : "2x"
     },
     {
-      "idiom" : "universal",
       "filename" : "icon-signal-mini-two-bars@3x.png",
+      "idiom" : "universal",
       "scale" : "3x"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/Sources/TripKitUI/Resources/TripKitUI.xcassets/Code/icon-signal-bars3.imageset/Contents.json
+++ b/Sources/TripKitUI/Resources/TripKitUI.xcassets/Code/icon-signal-bars3.imageset/Contents.json
@@ -1,23 +1,26 @@
 {
   "images" : [
     {
-      "idiom" : "universal",
       "filename" : "icon-signal-mini-three-bars.png",
+      "idiom" : "universal",
       "scale" : "1x"
     },
     {
-      "idiom" : "universal",
       "filename" : "icon-signal-mini-three-bars@2x.png",
+      "idiom" : "universal",
       "scale" : "2x"
     },
     {
-      "idiom" : "universal",
       "filename" : "icon-signal-mini-three-bars@3x.png",
+      "idiom" : "universal",
       "scale" : "3x"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/Sources/TripKitUI/cards/TKUIRoutingResultsCard.swift
+++ b/Sources/TripKitUI/cards/TKUIRoutingResultsCard.swift
@@ -438,7 +438,7 @@ extension TKUITripCell {
 
 extension TKUITripCell.Model {
 
-  init(_ trip: Trip, allowFading: Bool, isArriveBefore: Bool?) {
+  init(_ trip: Trip, allowFading: Bool, isArriveBefore: Bool? = nil) {
     self.init(
       departure: trip.departureTime,
       arrival: trip.arrivalTime,

--- a/Sources/TripKitUI/cards/TKUITripOverviewCard.swift
+++ b/Sources/TripKitUI/cards/TKUITripOverviewCard.swift
@@ -63,6 +63,7 @@ public class TKUITripOverviewCard: TKUITableCard {
   // we model it as an observable sequence.
   private let presentedTripPublisher = PublishSubject<Trip>()
   
+  private var titleView: TKUITripTitleView?
   private weak var tableView: UITableView?
   
   var tripMapManager: TKUITripMapManager? { mapManager as? TKUITripMapManager }
@@ -71,8 +72,12 @@ public class TKUITripOverviewCard: TKUITableCard {
     self.initialTrip = trip
     self.index = index
     
+    let tripTitle = TKUITripTitleView.newInstance()
+    tripTitle.configure(with: .init(trip, allowFading: false))
+    self.titleView = tripTitle
+    
     let mapManager = TKUITripOverviewCard.config.mapManagerFactory(trip)
-    super.init(title: Loc.Trip(index: index.map { $0 + 1 }), mapManager: mapManager)
+    super.init(title: .custom(tripTitle, dismissButton: tripTitle.dismissButton), mapManager: mapManager)
 
     if let knownMapManager = mapManager as? TKUIMapManager {
       knownMapManager.attributionDisplayer = { [weak self] sources, sender in
@@ -130,10 +135,6 @@ public class TKUITripOverviewCard: TKUITableCard {
         isVisible: isVisible.asDriver(onErrorJustReturn: true)
       )
     )
-    
-    viewModel.titles
-      .drive(cardView.rx.titles)
-      .disposed(by: disposeBag)
 
     viewModel.sections
       .drive(tableView.rx.items(dataSource: dataSource))

--- a/Sources/TripKitUI/helper/Trip+Titles.swift
+++ b/Sources/TripKitUI/helper/Trip+Titles.swift
@@ -31,10 +31,9 @@ extension Trip {
   
   static func timeTitles(departure: Date, arrival: Date, departureTimeZone: TimeZone, arrivalTimeZone: TimeZone, focusOnDuration: Bool, hideExactTimes: Bool, isArriveBefore: Bool, capitalize: Bool = false) -> (title: String, subtitle: String) {
     
+    guard !hideExactTimes else { return ("", "") }
+
     let duration = arrival.durationSince(departure)
-    
-    guard !hideExactTimes else { return (duration, "") }
-    
     if focusOnDuration {
       let subtitle: String
       if isArriveBefore {
@@ -56,5 +55,4 @@ extension Trip {
     }
   }
 
-  
 }

--- a/Sources/TripKitUI/view model/TKUITripOverviewViewModel.swift
+++ b/Sources/TripKitUI/view model/TKUITripOverviewViewModel.swift
@@ -22,10 +22,6 @@ class TKUITripOverviewViewModel {
   
   init(presentedTrip: Infallible<Trip>, inputs: UIInput = UIInput()) {
     
-    titles = presentedTrip
-      .asDriver(onErrorDriveWith: .empty())
-      .flatMapLatest { $0.rx.titles }
-    
     dataSources = presentedTrip
       .asDriver(onErrorDriveWith: .empty())
       .map { $0.tripGroup.sources }
@@ -78,9 +74,7 @@ class TKUITripOverviewViewModel {
       }
     
   }
-  
-  let titles: Driver<(title: String, subtitle: String?)>
-  
+    
   let sections: Driver<[Section]>
   
   let actions: Driver<([TKUITripOverviewCard.TripAction], Trip)>
@@ -96,14 +90,6 @@ class TKUITripOverviewViewModel {
 extension TKUITripOverviewViewModel {
   convenience init(initialTrip: Trip) {
     self.init(presentedTrip: .just(initialTrip))
-  }
-}
-
-fileprivate extension Reactive where Base == Trip {
-  var titles: Driver<(title: String, subtitle: String?)> {
-    return Observable.merge(observe(Date.self, "arrivalTime"), observe(Date.self, "departureTime"))
-      .compactMap { [unowned base] _ in base.timeTitles(capitalize: true) }
-      .asDriver(onErrorDriveWith: .empty())
   }
 }
 

--- a/Sources/TripKitUI/views/results/TKUITripCell.swift
+++ b/Sources/TripKitUI/views/results/TKUITripCell.swift
@@ -16,6 +16,7 @@ public class TKUITripCell: UITableViewCell {
   
   public static let reuseIdentifier: String = "TKUITripCell"
 
+  @IBOutlet weak var titleStackView: UIStackView!
   @IBOutlet weak var titleLabel: UILabel!
   @IBOutlet weak var subtitleLabel: UILabel!
   @IBOutlet weak var segmentView: TKUITripSegmentsView!
@@ -85,7 +86,7 @@ public class TKUITripCell: UITableViewCell {
   func configure(_ model: Model) {
     guard let formatter = self.formatter else { return }
     
-    titleLabel.attributedText = formatter.primaryTimeString(departure: model.departure, arrival: model.arrival, departureTimeZone: model.departureTimeZone, arrivalTimeZone: model.arrivalTimeZone, focusOnDuration: model.focusOnDuration, isArriveBefore: model.isArriveBefore)
+    titleLabel.attributedText = model.hideExactTimes ? nil : formatter.primaryTimeString(departure: model.departure, arrival: model.arrival, departureTimeZone: model.departureTimeZone, arrivalTimeZone: model.arrivalTimeZone, focusOnDuration: model.focusOnDuration, isArriveBefore: model.isArriveBefore)
     
     subtitleLabel.attributedText = model.hideExactTimes ? nil : formatter.secondaryTimeString(departure: model.departure, arrival: model.arrival, departureTimeZone: model.departureTimeZone, arrivalTimeZone: model.arrivalTimeZone, focusOnDuration: model.focusOnDuration, isArriveBefore: model.isArriveBefore)
     

--- a/Sources/TripKitUI/views/results/TKUITripCell.xib
+++ b/Sources/TripKitUI/views/results/TKUITripCell.xib
@@ -94,6 +94,7 @@
                 <outlet property="separatorView" destination="83m-f5-90i" id="di4-QI-Rxp"/>
                 <outlet property="subtitleLabel" destination="qJE-k6-hxt" id="XGN-jL-yhC"/>
                 <outlet property="titleLabel" destination="vsO-d9-TCI" id="bYl-xE-bZL"/>
+                <outlet property="titleStackView" destination="R4b-AK-zvO" id="ACT-9O-qwq"/>
             </connections>
             <point key="canvasLocation" x="67.200000000000003" y="102.99850074962519"/>
         </tableViewCell>

--- a/Sources/TripKitUI/views/timetable/TKUIServiceTitleView.swift
+++ b/Sources/TripKitUI/views/timetable/TKUIServiceTitleView.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-import RxSwift
 import TGCardViewController
 
 import TripKit
@@ -26,8 +25,6 @@ class TKUIServiceTitleView: UIView {
   
   @IBOutlet weak var accessoryStack: UIStackView!
   
-  private let disposeBag = DisposeBag()
-  
   static func newInstance() -> TKUIServiceTitleView {
     return Bundle(for: TKUIServiceTitleView.self).loadNibNamed("TKUIServiceTitleView", owner: self, options: nil)?.first as! TKUIServiceTitleView
   }
@@ -42,7 +39,7 @@ class TKUIServiceTitleView: UIView {
     serviceTitleLabel.text = nil
     
     serviceShortNameLabel.text = nil
-    
+
     serviceTimeLabel.textColor = .tkLabelSecondary
     serviceTimeLabel.text = nil
     

--- a/Sources/TripKitUI/views/trip overview/TKUITripTitleView.swift
+++ b/Sources/TripKitUI/views/trip overview/TKUITripTitleView.swift
@@ -1,0 +1,70 @@
+//
+//  TKUITripTitleView.swift
+//  TripKitUI-iOS
+//
+//  Created by Adrian Schönig on 3/2/2022.
+//  Copyright © 2022 SkedGo Pty Ltd. All rights reserved.
+//
+
+import UIKit
+
+import TGCardViewController
+
+import TripKit
+
+class TKUITripTitleView: UIView {
+  
+  @IBOutlet weak var timeStack: UIStackView!
+  @IBOutlet weak var timeTitleLabel: TKUIStyledLabel!
+  @IBOutlet weak var timeSubtitleLabel: TKUIStyledLabel!
+  @IBOutlet weak var segmentView: TKUITripSegmentsView!
+
+  @IBOutlet weak var dismissButton: UIButton!
+  
+  private var formatter: TKUITripCell.Formatter? = nil
+
+  static func newInstance() -> TKUITripTitleView {
+    return Bundle(for: TKUITripTitleView.self).loadNibNamed("TKUITripTitleView", owner: self, options: nil)?.first as! TKUITripTitleView
+  }
+
+  override func awakeFromNib() {
+    super.awakeFromNib()
+    
+    backgroundColor = .tkBackground
+    
+    formatter = .init()
+    formatter?.primaryColor = .tkLabelPrimary
+    formatter?.primaryFont = TKStyleManager.customFont(forTextStyle: .body)
+    formatter?.secondaryColor = .tkLabelSecondary
+    formatter?.secondaryFont = TKStyleManager.customFont(forTextStyle: .body)
+
+    timeTitleLabel.text = nil
+    timeSubtitleLabel.text = nil
+
+    dismissButton.setImage(TGCard.closeButtonImage, for: .normal)
+    dismissButton.setTitle(nil, for: .normal)
+    dismissButton.accessibilityLabel = Loc.Close
+  }
+
+}
+
+// MARK: - Configure
+
+extension TKUITripTitleView {
+  func configure(with model: TKUITripCell.Model) {
+    guard let formatter = self.formatter else { return }
+
+    timeTitleLabel.attributedText = model.hideExactTimes ? nil : formatter.primaryTimeString(departure: model.departure, arrival: model.arrival, departureTimeZone: model.departureTimeZone, arrivalTimeZone: model.arrivalTimeZone, focusOnDuration: model.focusOnDuration, isArriveBefore: model.isArriveBefore)
+    
+    timeSubtitleLabel.attributedText = model.hideExactTimes ? nil : formatter.secondaryTimeString(departure: model.departure, arrival: model.arrival, departureTimeZone: model.departureTimeZone, arrivalTimeZone: model.arrivalTimeZone, focusOnDuration: model.focusOnDuration, isArriveBefore: model.isArriveBefore)
+    
+    segmentView.isCanceled = model.isCancelled
+    segmentView.configure(model.segments)
+    
+    let alpha: CGFloat = model.showFaded ? 0.2 : 1
+    timeTitleLabel.alpha = alpha
+    timeSubtitleLabel.alpha = alpha
+    
+    accessibilityLabel = model.accessibilityLabel
+  }
+}

--- a/Sources/TripKitUI/views/trip overview/TKUITripTitleView.xib
+++ b/Sources/TripKitUI/views/trip overview/TKUITripTitleView.xib
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="PuZ-UO-Kto" customClass="TKUITripTitleView" customModule="TripKitUI" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="372" height="80"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <subviews>
+                <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="253" axis="vertical" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="xnJ-3S-K7I">
+                    <rect key="frame" x="16" y="8" width="302" height="64"/>
+                    <subviews>
+                        <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="251" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="k6z-To-XRp">
+                            <rect key="frame" x="0.0" y="0.0" width="302" height="16"/>
+                            <subviews>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="04:59 - 05:35" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HpT-7Q-6Qy" customClass="TKUIStyledLabel" customModule="TripKitUI" customModuleProvider="target">
+                                    <rect key="frame" x="0.0" y="0.0" width="91.5" height="16"/>
+                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                    <nil key="textColor"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0Mx-Jy-AMQ" userLabel="Spacer">
+                                    <rect key="frame" x="95.5" y="0.0" width="154.5" height="16"/>
+                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                </view>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="36mins" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fBP-RS-YPy" customClass="TKUIStyledLabel" customModule="TripKitUI" customModuleProvider="target">
+                                    <rect key="frame" x="254" y="0.0" width="48" height="16"/>
+                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                    <nil key="textColor"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                            </subviews>
+                        </stackView>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ucH-Dq-vKm" customClass="TKUITripSegmentsView" customModule="TripKitUI" customModuleProvider="target">
+                            <rect key="frame" x="0.0" y="24" width="240" height="40"/>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="40" id="dO8-iG-ip6"/>
+                            </constraints>
+                        </view>
+                    </subviews>
+                </stackView>
+                <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="253" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Fbi-jx-QPl">
+                    <rect key="frame" x="324" y="-11" width="44" height="44"/>
+                    <constraints>
+                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="Pe5-A6-5ca"/>
+                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="44" id="tz4-XP-1t3"/>
+                    </constraints>
+                    <state key="normal" title="Close"/>
+                </button>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <constraints>
+                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="xnJ-3S-K7I" secondAttribute="bottom" constant="8" id="3DI-QA-0DT"/>
+                <constraint firstItem="Fbi-jx-QPl" firstAttribute="top" secondItem="PuZ-UO-Kto" secondAttribute="top" constant="-11" id="FKF-TB-hm6"/>
+                <constraint firstItem="xnJ-3S-K7I" firstAttribute="top" secondItem="PuZ-UO-Kto" secondAttribute="top" constant="8" id="PV0-cq-QeC"/>
+                <constraint firstItem="Fbi-jx-QPl" firstAttribute="leading" secondItem="xnJ-3S-K7I" secondAttribute="trailing" constant="6" id="Taf-TM-ott"/>
+                <constraint firstAttribute="trailing" secondItem="Fbi-jx-QPl" secondAttribute="trailing" constant="4" id="ibX-Zd-MQ6"/>
+                <constraint firstItem="xnJ-3S-K7I" firstAttribute="leading" secondItem="PuZ-UO-Kto" secondAttribute="leading" constant="16" id="jRi-7w-aM1"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <connections>
+                <outlet property="dismissButton" destination="Fbi-jx-QPl" id="ZxJ-SN-MqU"/>
+                <outlet property="segmentView" destination="ucH-Dq-vKm" id="Sul-og-ba0"/>
+                <outlet property="timeStack" destination="k6z-To-XRp" id="n8m-P6-5Bv"/>
+                <outlet property="timeSubtitleLabel" destination="fBP-RS-YPy" id="bad-Jc-a0T"/>
+                <outlet property="timeTitleLabel" destination="HpT-7Q-6Qy" id="4AR-eJ-hp3"/>
+            </connections>
+            <point key="canvasLocation" x="20.289855072463769" y="-670.3125"/>
+        </view>
+    </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Sources/TripKitUI/views/trip overview/TKUITripTitleView.xib
+++ b/Sources/TripKitUI/views/trip overview/TKUITripTitleView.xib
@@ -58,7 +58,7 @@
             </subviews>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
-                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="xnJ-3S-K7I" secondAttribute="bottom" constant="8" id="3DI-QA-0DT"/>
+                <constraint firstAttribute="bottom" secondItem="xnJ-3S-K7I" secondAttribute="bottom" constant="8" id="3DI-QA-0DT"/>
                 <constraint firstItem="Fbi-jx-QPl" firstAttribute="top" secondItem="PuZ-UO-Kto" secondAttribute="top" constant="-11" id="FKF-TB-hm6"/>
                 <constraint firstItem="xnJ-3S-K7I" firstAttribute="top" secondItem="PuZ-UO-Kto" secondAttribute="top" constant="8" id="PV0-cq-QeC"/>
                 <constraint firstItem="Fbi-jx-QPl" firstAttribute="leading" secondItem="xnJ-3S-K7I" secondAttribute="trailing" constant="6" id="Taf-TM-ott"/>

--- a/Sources/TripKitUI/views/trip overview/TKUITripTitleView.xib
+++ b/Sources/TripKitUI/views/trip overview/TKUITripTitleView.xib
@@ -40,7 +40,7 @@
                         </stackView>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ucH-Dq-vKm" customClass="TKUITripSegmentsView" customModule="TripKitUI" customModuleProvider="target">
                             <rect key="frame" x="0.0" y="24" width="240" height="40"/>
-                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="40" id="dO8-iG-ip6"/>
                             </constraints>

--- a/TripKit.xcodeproj/project.pbxproj
+++ b/TripKit.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		3A1777B0232C17570093D495 /* TripKitInterApp.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3A6DF167202C97F60084CB2C /* TripKitInterApp.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3A1777B1232C17590093D495 /* TripKitUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A6DF084202C8DA30084CB2C /* TripKitUI.framework */; };
 		3A1777B2232C17590093D495 /* TripKitUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3A6DF084202C8DA30084CB2C /* TripKitUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		3A19BE2527ABA44500B4AA8C /* TKUITripTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A19BE2427ABA44500B4AA8C /* TKUITripTitleView.swift */; };
+		3A19BE2727ABA44D00B4AA8C /* TKUITripTitleView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 3A19BE2627ABA44D00B4AA8C /* TKUITripTitleView.xib */; };
 		3A1AABAC26CB6F8000FDDB06 /* TKAutocompletionResult+Icon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1AABAA26CB6F8000FDDB06 /* TKAutocompletionResult+Icon.swift */; };
 		3A1AABAD26CB6F8000FDDB06 /* TKAutocompletionResult+Icon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1AABAA26CB6F8000FDDB06 /* TKAutocompletionResult+Icon.swift */; };
 		3A1AABB426CB78DE00FDDB06 /* pelias-au.json in Resources */ = {isa = PBXBuildFile; fileRef = 3A1AABB126CB78DE00FDDB06 /* pelias-au.json */; };
@@ -948,6 +950,8 @@
 
 /* Begin PBXFileReference section */
 		3A0747B02730D4C3000D752F /* polygons-au-211102.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "polygons-au-211102.json"; sourceTree = "<group>"; };
+		3A19BE2427ABA44500B4AA8C /* TKUITripTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TKUITripTitleView.swift; sourceTree = "<group>"; };
+		3A19BE2627ABA44D00B4AA8C /* TKUITripTitleView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TKUITripTitleView.xib; sourceTree = "<group>"; };
 		3A1AABAA26CB6F8000FDDB06 /* TKAutocompletionResult+Icon.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TKAutocompletionResult+Icon.swift"; sourceTree = "<group>"; };
 		3A1AABB126CB78DE00FDDB06 /* pelias-au.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "pelias-au.json"; sourceTree = "<group>"; };
 		3A1AABB226CB78DE00FDDB06 /* pelias-us.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "pelias-us.json"; sourceTree = "<group>"; };
@@ -2528,6 +2532,8 @@
 				3AFF278226C6975F007809CD /* TKUISegmentStationaryDoubleCell.swift */,
 				3AFF278726C6975F007809CD /* TKUISegmentStationaryDoubleCell.xib */,
 				3AFF277D26C6975F007809CD /* TKUITrainOccupancyView.swift */,
+				3A19BE2427ABA44500B4AA8C /* TKUITripTitleView.swift */,
+				3A19BE2627ABA44D00B4AA8C /* TKUITripTitleView.xib */,
 			);
 			path = "trip overview";
 			sourceTree = "<group>";
@@ -3288,6 +3294,7 @@
 				3AFF2B0B26C69B63007809CD /* TKUISectionedAlertViewController.xib in Resources */,
 				3AFF2B7726C69BBE007809CD /* TKUIExtendedActionView.xib in Resources */,
 				3AFF2B5426C69BA4007809CD /* TKUIRoutingSupportView.xib in Resources */,
+				3A19BE2727ABA44D00B4AA8C /* TKUITripTitleView.xib in Resources */,
 				D3AB4792273DE39E0086C956 /* TKUIModePickerCell.xib in Resources */,
 				3AFF2B6F26C69BB9007809CD /* TKUIServiceHeaderView.xib in Resources */,
 				3AFF2B9926C69BC9007809CD /* TKUISegmentMovingCell.xib in Resources */,
@@ -3640,6 +3647,7 @@
 				3AFF2BAD26C69BE7007809CD /* TKShareHelper+Rx.swift in Sources */,
 				3AFF2BA526C69BDE007809CD /* UIColor+Variations.swift in Sources */,
 				3AFF2BC526C69BE7007809CD /* NSManagedObjectContext+Rx.swift in Sources */,
+				3A19BE2527ABA44500B4AA8C /* TKUITripTitleView.swift in Sources */,
 				3AFF2AEB26C69B56007809CD /* TKUITimetableCard+Content.swift in Sources */,
 				3AFF2BCE26C69BF4007809CD /* IdentifiableValue.swift in Sources */,
 				3AFF2B4726C69B9C007809CD /* TKUIAnnotations+TripKit.swift in Sources */,


### PR DESCRIPTION
Parses the new `segment.hideExactTimes` flag (see https://github.com/skedgo/tripgo-api/pull/213) and then hides both times and durations.

Notable change besides that is that the title of the TKUITripOverviewCard now looks similar to trips on the trip results page, as otherwise there wouldn't be anything to show there as previously this just showed times and duration.

Also:
- Fix dark mode support of real-time icon