### PR TITLE
Option to set focus on query input search bar

### DIFF
--- a/Sources/TripKitUI/cards/TKUIHomeCard+Configuration.swift
+++ b/Sources/TripKitUI/cards/TKUIHomeCard+Configuration.swift
@@ -72,6 +72,10 @@ public extension TKUIHomeCard {
     
     /// Set where the initial VoiceOver focus should be. Defaults to `.searchBar`
     public var voiceOverStartMode: TKUIHomeCard.VoiceOverMode = .searchBar
+    
+    /// Determines if a  `TKUIRoutingQueryInputCard` starts with a focus on the destination field,
+    /// if activated through the direction button in the home card.
+    public var directionButtonStartsQueryInputInDestinationMode: Bool = true
   }
   
 }

--- a/Sources/TripKitUI/cards/TKUIHomeCard.swift
+++ b/Sources/TripKitUI/cards/TKUIHomeCard.swift
@@ -179,7 +179,9 @@ open class TKUIHomeCard: TKUITableCard {
       .disposed(by: disposeBag)
     
     headerView.directionsButton?.rx.tap.asSignal()
-      .emit(onNext: { [weak self] in self?.showQueryInput(startingInDestinationMode: false) })
+      .emit(onNext: { [weak self] in
+        self?.showQueryInput(startingInDestinationMode: Self.config.directionButtonStartsQueryInputInDestinationMode)
+      })
       .disposed(by: disposeBag)
 
     // Map interaction


### PR DESCRIPTION
This is a follow up on https://redmine.buzzhives.com/issues/16538. It was decided that focusing on the origin when query input card is launched should be limit to MI Ride only.