### PR TITLE
fix constraint issues for result header and footer

### DIFF
--- a/Sources/TripKitUI/cards/TKUIRoutingResultsCard.swift
+++ b/Sources/TripKitUI/cards/TKUIRoutingResultsCard.swift
@@ -511,7 +511,15 @@ extension TKUIRoutingResultsCard: UITableViewDelegate {
     return footerView
   }
   
+  public func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+    return getFooterHeight(from: section)
+  }
+  
   public func tableView(_ tableView: UITableView, estimatedHeightForFooterInSection section: Int) -> CGFloat {
+    return getFooterHeight(from: section)
+  }
+  
+  private func getFooterHeight(from section: Int) -> CGFloat {
     if dataSource.sectionModels[section].items.first?.trip == nil {
       return .leastNonzeroMagnitude
     } else {
@@ -536,7 +544,15 @@ extension TKUIRoutingResultsCard: UITableViewDelegate {
     return headerView
   }
   
+  public func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+    return getHeaderHeight(from: section)
+  }
+  
   public func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
+    return getHeaderHeight(from: section)
+  }
+    
+  private func getHeaderHeight(from section: Int) -> CGFloat {
     let section = dataSource.sectionModels[section]
     if section.badge?.footerContent == nil {
       return 16

--- a/Sources/TripKitUI/views/results/TKUIResultsSectionFooterView.swift
+++ b/Sources/TripKitUI/views/results/TKUIResultsSectionFooterView.swift
@@ -67,15 +67,21 @@ class TKUIResultsSectionFooterView: UITableViewHeaderFooterView {
     button.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
     self.button = button
     contentView.addSubview(button)
+      
+    let topMarginConstraint = costLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 6)
+    topMarginConstraint.priority = UILayoutPriority(rawValue: 999)
+  
+    let bottomMarginConstraint = contentView.bottomAnchor.constraint(equalTo: costLabel.bottomAnchor, constant: 6)
+    bottomMarginConstraint.priority = UILayoutPriority(rawValue: 999)
     
     NSLayoutConstraint.activate([
       costLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
       button.leadingAnchor.constraint(equalTo: costLabel.trailingAnchor, constant: 16),
       contentView.trailingAnchor.constraint(equalTo: button.trailingAnchor, constant: 16),
       
-      costLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 6),
+      topMarginConstraint,
       costLabel.centerYAnchor.constraint(equalTo: button.centerYAnchor),
-      contentView.bottomAnchor.constraint(equalTo: costLabel.bottomAnchor, constant: 6)
+      bottomMarginConstraint
     ])
   }
   

--- a/Sources/TripKitUI/views/results/TKUIResultsSectionHeaderView.swift
+++ b/Sources/TripKitUI/views/results/TKUIResultsSectionHeaderView.swift
@@ -77,9 +77,7 @@ class TKUIResultsSectionHeaderView: UITableViewHeaderFooterView {
     badgeIcon.contentMode = .scaleAspectFit
     badgeIcon.tintColor = .tkFilledButtonTextColor
     badgeIcon.widthAnchor.constraint(equalToConstant: 16).isActive = true
-    let heightConstraint = badgeIcon.heightAnchor.constraint(equalToConstant: 16)
-    heightConstraint.priority = UILayoutPriority(rawValue: 999)
-    heightConstraint.isActive = true
+    badgeIcon.heightAnchor.constraint(equalToConstant: 16).isActive = true
     badgeIcon.translatesAutoresizingMaskIntoConstraints = false
     self.badgeIcon = badgeIcon
     wrapper.addSubview(badgeIcon)
@@ -92,15 +90,21 @@ class TKUIResultsSectionHeaderView: UITableViewHeaderFooterView {
     badgeLabel.translatesAutoresizingMaskIntoConstraints = false
     self.badgeLabel = badgeLabel
     wrapper.addSubview(badgeLabel)
+      
+    let bottomWrapperMarginConstraint = wrapper.bottomAnchor.constraint(equalTo: badgeIcon.bottomAnchor, constant: 4)
+    bottomWrapperMarginConstraint.priority = UILayoutPriority(rawValue: 999)
+        
+    let badgeTopMarginConstraint = badgeIcon.topAnchor.constraint(equalTo: wrapper.topAnchor, constant: 16)
+    badgeTopMarginConstraint.priority = UILayoutPriority(rawValue: 999)
     
     NSLayoutConstraint.activate([
       badgeIcon.leadingAnchor.constraint(equalTo: wrapper.leadingAnchor, constant: 16),
       badgeLabel.leadingAnchor.constraint(equalTo: badgeIcon.trailingAnchor, constant: 8),
       wrapper.trailingAnchor.constraint(equalTo: badgeLabel.trailingAnchor, constant: 16),
       
-      badgeIcon.topAnchor.constraint(equalTo: wrapper.topAnchor, constant: 16),
+      badgeTopMarginConstraint,
       badgeLabel.centerYAnchor.constraint(equalTo: badgeIcon.centerYAnchor),
-      wrapper.bottomAnchor.constraint(equalTo: badgeIcon.bottomAnchor, constant: 4)
+      bottomWrapperMarginConstraint
     ])
   }
   


### PR DESCRIPTION
- fixed auto layout issue with trip result header (text overlap or missing text)
- fixed auto layout issue with trip result section (no visual issues but present in the logs)