### PR TITLE
Allow settings routing configuration parameters explicitly

### DIFF
--- a/Sources/TripKit/server/TKTripFetcher.swift
+++ b/Sources/TripKit/server/TKTripFetcher.swift
@@ -108,7 +108,7 @@ public enum TKTripFetcher {
 
     // fill in some default parameters that don't relate to trip properties
     // but rather how it's output -- at least, where the URL doesn't have them
-    let config = TKSettings.Config()
+    let config = TKSettings.Config.userSettings()
     var queryItems = components.queryItems ?? []
     queryItems.addDefault(name: "v", value: String(config.version))
     queryItems.addDefault(name: "unit", value: config.distanceUnit.rawValue)

--- a/Sources/TripKit/server/TKWaypointRouter.swift
+++ b/Sources/TripKit/server/TKWaypointRouter.swift
@@ -89,7 +89,7 @@ extension TKWaypointRouter {
     let leaveAt = departure > now ? departure : now
     
     var paras = [String: Any]()
-    paras["config"]   = TKSettings.config
+    paras["config"]   = TKSettings.Config.userSettings().paras
     paras["vehicles"] = TKAPIToCoreDataConverter.vehiclesPayload(for: vehicles)
     paras["segments"] = pattern
     paras["leaveAt"]  = leaveAt.timeIntervalSince1970 + 60
@@ -327,7 +327,7 @@ class WaypointParasBuilder {
     guard let trip = segmentToMatch.trip else { preconditionFailure() }
     
     var paras: [String: Any] = [
-      "config": TKSettings.config,
+      "config": TKSettings.Config.userSettings().paras,
       "vehicles": TKAPIToCoreDataConverter.vehiclesPayload(for: vehicles)
     ]
     
@@ -491,7 +491,7 @@ class WaypointParasBuilder {
     }
     
     var paras: [String: Any] = [
-      "config": TKSettings.config,
+      "config": TKSettings.Config.userSettings().paras,
       "vehicles": TKAPIToCoreDataConverter.vehiclesPayload(for: vehicles)
     ]
 
@@ -536,7 +536,7 @@ class WaypointParasBuilder {
       else { throw TKWaypointRouter.WaypointError.segmentNotEligible }
     
     var paras: [String: Any] = [
-      "config": TKSettings.config,
+      "config": TKSettings.Config.userSettings().paras,
       "vehicles": TKAPIToCoreDataConverter.vehiclesPayload(for: vehicles)
     ]
     
@@ -584,7 +584,7 @@ class WaypointParasBuilder {
       else { throw TKWaypointRouter.WaypointError.segmentNotEligible }
     
     var paras: [String: Any] = [
-      "config": TKSettings.config,
+      "config": TKSettings.Config.userSettings().paras,
       "vehicles": TKAPIToCoreDataConverter.vehiclesPayload(for: vehicles)
     ]
     

--- a/Sources/TripKitUI/helper/RxTripKit/TKDeparturesProvider.swift
+++ b/Sources/TripKitUI/helper/RxTripKit/TKDeparturesProvider.swift
@@ -51,7 +51,7 @@ extension TKDeparturesProvider {
       "region": region.name,
       "embarkationStops": stopCodes,
       "limit": limit,
-      "config": TKSettings.config
+      "config": TKSettings.Config.userSettings().paras
     ]
     if let date = fromDate {
       paras["timeStamp"] = date.timeIntervalSince1970
@@ -119,7 +119,7 @@ extension TKDeparturesProvider {
       "embarkationStops": [table.startStopCode],
       "disembarkationStops": [table.endStopCode],
       "limit": limit,
-      "config": TKSettings.config
+      "config": TKSettings.Config.userSettings().paras
     ]
   }
   

--- a/Tests/TripKitTests/routing/TKSettingsTest.swift
+++ b/Tests/TripKitTests/routing/TKSettingsTest.swift
@@ -15,8 +15,8 @@ class TKSettingsTest: XCTestCase {
   func testDefaultValues() throws {
     let config = TKSettings.Config.defaultValues()
     XCTAssertEqual(config.version, TKSettings.parserJsonVersion)
-    XCTAssertEqual(config.distanceUnit, Locale.current.usesMetricSystem ? .metric : .imperial)
-    XCTAssertEqual(config.weights, [.money: 1.0, .carbon: 1.0, .time: 1.0, .hassle: 1.0])
+    XCTAssertEqual(config.distanceUnit, .auto)
+    XCTAssertEqual(config.weights, [.money: 1.0, .carbon: 1.0, .time: 1.0, .hassle: 1.0, .exercise: 1.0])
     XCTAssertEqual(config.avoidModes, [])
     XCTAssertEqual(config.concession, false)
     XCTAssertEqual(config.wheelchair, false)
@@ -26,7 +26,7 @@ class TKSettingsTest: XCTestCase {
     XCTAssertNil(config.minimumTransferMinutes)
     XCTAssertEqual(config.emissions, [:])
     XCTAssertEqual(config.bookingSandbox, false)
-    XCTAssertEqual(config.twoWayHireCostIncludesReturn, true)
+    XCTAssertEqual(config.twoWayHireCostIncludesReturn, false)
   }
   
   func testReadPerformance() {

--- a/Tests/TripKitTests/routing/TKSettingsTest.swift
+++ b/Tests/TripKitTests/routing/TKSettingsTest.swift
@@ -12,15 +12,8 @@ import XCTest
 
 class TKSettingsTest: XCTestCase {
   
-  override func setUp() {
-    // TODO: Should reset here ideally
-  }
-  
   func testDefaultValues() throws {
-    // TODO: Renable when settings are settable to defaults
-    try XCTSkipIf(true)
-    
-    let config = TKSettings.Config()
+    let config = TKSettings.Config.defaultValues()
     XCTAssertEqual(config.version, TKSettings.parserJsonVersion)
     XCTAssertEqual(config.distanceUnit, Locale.current.usesMetricSystem ? .metric : .imperial)
     XCTAssertEqual(config.weights, [.money: 1.0, .carbon: 1.0, .time: 1.0, .hassle: 1.0])
@@ -38,7 +31,7 @@ class TKSettingsTest: XCTestCase {
   
   func testReadPerformance() {
       self.measure {
-        _ = TKSettings.Config()
+        _ = TKSettings.Config.userSettings()
       }
   }
     


### PR DESCRIPTION
... rather than always implicitly using what's saved in user defaults

- Adds `TKSettings.Config.userSettings()` and `TKSettings.Config.defaultValues()
- Deprecates `TKSettings.Config()` in favour of `TKSettings.Config.userSettings()`
- Deprecates `TKSettings.config`
- Adds `TKRouter.config` override