### PR TITLE
Mode picker persistence

### DIFF
--- a/Sources/TripKit/helpers/TKUserProfileHelper.swift
+++ b/Sources/TripKit/helpers/TKUserProfileHelper.swift
@@ -137,31 +137,20 @@ public class TKUserProfileHelper: NSObject {
   
   /// update picked modes provided with all reference modes to determine disabled modes
   @objc public class func update(pickedModes: Set<TKModeInfo>, allModes: Set<TKModeInfo>) {
-    var modes = disabledSharedVehicleModes
+    var modes = Set(disabledSharedVehicleModes)
     
-    let pickedIds = pickedModes.compactMap { try? JSONEncoder().encode($0)  }
-    let allIds = allModes.compactMap { try? JSONEncoder().encode($0)  }
+    let picked = Set(pickedModes.compactMap { try? JSONEncoder().encode($0)  })
+    var toDisable = Set(allModes.compactMap { try? JSONEncoder().encode($0)  })
     
-    let toDisable = allIds.filter {
-      !pickedIds.contains($0)
-    }
+    toDisable.subtract(picked)
     
-    pickedIds.forEach { mode in
-      if modes.contains(mode) {
-        modes = modes.filter { mode != $0 }
-      }
-    }
+    modes.subtract(picked)
+    modes.formUnion(toDisable)
     
-    toDisable.forEach {
-      if !modes.contains($0) {
-        modes.append($0)
-      }
-    }
-    
-    UserDefaults.shared.set(modes, forKey: DefaultsKey.disabled.rawValue)
+    UserDefaults.shared.set(Array(modes), forKey: DefaultsKey.disabled.rawValue)
   }
     
-  @objc public class var disabledSharedVehicleModes: [Data] {
+  class var disabledSharedVehicleModes: [Data] {
     if let disabled = UserDefaults.shared.object(forKey: DefaultsKey.disabled.rawValue) as? [Data] {
       return disabled
     } else {

--- a/Sources/TripKit/helpers/TKUserProfileHelper.swift
+++ b/Sources/TripKit/helpers/TKUserProfileHelper.swift
@@ -15,6 +15,7 @@ public class TKUserProfileHelper: NSObject {
     case sortedEnabled = "profileSortedModeIdentifiers"
     case hidden = "profileHiddenModeIdentifiers"
     case disliked = "profileDislikedTransitMode"
+    case enabled = "profileEnabledCyclingModes"
   }
   
   public typealias Identifier = String
@@ -132,5 +133,29 @@ public class TKUserProfileHelper: NSObject {
     }
   }
   
+  // MARK: - Mode by mode, Mode picker
+  
+  @objc public class func fetchPreferredAvailableModes(from identifiers: [Identifier]) -> Set<Identifier> {
+    let enabled = enabledSharedVehicleModes
+    let available = identifiers.filter { enabled.contains($0) }
+    return Set(available)
+  }
+  
+  @objc public class func isSharedVehicleModeEnabled(_ identifier: Identifier) -> Bool {
+    return enabledSharedVehicleModes.contains(identifier)
+  }
+  
+  @objc public class func setEnabledSharedVehicleModes(_ identifiers: [Identifier]) {
+    // Replace with set instead of appending / removing one to clean list - in case of any backend identifier change
+    UserDefaults.shared.set(identifiers, forKey: DefaultsKey.enabled.rawValue)
+  }
+    
+  @objc public class var enabledSharedVehicleModes: [Identifier] {
+    if let disabled = UserDefaults.shared.object(forKey: DefaultsKey.enabled.rawValue) as? [Identifier] {
+      return disabled
+    } else {
+      return []
+    }
+  }
   
 }

--- a/Sources/TripKit/model/TKModeInfo.swift
+++ b/Sources/TripKit/model/TKModeInfo.swift
@@ -57,14 +57,7 @@ public class TKModeInfo: NSObject, Codable, NSSecureCoding {
     else {
       return true
     }
-    var hasDisabled = false
-    for mode in disabledSharedVehicleModes {
-      if encoded == mode {
-        hasDisabled = true
-        break
-      }
-    }
-    return !hasDisabled
+    return !disabledSharedVehicleModes.contains(encoded)
   }
 
   @objc(modeInfoForDictionary:)

--- a/Sources/TripKit/model/TKModeInfo.swift
+++ b/Sources/TripKit/model/TKModeInfo.swift
@@ -49,6 +49,23 @@ public class TKModeInfo: NSObject, Codable, NSSecureCoding {
     return rgbColor?.color
   }
   private let rgbColor: TKAPI.RGBColor?
+  
+  /// Determines if the saved mode is enabled or disabled.
+  @objc public var isEnabled: Bool {
+    let disabledSharedVehicleModes = TKUserProfileHelper.disabledSharedVehicleModes
+    guard let encoded = try? JSONEncoder().encode(self)
+    else {
+      return true
+    }
+    var hasDisabled = false
+    for mode in disabledSharedVehicleModes {
+      if encoded == mode {
+        hasDisabled = true
+        break
+      }
+    }
+    return !hasDisabled
+  }
 
   @objc(modeInfoForDictionary:)
   public class func modeInfo(for json: [String: Any]?) -> TKModeInfo? {

--- a/Sources/TripKitUI/view model/TKUINearbyViewModel+Content.swift
+++ b/Sources/TripKitUI/view model/TKUINearbyViewModel+Content.swift
@@ -129,15 +129,10 @@ extension TKUINearbyViewModel {
       
     } else {
       let byModes: [TKModeCoordinate]
-      if let enabled = modes {
-        TKUserProfileHelper.setEnabledSharedVehicleModes(enabled.compactMap { $0.identifier })
-        
-        byModes = content.locations.filter { location in
-          return enabled.contains { $0 == location.stopModeInfo }
-        }
-      } else {
-        byModes = content.locations
+      byModes = content.locations.filter  { location in
+        return TKUserProfileHelper.isSharedVehicleModeEnabled(mode: location.stopModeInfo)
       }
+      
       return ViewContent(locations: byModes, mapCenter: content.mapCenter)
     }
   }

--- a/Sources/TripKitUI/view model/TKUINearbyViewModel+Content.swift
+++ b/Sources/TripKitUI/view model/TKUINearbyViewModel+Content.swift
@@ -135,7 +135,7 @@ extension TKUINearbyViewModel {
       }
       
       byModes = content.locations.filter  { location in
-        return TKUserProfileHelper.isSharedVehicleModeEnabled(mode: location.stopModeInfo)
+        return location.stopModeInfo.isEnabled
       }
       
       return ViewContent(locations: byModes, mapCenter: content.mapCenter)

--- a/Sources/TripKitUI/view model/TKUINearbyViewModel+Content.swift
+++ b/Sources/TripKitUI/view model/TKUINearbyViewModel+Content.swift
@@ -120,7 +120,7 @@ extension TKUINearbyViewModel {
       .map { ViewContent(locations: $0.0, mapCenter: $0.1) }
   }
   
-  static func filterNearbyContent(_ content: ViewContent, modes: Set<TKModeInfo>?, focusOn annotation: MKAnnotation?) -> ViewContent {
+  static func filterNearbyContent(_ content: ViewContent, pickedModes: Set<TKModeInfo>?, allModes: [TKModeInfo], focusOn annotation: MKAnnotation?) -> ViewContent {
     if let focus = annotation {
       let byFocus = content.locations.filter { location in
         return location.coordinate.latitude == focus.coordinate.latitude && location.coordinate.longitude == focus.coordinate.longitude
@@ -129,6 +129,11 @@ extension TKUINearbyViewModel {
       
     } else {
       let byModes: [TKModeCoordinate]
+      
+      if let modes = pickedModes {
+        TKUserProfileHelper.update(pickedModes: modes, allModes: Set(allModes))
+      }
+      
       byModes = content.locations.filter  { location in
         return TKUserProfileHelper.isSharedVehicleModeEnabled(mode: location.stopModeInfo)
       }

--- a/Sources/TripKitUI/view model/TKUINearbyViewModel+Content.swift
+++ b/Sources/TripKitUI/view model/TKUINearbyViewModel+Content.swift
@@ -128,9 +128,15 @@ extension TKUINearbyViewModel {
       return ViewContent(locations: byFocus, mapCenter: content.mapCenter)
       
     } else {
-      let byModes = content.locations.filter { location in
-        guard let enabled = modes else { return true }
-        return enabled.contains { $0 == location.stopModeInfo }
+      let byModes: [TKModeCoordinate]
+      if let enabled = modes {
+        TKUserProfileHelper.setEnabledSharedVehicleModes(enabled.compactMap { $0.identifier })
+        
+        byModes = content.locations.filter { location in
+          return enabled.contains { $0 == location.stopModeInfo }
+        }
+      } else {
+        byModes = content.locations
       }
       return ViewContent(locations: byModes, mapCenter: content.mapCenter)
     }

--- a/Sources/TripKitUI/view model/TKUINearbyViewModel.swift
+++ b/Sources/TripKitUI/view model/TKUINearbyViewModel.swift
@@ -49,6 +49,7 @@ public class TKUINearbyViewModel {
     }
   }
   
+  // TODO: Update parameter documentation
   /// Creates a new view model
   ///
   /// - Parameters:

--- a/Sources/TripKitUI/view model/TKUINearbyViewModel.swift
+++ b/Sources/TripKitUI/view model/TKUINearbyViewModel.swift
@@ -89,7 +89,11 @@ public class TKUINearbyViewModel {
     
     /// Variant of `nearby` that's filtering according to `pickedModes`
     let pickedModes = cardInput.pickedModes.asObservable()
-      .map { $0 as Set<TKModeInfo>? }
+      .map {
+        let modes = $0 as Set<TKModeInfo>?
+        TKUserProfileHelper.setEnabledSharedVehicleModes(modes: modes ?? Set<TKModeInfo>())
+        return modes as Set<TKModeInfo>?
+      }
       .startWith(nil)
     
     let focused = mapInput.focus

--- a/Sources/TripKitUI/view model/TKUINearbyViewModel.swift
+++ b/Sources/TripKitUI/view model/TKUINearbyViewModel.swift
@@ -92,7 +92,7 @@ public class TKUINearbyViewModel {
       .map {
         let modes = $0 as Set<TKModeInfo>?
         TKUserProfileHelper.setEnabledSharedVehicleModes(modes: modes ?? Set<TKModeInfo>())
-        return modes as Set<TKModeInfo>?
+        return modes
       }
       .startWith(nil)
     


### PR DESCRIPTION
Added mode picker persistence. 

Added `allModes` reference to `filteredNearby` to determine which modes are disabled

mode distinction is determined via `identifier` and `localImageName` as I wanted to reduce saving too much data to UserDefaults. As I see that the distinction of TKModeInfo is via its variables (Equatable). 

Would be nice if there is a single variable that uniquely identifies the mode since `identifier` seems to be showing a group-type value, and gets every beam / neuron modes alike.

On other note: @nighthawk `identifier` seems to be a group-type value which is good for sorting initially #186 but there seems to be grouping based on location, so that might be an issue. I get now why you mentioned before that this is not a good group identifier. 