### PR TITLE
Tweaks of autocompletion behaviour

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,8 +17,10 @@ jobs:
       - name: Prepare dependencies
         run: |
           brew install sourcekitten
-          pip3 install mkdocs
-          pip3 install pymdown-extensions     
+          python --version
+          pip install --upgrade pip
+          pip install mkdocs
+          pip install pymdown-extensions     
 
       - name: Build docs
         run: |

--- a/Scripts/docs.sh
+++ b/Scripts/docs.sh
@@ -2,6 +2,13 @@
 # Bash script to update documentation
 
 (
+  # Checking that we have mkdocs
+  mkdocs --version
+  if [[ $? -ne 0 ]]; then
+    echo "mkdocs is missing. Check the logs and install it."
+    exit 1
+  fi
+
   # echo "Building TripKit docs..."
   ./docs_tripkit.sh
 

--- a/Sources/TripKit/helpers/TKJSONCache.swift
+++ b/Sources/TripKit/helpers/TKJSONCache.swift
@@ -27,7 +27,8 @@ public class TKJSONCache: TKFileCache {
         NSArray.self,
         NSDictionary.self,
         NSDate.self,
-        NSString.self
+        NSString.self,
+        NSNumber.self,
       ], from: data) as? [String: AnyObject]
     
     } catch {

--- a/Sources/TripKit/model/CoreData/Trip+CoreDataClass.swift
+++ b/Sources/TripKit/model/CoreData/Trip+CoreDataClass.swift
@@ -126,7 +126,11 @@ extension Trip {
   @discardableResult
   func calculateDuration() -> TimeInterval {
     let minutes = arrivalTime.minutesSince(departureTime)
-    self.minutes = Int16(min(Double(INT16_MAX), Double(minutes)))
+    
+    // This can occasionally happen due to bad real-time data
+    guard minutes >= Int16.min, minutes <= Int16.max else { return 0 }
+    
+    self.minutes = Int16(min(Double(Int16.max), Double(minutes)))
     return TimeInterval(minutes * 60)
   }
 }

--- a/Sources/TripKit/search/TKAppleGeocoder.swift
+++ b/Sources/TripKit/search/TKAppleGeocoder.swift
@@ -61,6 +61,10 @@ extension TKAppleGeocoder: TKAutocompleting {
   
   public func autocomplete(_ input: String, near mapRect: MKMapRect, completion: @escaping (Result<[TKAutocompletionResult], Error>) -> Void) {
     
+    guard !input.isEmpty else {
+      return completion(.success([]))
+    }
+    
     completerDelegate = LocalSearchCompleterDelegate { results in
       completion(results.map {
         $0.enumerated().map { TKAutocompletionResult($1, forInput: input, index: $0) }
@@ -76,6 +80,11 @@ extension TKAppleGeocoder: TKAutocompleting {
     } else {
       completer.filterType = .locationsOnly
     }
+  }
+  
+  public func cancelAutocompletion() {
+    completerDelegate = nil
+    completer.cancel()
   }
   
   public func annotation(for result: TKAutocompletionResult, completion: @escaping (Result<MKAnnotation?, Error>) -> Void) {

--- a/Sources/TripKit/search/TKGeocoding.swift
+++ b/Sources/TripKit/search/TKGeocoding.swift
@@ -43,7 +43,7 @@ public protocol TKAutocompleting {
   /// - Parameters:
   ///   - input: Query fragment typed by user
   ///   - mapRect: Last map rect the map view was zoomed to (can be `MKMapRectNull`)
-  ///   - completion: Handled called with the autocompletion results for query fragment. Should fire with empty result or error out if nothing found. Needs to be called.
+  ///   - completion: Handled called with the autocompletion results for query fragment. Should fire with empty result or error out if nothing found. Needs to be called, unless `cancelAutocompletion` was called.
   func autocomplete(_ input: String, near mapRect: MKMapRect, completion: @escaping (Result<[TKAutocompletionResult], Error>) -> Void)
   
   /// Called to fetch the annotation for a previously returned autocompletion result
@@ -51,6 +51,10 @@ public protocol TKAutocompleting {
   /// - Parameter result: The result for which to fetch the annotation
   /// - Parameter completion: Completion handler that's called with the annotation for the result, if representable as such. Called with `nil` if not representable, or can also be called with an error if it is representable but the conversion failed. Needs to be called.
   func annotation(for result: TKAutocompletionResult, completion: @escaping (Result<MKAnnotation?, Error>) -> Void)
+  
+  /// Called when previously requested autocompletion result is no longer relevant. Use this to clean
+  /// up resources.
+  func cancelAutocompletion()
   
   #if os(iOS) || os(tvOS)
   /// Text and action for an additional row to display in the results, e.g., to request
@@ -72,6 +76,8 @@ public enum TKAutocompletionSelection {
 }
 
 extension TKAutocompleting {
+  
+  public func cancelAutocompletion() {}
   
   #if os(iOS) || os(tvOS)
   public func additionalActionTitle() -> String? {

--- a/Sources/TripKitUI/controller/TKUIAutocompletionViewController.swift
+++ b/Sources/TripKitUI/controller/TKUIAutocompletionViewController.swift
@@ -108,7 +108,10 @@ public class TKUIAutocompletionViewController: UITableViewController {
     
     viewModel.triggerAction
       .asObservable()
-      .flatMapLatest { $0.triggerAdditional(presenter: self).asObservable() }
+      .flatMapLatest { [weak self] provider -> Observable<Bool> in
+        guard let self = self else { return .empty() }
+        return provider.triggerAdditional(presenter: self).asObservable()
+      }
       .subscribe()
       .disposed(by: disposeBag)
     

--- a/Sources/TripKitUI/helper/RxTripKit/TKGeocoding+Rx.swift
+++ b/Sources/TripKitUI/helper/RxTripKit/TKGeocoding+Rx.swift
@@ -60,7 +60,9 @@ public extension TKAutocompleting {
           subscriber(.failure(error))
         }
       }
-      return Disposables.create()
+      return Disposables.create {
+        self.cancelAutocompletion()
+      }
     }
   }
   
@@ -173,7 +175,7 @@ extension ObservableType {
       let merged = Observable.merge(observables)
         .scan(into: []) { $0.append(contentsOf: $1) }
         .map { $0.sorted(by: comparer) }
-        .share(replay: 1, scope: .forever)
+        .share(replay: 1, scope: .whileConnected)
       
       // ... This represents 1.: What are the best X results when the timer first?
       let timeOut = Observable<Int>.timer(cutOff, scheduler: SharingScheduler.make())

--- a/Sources/TripKitUI/helper/RxTripKit/TKGeocoding+Rx.swift
+++ b/Sources/TripKitUI/helper/RxTripKit/TKGeocoding+Rx.swift
@@ -177,7 +177,7 @@ extension ObservableType {
       let merged = Observable.merge(observables)
         .scan(into: []) { $0.append(contentsOf: $1) }
         .map { $0.sorted(by: comparer) }
-        .share(replay: 1, scope: .whileConnected)
+        .share(replay: 1, scope: .forever)
       
       // ... This represents 1.: What are the best X results when the timer first?
       let timeOut = Observable<Int>.timer(cutOff, scheduler: SharingScheduler.make())

--- a/Sources/TripKitUI/helper/RxTripKit/TKGeocoding+Rx.swift
+++ b/Sources/TripKitUI/helper/RxTripKit/TKGeocoding+Rx.swift
@@ -123,16 +123,18 @@ public extension Array where Element == TKAutocompleting {
   ///
   /// - Parameters:
   ///   - text: Input text, which should fire when user enters text
-  ///   - mapRect: Map rect to bias results towards
+  ///   - mapRect: Map rect to bias results towards, which should fire whenever map moves and
+  ///     provide an initial value
   /// - Returns: Stream of autocompletion results. For each input change, it
   ///     can fire multiple times as more results are found by different
   ///     providers (i.e., elements in this array).
-  func autocomplete(_ text: Observable<(String, forced: Bool)>, mapRect: MKMapRect) -> Observable<[TKAutocompletionResult]> {
+  func autocomplete(_ text: Observable<(String, forced: Bool)>, mapRect: Observable<MKMapRect>) -> Observable<[TKAutocompletionResult]> {
     
     return text
       .distinctUntilChanged( { $0.0 == $1.0 && $0.1 == $1.1} )
+      .withLatestFrom(mapRect) { ($0, $1) }
       .debounce(.milliseconds(200), scheduler: MainScheduler.asyncInstance)
-      .flatMapLatest { input -> Observable<[TKAutocompletionResult]> in
+      .flatMapLatest { input, mapRect -> Observable<[TKAutocompletionResult]> in
         let autocompletions = self.map { provider in
           provider
             .autocomplete(input.0, near: mapRect)

--- a/Sources/TripKitUI/view model/TKUIAutocompletionViewModel.swift
+++ b/Sources/TripKitUI/view model/TKUIAutocompletionViewModel.swift
@@ -162,8 +162,7 @@ extension TKUIAutocompletionViewModel {
     let searchTrigger = refresh.asObservable().startWith(())
 
     return searchTrigger
-      .withLatestFrom(biasMapRect)
-      .flatMapLatest { providers.autocomplete(searchText, mapRect: $0) }
+      .flatMapLatest { providers.autocomplete(searchText, mapRect: biasMapRect.asObservable()) }
       .map { $0.buildSections(includeCurrentLocation: includeCurrentLocation, includeAccessory: includeAccessory) + additionalSection }
   }
   

--- a/Sources/TripKitUI/view model/TKUIAutocompletionViewModel.swift
+++ b/Sources/TripKitUI/view model/TKUIAutocompletionViewModel.swift
@@ -159,13 +159,10 @@ extension TKUIAutocompletionViewModel {
       .map { Item.action($0) }
     let additionalSection = additionalItems.isEmpty ? [] : [Section(identifier: "actions", items: additionalItems, title: Loc.MoreResults)]
     
-    let searchTrigger: Observable<MKMapRect>
-      = Observable.combineLatest(
-        refresh.asObservable().startWith(()),
-        biasMapRect.asObservable()
-      ) { $1 }
+    let searchTrigger = refresh.asObservable().startWith(())
 
     return searchTrigger
+      .withLatestFrom(biasMapRect)
       .flatMapLatest { providers.autocomplete(searchText, mapRect: $0) }
       .map { $0.buildSections(includeCurrentLocation: includeCurrentLocation, includeAccessory: includeAccessory) + additionalSection }
   }

--- a/Tests/TripKitTests/Data/regions.json
+++ b/Tests/TripKitTests/Data/regions.json
@@ -1,4556 +1,6511 @@
 {
-  "hashCode": 1655272037,
   "modes": {
     "cy_bic": {
+      "title": "Bicycle",
       "color": {
-        "blue": 99,
+        "red": 0,
         "green": 180,
-        "red": 0
-      },
-      "title": "Bicycle"
+        "blue": 99
+      }
     },
     "cy_bic-s": {
+      "title": "Shared micromobility",
       "color": {
-        "blue": 99,
+        "red": 30,
         "green": 199,
-        "red": 30
-      },
-      "title": "Bike share"
-    },
-    "cy_bic-s_SoBi11": {
-      "URL": "http://coast.socialbicycles.com",
-      "color": {
-        "blue": 192,
-        "green": 157,
-        "red": 24
-      },
-      "title": "Coast Bike Share"
-    },
-    "cy_bic-s_SoBi124": {
-      "URL": "https://bikethetower.com/",
-      "color": {
-        "blue": 50,
-        "green": 32,
-        "red": 195
-      },
-      "title": "Tower Bridge Bike Share Preview"
-    },
-    "cy_bic-s_SoBi126": {
-      "color": {
-        "blue": 99,
-        "green": 199,
-        "red": 30
-      },
-      "title": "BTN BikeShare"
-    },
-    "cy_bic-s_SoBi20": {
-      "URL": "http://grid.socialbicycles.com",
-      "color": {
-        "blue": 39,
-        "green": 214,
-        "red": 67
-      },
-      "title": "Grid Bike Share"
-    },
-    "cy_bic-s_SoBi23": {
-      "URL": "https://juicebikeshare.com/",
-      "color": {
-        "blue": 23,
-        "green": 93,
-        "red": 231
-      },
-      "title": "Juice Bike Share"
-    },
-    "cy_bic-s_SoBi31": {
-      "URL": "http://relaybikeshare.com/",
-      "color": {
-        "blue": 128,
-        "green": 186,
-        "red": 75
-      },
-      "title": "Relay Bike Share"
-    },
-    "cy_bic-s_SoBi41": {
-      "URL": "https://velogo.ca/",
-      "color": {
-        "blue": 69,
-        "green": 152,
-        "red": 63
-      },
-      "title": "VeloGo"
-    },
-    "cy_bic-s_SoBi78": {
-      "URL": "https://reddybikeshare.socialbicycles.com",
-      "color": {
-        "blue": 50,
-        "green": 32,
-        "red": 195
-      },
-      "title": "Reddy bikeshare"
-    },
-    "cy_bic-s_SoBi92": {
-      "URL": "https://www.biketownpdx.com/",
-      "color": {
-        "blue": 2,
-        "green": 76,
-        "red": 252
-      },
-      "icon": "biketown",
-      "title": "BIKETOWNpdx"
-    },
-    "cy_bic-s_SoBi93": {
-      "URL": "http://uhbikes.com/",
-      "color": {
-        "blue": 0,
-        "green": 0,
-        "red": 255
-      },
-      "title": "UHBikes"
-    },
-    "cy_bic-s_arborbike": {
-      "URL": "http://arborbike.org/",
-      "color": {
-        "blue": 120,
-        "green": 36,
-        "red": 34
-      },
-      "title": "ArborBike"
-    },
-    "cy_bic-s_belfastbikes-belfast": {
-      "URL": "http://www.belfastbikes.co.uk/en/belfast/",
-      "color": {
-        "blue": 210,
-        "green": 208,
-        "red": 197
-      },
-      "title": "BelfastBikes"
-    },
-    "cy_bic-s_bergen-bysykkel": {
-      "color": {
-        "blue": 99,
-        "green": 199,
-        "red": 30
-      },
-      "title": "Bysykkel"
-    },
-    "cy_bic-s_bicing": {
-      "URL": "https://www.bicing.cat",
-      "color": {
-        "blue": 99,
-        "green": 199,
-        "red": 30
-      },
-      "title": "Bicing"
-    },
-    "cy_bic-s_bicloo": {
-      "URL": "http://www.bicloo.nantesmetropole.fr",
-      "color": {
-        "blue": 99,
-        "green": 199,
-        "red": 30
-      },
-      "title": "Bicloo"
-    },
-    "cy_bic-s_bikepoa": {
-      "URL": "https://www.mobilicidade.com.br/bikepoa.asp",
-      "color": {
-        "blue": 0,
-        "green": 153,
-        "red": 255
-      },
-      "title": "BikePOA"
-    },
-    "cy_bic-s_bixi-montreal": {
-      "URL": "http://montreal.bixi.com",
-      "color": {
-        "blue": 37,
-        "green": 49,
-        "red": 238
-      },
-      "icon": "bixi",
-      "title": "Bixi"
-    },
-    "cy_bic-s_bubi": {
-      "URL": "http://molbubi.bkk.hu",
-      "color": {
-        "blue": 99,
-        "green": 199,
-        "red": 30
-      },
-      "title": "MOL Bubi"
-    },
-    "cy_bic-s_bublr-bikes": {
-      "URL": "http://bublrbikes.com/",
-      "color": {
-        "blue": 234,
-        "green": 183,
-        "red": 26
-      },
-      "title": "Bublr Bikes"
-    },
-    "cy_bic-s_bycyklen": {
-      "URL": "https://bycyklen.dk/",
-      "color": {
-        "blue": 49,
-        "green": 102,
-        "red": 242
-      },
-      "title": "Bycyklen"
-    },
-    "cy_bic-s_bysykkelen": {
-      "URL": "http://bysykkelen.no/",
-      "color": {
-        "blue": 200,
-        "green": 11,
-        "red": 0
-      },
-      "title": "Bysykkelen"
-    },
-    "cy_bic-s_citybikes-helsinki": {
-      "URL": "https://www.hsl.fi/en/citybikes",
-      "color": {
-        "blue": 52,
-        "green": 188,
-        "red": 251
-      },
-      "title": "City bikes"
-    },
-    "cy_bic-s_citycycle": {
-      "URL": "http://www.citycycle.com.au",
-      "color": {
-        "blue": 99,
-        "green": 199,
-        "red": 30
-      },
-      "title": "CityCycle"
-    },
-    "cy_bic-s_cogo": {
-      "URL": "https://www.cogobikeshare.com/",
-      "color": {
-        "blue": 255,
-        "green": 255,
-        "red": 255
-      },
-      "title": "CoGo"
-    },
-    "cy_bic-s_decobike-san-diego": {
-      "URL": "http://www.decobike.com/sandiego/",
-      "color": {
-        "blue": 255,
-        "green": 255,
-        "red": 255
-      },
-      "title": "Decobike San Diego"
-    },
-    "cy_bic-s_divvy": {
-      "URL": "http://divvybikes.com",
-      "color": {
-        "blue": 240,
-        "green": 194,
-        "red": 81
-      },
-      "icon": "divvy",
-      "title": "Divvy"
-    },
-    "cy_bic-s_dublinbikes": {
-      "URL": "http://www.dublinbikes.ie",
-      "color": {
-        "blue": 210,
-        "green": 208,
-        "red": 197
-      },
-      "title": "dublinbikes"
-    },
-    "cy_bic-s_ecobici": {
-      "URL": "https://www.ecobici.df.gob.mx",
-      "color": {
-        "blue": 99,
-        "green": 199,
-        "red": 30
-      },
-      "title": "EcoBici"
-    },
-    "cy_bic-s_fortworth": {
-      "URL": "http://fortworthbikesharing.org",
-      "color": {
-        "blue": 170,
-        "green": 93,
-        "red": 0
-      },
-      "darkIcon": "bcycle-dark",
-      "icon": "bcycle",
-      "title": "Fort Worth Bike Sharing"
-    },
-    "cy_bic-s_goeteborg": {
-      "URL": "http://www.goteborgbikes.se/",
-      "color": {
-        "blue": 195,
-        "green": 144,
-        "red": 59
-      },
-      "title": "Styr & Ställ"
-    },
-    "cy_bic-s_greenbikeslc": {
-      "URL": "https://greenbikeslc.org/",
-      "color": {
-        "blue": 170,
-        "green": 93,
-        "red": 0
-      },
-      "darkIcon": "bcycle-dark",
-      "icon": "bcycle",
-      "title": "GREENbike"
-    },
-    "cy_bic-s_healthy-ride-pittsburgh-pittsburgh": {
-      "URL": "https://healthyridepgh.com/",
-      "color": {
-        "blue": 224,
-        "green": 171,
-        "red": 0
-      },
-      "title": "Healthy Ride"
-    },
-    "cy_bic-s_houston": {
-      "URL": "http://houston.bcycle.com/",
-      "color": {
-        "blue": 170,
-        "green": 93,
-        "red": 0
-      },
-      "darkIcon": "bcycle-dark",
-      "icon": "bcycle",
-      "title": "Houston B-cycle"
-    },
-    "cy_bic-s_hubway": {
-      "URL": "http://www.thehubway.com/",
-      "color": {
-        "blue": 66,
-        "green": 180,
-        "red": 70
-      },
-      "icon": "hubway",
-      "title": "Hubway"
-    },
-    "cy_bic-s_indego": {
-      "URL": "https://www.rideindego.com/",
-      "color": {
-        "blue": 203,
-        "green": 130,
-        "red": 0
-      },
-      "title": "Indego"
-    },
-    "cy_bic-s_indiana-pacers-bikeshare": {
-      "URL": "https://www.pacersbikeshare.org/",
-      "color": {
-        "blue": 99,
-        "green": 199,
-        "red": 30
-      },
-      "title": "Indiana Pacers Bikeshare"
-    },
-    "cy_bic-s_kansascity": {
-      "URL": "https://kansascity.bcycle.com/",
-      "color": {
-        "blue": 170,
-        "green": 93,
-        "red": 0
-      },
-      "darkIcon": "bcycle-dark",
-      "icon": "bcycle",
-      "title": "B-cycle"
-    },
-    "cy_bic-s_li-bia-velo": {
-      "URL": "http://www.libiavelo.be/",
-      "color": {
-        "blue": 221,
-        "green": 166,
-        "red": 0
-      },
-      "title": "Li bia velo"
-    },
-    "cy_bic-s_madison": {
-      "URL": "https://madison.bcycle.com/",
-      "color": {
-        "blue": 170,
-        "green": 93,
-        "red": 0
-      },
-      "darkIcon": "bcycle-dark",
-      "icon": "bcycle",
-      "title": "B-cycle"
-    },
-    "cy_bic-s_mobibikes": {
-      "URL": "https://www.mobibikes.ca/",
-      "color": {
-        "blue": 223,
-        "green": 171,
-        "red": 0
-      },
-      "title": "Mobi"
-    },
-    "cy_bic-s_nederland-maastricht": {
-      "color": {
-        "blue": 99,
-        "green": 199,
-        "red": 30
-      },
-      "title": "Nederland"
-    },
-    "cy_bic-s_nextbike-christchurch": {
-      "URL": "https://www.nextbike.co.nz/en/christchurch/",
-      "color": {
-        "blue": 166,
-        "green": 103,
-        "red": 30
-      },
-      "title": "Nextbike"
-    },
-    "cy_bic-s_nextbike-flensburg": {
-      "URL": "https://www.nextbike.de/flensburg/",
-      "color": {
-        "blue": 166,
-        "green": 103,
-        "red": 30
-      },
-      "title": "Nextbike"
-    },
-    "cy_bic-s_nextbike-university-of-warwick": {
-      "URL": "http://www.nextbike.co.uk/en/university-of-warwick/",
-      "color": {
-        "blue": 166,
-        "green": 103,
-        "red": 30
-      },
-      "title": "Nextbike"
-    },
-    "cy_bic-s_nextbike-victoria": {
-      "color": {
-        "blue": 99,
-        "green": 199,
-        "red": 30
-      },
-      "title": "Nextbike"
-    },
-    "cy_bic-s_nice-ride": {
-      "URL": "http://www.niceridemn.org",
-      "color": {
-        "blue": 56,
-        "green": 213,
-        "red": 187
-      },
-      "icon": "niceride",
-      "title": "Nice Ride"
-    },
-    "cy_bic-s_pronto-cycle-share": {
-      "URL": "http://www.prontocycleshare.com/",
-      "color": {
-        "blue": 99,
-        "green": 199,
-        "red": 30
-      },
-      "title": "Pronto Cycle Share"
-    },
-    "cy_bic-s_santiago": {
-      "URL": "http://www.bikesantiago.cl/",
-      "color": {
-        "blue": 25,
-        "green": 154,
-        "red": 255
-      },
-      "title": "Bike Santiago"
-    },
-    "cy_bic-s_sixt-jalgrattarent-tallinn": {
-      "color": {
-        "blue": 99,
-        "green": 199,
-        "red": 30
-      },
-      "title": "SIXT jalgrattarent"
-    },
-    "cy_bic-s_sixt-riga": {
-      "color": {
-        "blue": 99,
-        "green": 199,
-        "red": 30
-      },
-      "title": "SiXT"
-    },
-    "cy_bic-s_telofun": {
-      "URL": "https://www.tel-o-fun.co.il/",
-      "color": {
-        "blue": 65,
-        "green": 194,
-        "red": 137
-      },
-      "title": "Tel-O-Fun"
-    },
-    "cy_bic-s_velo": {
-      "URL": "http://www.velo.toulouse.fr",
-      "color": {
-        "blue": 99,
-        "green": 199,
-        "red": 30
-      },
-      "title": "Vélô"
+        "blue": 99
+      }
     },
     "in_air": {
+      "title": "Flight",
+      "subtitle": "Flight",
+      "icon": "aeroplane",
       "color": {
-        "blue": 99,
+        "red": 0,
         "green": 180,
-        "red": 0
+        "blue": 99
       },
-      "title": "Flight"
+      "isTemplate": true
     },
     "me_car": {
+      "title": "Car",
       "color": {
-        "blue": 240,
+        "red": 66,
         "green": 149,
-        "red": 66
-      },
-      "title": "Car"
+        "blue": 240
+      }
+    },
+    "me_car-s": {
+      "title": "Car-sharing",
+      "color": {
+        "red": 115,
+        "green": 169,
+        "blue": 243
+      }
     },
     "me_car-s_Carrot": {
-      "URL": "http://www.carrot.mx/",
-      "color": {
-        "blue": 33,
-        "green": 155,
-        "red": 246
-      },
+      "title": "Carrot",
+      "subtitle": "Car-sharing",
       "icon": "carrot",
-      "title": "Carrot"
+      "color": {
+        "red": 246,
+        "green": 155,
+        "blue": 33
+      },
+      "URL": "http://www.carrot.mx/",
+      "isBranding": true
+    },
+    "me_car-s_MODO": {
+      "title": "Modo",
+      "subtitle": "Car-sharing",
+      "icon": "modo",
+      "color": {
+        "red": 239,
+        "green": 62,
+        "blue": 54
+      },
+      "URL": "https://modo.coop/",
+      "isBranding": true
     },
     "me_mot": {
+      "title": "Motorbike",
       "color": {
-        "blue": 199,
+        "red": 46,
         "green": 196,
-        "red": 46
-      },
-      "title": "Motorbike"
-    },
-    "ps_shu": {
-      "URL": "http://www.jayride.com.au/",
-      "color": {
-        "blue": 60,
-        "green": 123,
-        "red": 233
-      },
-      "implies": [
-                  "ps_tax"
-                  ],
-      "title": "Shuttle"
+        "blue": 199
+      }
     },
     "ps_tax": {
+      "title": "Taxi",
       "color": {
-        "blue": 62,
+        "red": 221,
         "green": 202,
-        "red": 221
+        "blue": 62
+      }
+    },
+    "ps_tnc_alula-jeeny": {
+      "title": "Jeeny",
+      "subtitle": "Ride-hailing",
+      "icon": "alula-jeeny",
+      "color": {
+        "red": 102,
+        "green": 74,
+        "blue": 145
       },
-      "title": "Taxi"
+      "URL": "https://jeeny.me/ar",
+      "isBranding": true
+    },
+    "ps_tnc_alula-lamar": {
+      "title": "Lamar company",
+      "subtitle": "Ride-hailing",
+      "icon": "alula-lamar",
+      "color": {
+        "red": 114,
+        "green": 50,
+        "blue": 47
+      },
+      "URL": "mailto:it@lamarltd.sd",
+      "isBranding": true
+    },
+    "pt_ltd_MON": {
+      "title": "Inter-campus bus",
+      "subtitle": "Private transit",
+      "color": {
+        "red": 45,
+        "green": 197,
+        "blue": 104
+      },
+      "implies": [
+        "pt_pub"
+      ],
+      "URL": "https://www.monash.edu/people/transport-parking/inter-campus-shuttle-bus"
     },
     "pt_ltd_SCHOOLBUS": {
-      "color": {
-        "blue": 104,
-        "green": 197,
-        "red": 45
-      },
+      "title": "School bus",
+      "subtitle": "Private transit",
       "icon": "school-bus",
+      "color": {
+        "red": 45,
+        "green": 197,
+        "blue": 104
+      },
       "implies": [
-                  "pt_pub"
-                  ],
-      "title": "School bus"
+        "pt_pub"
+      ],
+      "isTemplate": true
     },
     "pt_pub": {
+      "title": "Public transport",
       "color": {
-        "blue": 104,
+        "red": 45,
         "green": 197,
-        "red": 45
-      },
-      "title": "Public transport"
+        "blue": 104
+      }
     },
     "wa_wal": {
+      "title": "Walking",
       "color": {
-        "blue": 99,
+        "red": 30,
         "green": 199,
-        "red": 30
+        "blue": 99
       },
-      "required": true,
-      "title": "Walking"
+      "required": true
     },
     "wa_whe": {
+      "title": "Wheelchair",
       "color": {
-        "blue": 240,
+        "red": 66,
         "green": 149,
-        "red": 66
-      },
-      "title": "Wheelchair"
+        "blue": 240
+      }
     }
   },
   "regions": [
-              {
-              "cities": [
-                         {
-                         "lat": 49.916,
-                         "lng": -97.13,
-                         "timezone": "America/Winnipeg",
-                         "title": "Winnipeg, MB, Canada"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "CA_MB_Winnipeg",
-              "polygon": "_`jnH~lnqQ_ry@??_t`B~qy@?",
-              "timezone": "America/Winnipeg",
-              "urls": [
-                       "https://baryogenesis-ca-mb-winnipeg-tripgo.skedgo.com/satapp",
-                       "https://matter-ca-mb-winnipeg-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 37.77952,
-                         "lng": -122.41379,
-                         "timezone": "America/Los_Angeles",
-                         "title": "San Francisco, CA, USA"
-                         },
-                         {
-                         "lat": 37.33661,
-                         "lng": -121.88573,
-                         "timezone": "America/Los_Angeles",
-                         "title": "San Jose, CA, USA"
-                         },
-                         {
-                         "lat": 37.80302,
-                         "lng": -122.27025,
-                         "timezone": "America/Los_Angeles",
-                         "title": "Oakland, CA, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s",
-                        "wa_wal"
-                        ],
-              "name": "US_CA_SanFrancisco",
-              "polygon": "og|_F~}inVotfG??_owHntfG?",
-              "timezone": "America/Los_Angeles",
-              "urls": [
-                       "https://baryogenesis-us-ca-sanfrancisco-tripgo.skedgo.com/satapp",
-                       "https://stars-us-ca-sanfrancisco-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 42.33693,
-                         "lng": -83.0507,
-                         "timezone": "US/Eastern",
-                         "title": "Detroit, MI, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "US_MI_Detroit",
-              "polygon": "ixvaGz~u{NonJ{wF}iDqqRb{@}j_At~Szv@r}Obyd@ncG~aOkbWrne@",
-              "timezone": "US/Eastern",
-              "urls": [
-                       "https://inflationary-us-mi-detroit-tripgo.skedgo.com/satapp",
-                       "https://matter-us-mi-detroit-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 55.67577,
-                         "lng": 12.57073,
-                         "timezone": "Europe/Copenhagen",
-                         "title": "Copenhagen, Denmark"
-                         },
-                         {
-                         "lat": 55.40378,
-                         "lng": 10.40354,
-                         "timezone": "Europe/Copenhagen",
-                         "title": "Odense, Denmark"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_bycyklen",
-                        "wa_wal"
-                        ],
-              "name": "DK_Islands",
-              "polygon": "ozboImvf{@owsA|`f@o{K?_`qAo_eD_ieA_nbJ~wq@ovs@ndkA_xq@nu~A~iZ_{m@_{dL~kaA_hpBn`zBn}zF~eiA~whLoxzA~axBoqP~qvD",
-              "timezone": "Europe/Copenhagen",
-              "urls": [
-                       "https://matter-dk-islands-tripgo.skedgo.com/satapp",
-                       "https://granduni-dk-islands-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 51.81317,
-                         "lng": 5.83541,
-                         "timezone": "Europe/Amsterdam",
-                         "title": "Nijmegen, Netherlands"
-                         },
-                         {
-                         "lat": 52.21003,
-                         "lng": 5.96798,
-                         "timezone": "Europe/Amsterdam",
-                         "title": "Apeldoorn, Netherlands"
-                         },
-                         {
-                         "lat": 51.98436,
-                         "lng": 5.90104,
-                         "timezone": "Europe/Amsterdam",
-                         "title": "Arnhem, Netherlands"
-                         },
-                         {
-                         "lat": 52.22096,
-                         "lng": 6.89548,
-                         "timezone": "Europe/Amsterdam",
-                         "title": "Enschede, Netherlands"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "NL_Gelderland",
-              "polygon": "okb`Io_p_@?sapGh{BhJt`DqmH|~@zi@{d@rsFr{Att@qRnwDbuCq}BzdF~k@xjC}|JhQ_oPflC}lPaeDgbEej@chB~~KybHnZqhDnkGg{A`bHfbE`jCl{BfeEycBliB}pCro@|Zv~@xgF{HrgEh@?~|G~gGvT|zE~{BxjE~`Dfn@naAllBpK~eB_CdvNvdEpe@vnAhyBtZ|hFxoDrt@}BasCfhAoqFrwE}cNr`EwXhc@ruEpyDzZpaE||JzNxtAwbClpFt_BdhHbxB|fMprDhrPmg@zwF{eAvuFbd@lS|w@khC|}D`@cf@~xFmhBj`LqzBvn@ki@|qCvh@r{@pF|rHio@v_C}aAn~Aae@kw@{z@~lBnSbWuk@du@jh@neE{Phh@jd@~r@`n@urDhcB}i@~s@}iCnkClE_v@n_Mc~A|dE|gA`l@||@jzBzqAbqG{TnjCqOdn@h|@ppAneF_yF`mC{a@i@vaaC",
-              "timezone": "Europe/Amsterdam",
-              "urls": [
-                       "https://hadron-nl-gelderland-tripgo.skedgo.com/satapp",
-                       "https://darkages-nl-gelderland-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 42.84634,
-                         "lng": -2.67251,
-                         "timezone": "Europe/Madrid",
-                         "title": "Vitoria Gasteiz, Spain"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "ES_PV_VitoriaGasteiz",
-              "polygon": "o}idGbezOsgO??w_ZrgO?",
-              "timezone": "Europe/Madrid",
-              "urls": [
-                       "https://matter-es-pv-vitoriagasteiz-tripgo.skedgo.com/satapp",
-                       "https://granduni-es-pv-vitoriagasteiz-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 60.173,
-                         "lng": 24.941,
-                         "timezone": "Europe/Helsinki",
-                         "title": "Helsinki, Finland"
-                         },
-                         {
-                         "lat": 60.98266,
-                         "lng": 25.66113,
-                         "timezone": "Europe/Helsinki",
-                         "title": "Lahti, Finland"
-                         },
-                         {
-                         "lat": 60.86823,
-                         "lng": 26.70358,
-                         "timezone": "Europe/Helsinki",
-                         "title": "Kouvola, Finland"
-                         },
-                         {
-                         "lat": 60.99305,
-                         "lng": 24.46072,
-                         "timezone": "Europe/Helsinki",
-                         "title": "Hämeenlinna, Finland"
-                         },
-                         {
-                         "lat": 61.05548,
-                         "lng": 28.1892,
-                         "timezone": "Europe/Helsinki",
-                         "title": "Lappeenranta, Finland"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_citybikes-helsinki",
-                        "wa_wal"
-                        ],
-              "name": "FI_SouthFinland",
-              "polygon": "_~rkJoyfiC_uu@_mVotLoaoAnzD_`qA_{m@ovs@_}tAnu~AokXoqmC_xq@oqPoh\\_ry@o|k@_xnD_~i@oyo@nxzAo~oE_yFop{@nqPojcA_xq@n_h@ozDoe`@~oR_ieAoggAou{EnkX_ieA_jZ_vJoqP_uu@_mVojcAn|k@_ieA~lpG~zdL~yxA~olG",
-              "timezone": "Europe/Helsinki",
-              "urls": [
-                       "https://matter-fi-southfinland-tripgo.skedgo.com/satapp",
-                       "https://granduni-fi-southfinland-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 53.21946,
-                         "lng": 6.56684,
-                         "timezone": "Europe/Amsterdam",
-                         "title": "Groningen, Netherlands"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "NL_NorthNetherlands",
-              "polygon": "sv_fIulo_@r]ue{E|wCikSh{HqzbAvs[kcKxfCgpKbqCuaYziHcvHrvN}pCt~KxlDtpScyA~vJfsDv~YleV~k_@bjAv|AzaCykAf_Lhk@rkIcmAnyChMbhYpdB~dH~cAurAleBlc@?nxoG",
-              "timezone": "Europe/Amsterdam",
-              "urls": [
-                       "https://hadron-nl-northnetherlands-tripgo.skedgo.com/satapp",
-                       "https://darkages-nl-northnetherlands-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 19.4284,
-                         "lng": -99.1276,
-                         "timezone": "America/Mexico_City",
-                         "title": "Mexico City, Mexico"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_car-s_Carrot",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_ecobici",
-                        "wa_wal"
-                        ],
-              "name": "MX_DIF_MexicoCity",
-              "polygon": "wdntBnk{}QcdnA??_r_CbdnA?",
-              "timezone": "America/Mexico_City",
-              "urls": [
-                       "https://inflationary-mx-dif-mexicocity-tripgo.skedgo.com/satapp",
-                       "https://granduni-mx-dif-mexicocity-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 48.8545,
-                         "lng": 2.33686,
-                         "timezone": "Europe/Paris",
-                         "title": "Paris, France"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s",
-                        "wa_wal"
-                        ],
-              "name": "FR_J_Paris",
-              "polygon": "ogpjHeoaKakFgtcArwJ}uu@jq_@}nr@xnm@z~eButGlpz@",
-              "timezone": "Europe/Paris",
-              "urls": [
-                       "https://matter-fr-j-paris-tripgo.skedgo.com/satapp",
-                       "https://darkages-fr-j-paris-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 50.41203,
-                         "lng": 4.44362,
-                         "timezone": "Europe/Brussels",
-                         "title": "Charleroi, Belgium"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "BE_SouthWestBelgium",
-              "polygon": "w|xtHugo\\byrB?rxPl}XzqNf`@xiHzla@hlAvtL}}Ap`SwyA~jFhlAbcUm~CtjJo}Fnc@y{D}_DexBwfL{mFdaEmmCgBzPxsGqg@bcDuvNeuCerGakL}|AzyEj`B~eBjKpxDsoI|mJieGxnI`fDr`YyaCj~FnDxgFuLprLldFvu@bu@vnCehDrsFw_GvbBawOtWyzErbG`_@nyTyyApV{}Bm{BsfAdmFf}ClgD~cBpoMgfEdeOecA|dBk_Ol{BeqHlxCmwAu~BqzDnr@_PvuF_zAn~Ak}AtW{vBz|A",
-              "timezone": "Europe/Brussels",
-              "urls": [
-                       "https://hadron-be-southwestbelgium-tripgo.skedgo.com/satapp",
-                       "https://darkages-be-southwestbelgium-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 59.9233,
-                         "lng": 10.79249,
-                         "timezone": "Europe/Oslo",
-                         "title": "Oslo, Norway"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s",
-                        "wa_wal"
-                        ],
-              "name": "NO_Oslo",
-              "polygon": "q|plJe~dv@}oEqccDwpaEehN_Wo`sMdbw@c|_Ab_`BxpNhst@ftcAbzCntm@l~\\ka@djPrwg@pkbAmnMx{hAl_d@ft@rlq@exc@rtW~qWllgAhcM~agEdqSnvlB",
-              "timezone": "Europe/Oslo",
-              "urls": [
-                       "https://matter-no-oslo-tripgo.skedgo.com/satapp",
-                       "https://darkages-no-oslo-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 42.36071,
-                         "lng": -71.0577,
-                         "timezone": "America/New_York",
-                         "title": "Boston, MA, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_hubway",
-                        "wa_wal"
-                        ],
-              "name": "US_MA_Boston",
-              "polygon": "ovg|Ft}aqLab\\zcB}oZxkg@icQ{KotB_Ud^bjGoi|C?sle@{sdAi[qbaFdvcI??`diF",
-              "timezone": "America/New_York",
-              "urls": [
-                       "https://inflationary-us-ma-boston-tripgo.skedgo.com/satapp",
-                       "https://matter-us-ma-boston-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 57.70723,
-                         "lng": 11.96702,
-                         "timezone": "Europe/Stockholm",
-                         "title": "Gothenburg, Sweden"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_goeteborg",
-                        "wa_wal"
-                        ],
-              "name": "SE_Gothenburg",
-              "polygon": "uzrbJqjfwBrhfGjvI?`r}p@shfG|nr@",
-              "timezone": "Europe/Stockholm",
-              "urls": [
-                       "https://matter-se-gothenburg-tripgo.skedgo.com/satapp",
-                       "https://darkages-se-gothenburg-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 39.953,
-                         "lng": -75.164,
-                         "timezone": "America/New_York",
-                         "title": "Philadelphia, PA, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_indego",
-                        "wa_wal"
-                        ],
-              "name": "US_PA_Philadelphia",
-              "polygon": "oiwpFnhzlMotiC??o~oEntiC?",
-              "timezone": "America/New_York",
-              "urls": [
-                       "https://inflationary-us-pa-philadelphia-tripgo.skedgo.com/satapp",
-                       "https://darkages-us-pa-philadelphia-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 30.263,
-                         "lng": -97.741,
-                         "timezone": "America/Chicago",
-                         "title": "Austin, TX, USA"
-                         },
-                         {
-                         "lat": 29.425,
-                         "lng": -98.495,
-                         "timezone": "America/Chicago",
-                         "title": "San Antonio, TX, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s",
-                        "wa_wal"
-                        ],
-              "name": "US_TX_Austin",
-              "polygon": "ohuoD~|f{Q_brJ??_brJ~arJ?",
-              "timezone": "America/Chicago",
-              "urls": [
-                       "https://inflationary-us-tx-austin-tripgo.skedgo.com/satapp",
-                       "https://darkages-us-tx-austin-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 41.87811,
-                         "lng": -87.6298,
-                         "timezone": "America/Chicago",
-                         "title": "Chicago, IL, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_divvy",
-                        "wa_wal"
-                        ],
-              "name": "US_IL_Chicago",
-              "polygon": "}ka{F~ek|OakiF??_kiF`kiF?",
-              "timezone": "America/Chicago",
-              "urls": [
-                       "https://baryogenesis-us-il-chicago-tripgo.skedgo.com/satapp",
-                       "https://hadron-us-il-chicago-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 42.26816,
-                         "lng": -83.73123,
-                         "timezone": "US/Eastern",
-                         "title": "Ann Arbor, MI, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_arborbike",
-                        "wa_wal"
-                        ],
-              "name": "US_MI_AnnArbor",
-              "polygon": "wdmaGrp~}NkEm{p@f~M_fBjEurXvnNgCdB~c_BuqO?aRrlq@yhJ{K",
-              "timezone": "US/Eastern",
-              "urls": [
-                       "https://inflationary-us-mi-annarbor-tripgo.skedgo.com/satapp",
-                       "https://matter-us-mi-annarbor-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 41.877,
-                         "lng": 12.481,
-                         "timezone": "Europe/Rome",
-                         "title": "Rome, Italy"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s",
-                        "wa_wal"
-                        ],
-              "name": "IT_Rome",
-              "polygon": "o_hzFokbfAoalE??o|eHnalE?",
-              "timezone": "Europe/Rome",
-              "urls": [
-                       "https://matter-it-rome-tripgo.skedgo.com/satapp",
-                       "https://darkages-it-rome-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 46.814,
-                         "lng": -71.241,
-                         "timezone": "Canada/Eastern",
-                         "title": "Quebec City, QC, Canada"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "CA_QC_QuebecCity",
-              "polygon": "_`yzG~j_tL_t`B??}ugC~s`B?",
-              "timezone": "Canada/Eastern",
-              "urls": [
-                       "https://baryogenesis-ca-qc-quebeccity-tripgo.skedgo.com/satapp",
-                       "https://matter-ca-qc-quebeccity-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 47.616,
-                         "lng": -122.327,
-                         "timezone": "US/Pacific",
-                         "title": "Seattle, WA, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_pronto-cycle-share",
-                        "wa_wal"
-                        ],
-              "name": "US_WA_Seattle",
-              "polygon": "_b`|G~n}nV_~cH??_owH~}cH?",
-              "timezone": "US/Pacific",
-              "urls": [
-                       "https://baryogenesis-us-wa-seattle-tripgo.skedgo.com/satapp",
-                       "https://hadron-us-wa-seattle-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 45.525,
-                         "lng": -122.676,
-                         "timezone": "US/Pacific",
-                         "title": "Portland, OR, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_SoBi92",
-                        "wa_wal"
-                        ],
-              "name": "US_OR_Portland",
-              "polygon": "_ur~F~~uxVootY??_pcSnotY?",
-              "timezone": "US/Pacific",
-              "urls": [
-                       "https://inflationary-us-or-portland-tripgo.skedgo.com/satapp",
-                       "https://matter-us-or-portland-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 51.519,
-                         "lng": -0.118,
-                         "timezone": "Europe/London",
-                         "title": "London, UK"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s",
-                        "wa_wal"
-                        ],
-              "name": "UK_London",
-              "polygon": "owxwH~dtB_t`B??_ibE~s`B?",
-              "timezone": "Europe/London",
-              "urls": [
-                       "https://hadron-uk-london-tripgo.skedgo.com/satapp",
-                       "https://stars-uk-london-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 53.8,
-                         "lng": -1.54,
-                         "timezone": "Europe/London",
-                         "title": "Leeds, UK"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "UK_Leeds",
-              "polygon": "_{qhI~cyK?o`qNnljB??n`qN",
-              "timezone": "Europe/London",
-              "urls": [
-                       "https://stars-uk-leeds-tripgo.skedgo.com/satapp",
-                       "https://inflationary-uk-leeds-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 42.10101,
-                         "lng": -72.58701,
-                         "timezone": "America/New_York",
-                         "title": "Springfield, MA, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "US_MA_Springfield",
-              "polygon": "y`{_Gpbt_Mwm`C}`o@l|H}knJ`{cCkCd`AtrpA{qAiC_G``zC{qAfrPq@dnMxkEbx@`b@x_IieFoUedBpkvBbFpaM",
-              "timezone": "America/New_York",
-              "urls": [
-                       "https://inflationary-us-ma-springfield-tripgo.skedgo.com/satapp",
-                       "https://matter-us-ma-springfield-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 38.20143,
-                         "lng": -85.73394,
-                         "timezone": "America/Kentucky/Louisville",
-                         "title": "Louisville, KY, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "US_KY_Louisville",
-              "polygon": "ahpfFd}}kO}zaB??qbeC|zaB?",
-              "timezone": "America/Kentucky/Louisville",
-              "urls": [
-                       "https://baryogenesis-us-ky-louisville-tripgo.skedgo.com/satapp",
-                       "https://inflationary-us-ky-louisville-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 50.91059,
-                         "lng": -1.40095,
-                         "timezone": "Europe/London",
-                         "title": "Southampton, UK"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_SoBi126",
-                        "wa_wal"
-                        ],
-              "name": "UK_SouthEastEngland",
-              "polygon": "_pbxH~_kI?__pR~f{C??~~oR",
-              "timezone": "Europe/London",
-              "urls": [
-                       "https://hadron-uk-southeastengland-tripgo.skedgo.com/satapp",
-                       "https://stars-uk-southeastengland-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 28.54212,
-                         "lng": -81.37905,
-                         "timezone": "US/Eastern",
-                         "title": "Orlando, FL, USA"
-                         },
-                         {
-                         "lat": 28.40383,
-                         "lng": -80.59868,
-                         "timezone": "US/Eastern",
-                         "title": "Space Coast, FL, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_SoBi23",
-                        "wa_wal"
-                        ],
-              "name": "US_FL_Orlando",
-              "polygon": "}e~hD|adrNy_iE??qoyFx_iE?",
-              "timezone": "US/Eastern",
-              "urls": [
-                       "https://inflationary-us-fl-orlando-tripgo.skedgo.com/satapp",
-                       "https://matter-us-fl-orlando-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 51.45545,
-                         "lng": -2.59159,
-                         "timezone": "Europe/London",
-                         "title": "Bristol, UK"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "UK_Bristol",
-              "polygon": "oro~H~kuP?_||F~yuE??~{|F",
-              "timezone": "Europe/London",
-              "urls": [
-                       "https://stars-uk-bristol-tripgo.skedgo.com/satapp",
-                       "https://inflationary-uk-bristol-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": -37.81137,
-                         "lng": 144.97183,
-                         "timezone": "Australia/Melbourne",
-                         "title": "Melbourne, VIC, Australia"
-                         },
-                         {
-                         "lat": -38.1489,
-                         "lng": 144.36103,
-                         "timezone": "Australia/Melbourne",
-                         "title": "Geelong, VIC, Australia"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "ps_shu",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s",
-                        "wa_wal"
-                        ],
-              "name": "AU_VIC_Melbourne",
-              "polygon": "hfcnEgrj{Y`qd@eeqBctKww\\eMkb_AlpPq~j@rn^o_d@z_k@q|H~ab@_bOaoh@iyYbMirVpeTapJlrGwvn@vcVqpo@|vc@hhCj~d@apJd~@}re@daYewB`zi@mhtAzil@wr{@xkZghNttc@yn}@w_m@mu[{oJ}oUuo@a{|AzzXuyiArbMykx@sbM_`~@~aW}xeAaf[{byAk`Bi{fA~a\\}j_AxgvB_og@f}WzlPrzjCmkmJtvyIbcJ?npav@",
-              "timezone": "Australia/Melbourne",
-              "urls": [
-                       "https://granduni-au-vic-melbourne-tripgo.skedgo.com/satapp",
-                       "https://darkages-au-vic-melbourne-tripgo.skedgo.com/satapp",
-                       "https://inflationary-au-vic-melbourne-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 48.392,
-                         "lng": -89.249,
-                         "timezone": "America/Thunder_Bay",
-                         "title": "Thunder Bay, ON, Canada"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "CA_ON_ThunderBay",
-              "polygon": "osveH~xbbPop{@??oweCnp{@?",
-              "timezone": "America/Thunder_Bay",
-              "urls": [
-                       "https://baryogenesis-ca-on-thunderbay-tripgo.skedgo.com/satapp",
-                       "https://matter-ca-on-thunderbay-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": -41.27845,
-                         "lng": 174.7791,
-                         "timezone": "NZ",
-                         "title": "Wellington, New Zealand"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "NZ_N_Wellington",
-              "polygon": "~~auF_}dh`@?~_nE_nbJ??_m~^~ocS??~koX",
-              "timezone": "NZ",
-              "urls": [
-                       "https://darkages-nz-n-wellington-tripgo.skedgo.com/satapp",
-                       "https://granduni-nz-n-wellington-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 52.63098,
-                         "lng": 1.29705,
-                         "timezone": "Europe/London",
-                         "title": "Norwich, UK"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "UK_Norwich",
-              "polygon": "_tpzH_ry@?~qy@_||F??_seKnxtI??~_kI",
-              "timezone": "Europe/London",
-              "urls": [
-                       "https://hadron-uk-norwich-tripgo.skedgo.com/satapp",
-                       "https://stars-uk-norwich-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 47.36856,
-                         "lng": 8.54044,
-                         "timezone": "Europe/Zurich",
-                         "title": "Zurich, Switzerland"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "CH_Zurich",
-              "polygon": "wttaHegcn@qyl@snlDj~cAoquE|kr@~[nlD~cbK",
-              "timezone": "Europe/Zurich",
-              "urls": [
-                       "https://matter-ch-zurich-tripgo.skedgo.com/satapp",
-                       "https://darkages-ch-zurich-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 52.48603,
-                         "lng": -1.89261,
-                         "timezone": "Europe/London",
-                         "title": "Birmingham, UK"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_nextbike-university-of-warwick",
-                        "wa_wal"
-                        ],
-              "name": "UK_Birmingham",
-              "polygon": "_qnbI~kuP?_~cH~ugC??~}cH",
-              "timezone": "Europe/London",
-              "urls": [
-                       "https://stars-uk-birmingham-tripgo.skedgo.com/satapp",
-                       "https://inflationary-uk-birmingham-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 44.977,
-                         "lng": -93.2746,
-                         "timezone": "America/Chicago",
-                         "title": "Minneapolis, MN, USA"
-                         },
-                         {
-                         "lat": 44.954,
-                         "lng": -93.0901,
-                         "timezone": "America/Chicago",
-                         "title": "St Paul, MN, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_nice-ride",
-                        "wa_wal"
-                        ],
-              "name": "US_MN_Minneapolis",
-              "polygon": "_{~mG~nd_Q_mpG??oihJ~lpG?",
-              "timezone": "America/Chicago",
-              "urls": [
-                       "https://inflationary-us-mn-minneapolis-tripgo.skedgo.com/satapp",
-                       "https://matter-us-mn-minneapolis-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": -33.44863,
-                         "lng": -70.66269,
-                         "timezone": "America/Santiago",
-                         "title": "Santiago, Chile"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_santiago",
-                        "wa_wal"
-                        ],
-              "name": "CL_SA_Santiago",
-              "polygon": "`~plErwuoLogiA??_hrAngiA?",
-              "timezone": "America/Santiago",
-              "urls": [
-                       "https://inflationary-cl-sa-santiago-tripgo.skedgo.com/satapp",
-                       "https://granduni-cl-sa-santiago-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 41.82399,
-                         "lng": -71.41283,
-                         "timezone": "US/Eastern",
-                         "title": "Providence, RI, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "US_RI_Providence",
-              "polygon": "odg{FpixuLm_AguI_zMvu@kf@cgHctqBvIceAyfqAtoWcAws@ezG|oRchBndZcyc@pe`@weAfkbArgpAdcB~aOih`@~qw@",
-              "timezone": "US/Eastern",
-              "urls": [
-                       "https://baryogenesis-us-ri-providence-tripgo.skedgo.com/satapp",
-                       "https://inflationary-us-ri-providence-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 40.415,
-                         "lng": -3.707,
-                         "timezone": "Europe/Madrid",
-                         "title": "Madrid, Spain"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s",
-                        "wa_wal"
-                        ],
-              "name": "ES_MD_Madrid",
-              "polygon": "oittFntzV_o}@??_cmA~n}@?",
-              "timezone": "Europe/Madrid",
-              "urls": [
-                       "https://matter-es-md-madrid-tripgo.skedgo.com/satapp",
-                       "https://granduni-es-md-madrid-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 51.44128,
-                         "lng": 5.47564,
-                         "timezone": "Europe/Amsterdam",
-                         "title": "Eindhoven, Netherlands"
-                         },
-                         {
-                         "lat": 51.56101,
-                         "lng": 5.09225,
-                         "timezone": "Europe/Amsterdam",
-                         "title": "Tilburg, Netherlands"
-                         },
-                         {
-                         "lat": 51.58912,
-                         "lng": 4.77579,
-                         "timezone": "Europe/Amsterdam",
-                         "title": "Breda, Netherlands"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "pt_ltd_SCHOOLBUS",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_nederland-maastricht",
-                        "wa_wal"
-                        ],
-              "name": "NL_SouthNetherlands",
-              "polygon": "wh_{HohmS?sjbO`y@ok@rfBvfFbl@mEhDk~FzkC{`It_GtrAleC_`PtfHzpC|zF}mJziG}dHfrH}pC`cMv_ClT{aCvvFhCpnDlsElLzpCx_Jn`GxqEdeIzoB_hAneHja@edCgwNfbAwpBnkE~Md_HdaVdnDjaL~eGbqDnk@b`EywDv}C~sAnqF|uFe~EbaDdPsfAgiHng@}tMjjHl`A`aB{bNlaG`]rfFl}Acq@feDdu@vzDxvCknA|zC`nElgBeaEn`Dha@hO|bTq_@|~`@~@b}KsfI{tAybA`zFw|D~eBemC{K}yPypNabMquE_ePwmImmBmdEujBppAzt@liIc~DtcAcOpqR_qF~fSy{Gnr@chDvmIbsEh}L`Gptb@{lApnBwuEor@abAfuCj_AtfF}q@vfFqyNvtLgmFy{DirEtaBiDvfF~eN~hR}aA~{\\o_CxbHuzImwO}yB~zKpgM|mPlZ~qZahJlTvdDncWh~No~GbbBliIwQdcJgzB|i@jL|zK~fNnuPz{HzsS~cHrd]ez@f}WgaHlTw`Ghg`@nzB~_Pj`EucA|a@roSicFfaKcgFdfCaeK{H",
-              "timezone": "Europe/Amsterdam",
-              "urls": [
-                       "https://hadron-nl-southnetherlands-tripgo.skedgo.com/satapp",
-                       "https://darkages-nl-southnetherlands-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": -42.88571,
-                         "lng": 147.32887,
-                         "timezone": "Australia/Sydney",
-                         "title": "Hobart, TAS, Australia"
-                         },
-                         {
-                         "lat": -41.43731,
-                         "lng": 147.14126,
-                         "timezone": "Australia/Sydney",
-                         "title": "Launceston, TAS, Australia"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "ps_shu",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "AU_TAS",
-              "polygon": "~cviGolgqZourQ??o_vWnurQ?",
-              "timezone": "Australia/Sydney",
-              "urls": [
-                       "https://granduni-au-tas-tripgo.skedgo.com/satapp",
-                       "https://darkages-au-tas-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 52.52115,
-                         "lng": 13.41035,
-                         "timezone": "Europe/Berlin",
-                         "title": "Berlin, Germany"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s",
-                        "wa_wal"
-                        ],
-              "name": "DE_BE_Berlin",
-              "polygon": "ohxaIg|ulA?gj|Gndr@_zxAnkX_nD~}Pn|R~`f@_`_@?vwgK",
-              "timezone": "Europe/Berlin",
-              "urls": [
-                       "https://hadron-de-be-berlin-tripgo.skedgo.com/satapp",
-                       "https://baryogenesis-de-be-berlin-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 52.63624,
-                         "lng": -1.14009,
-                         "timezone": "Europe/London",
-                         "title": "Leicester, UK"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "UK_Leicester",
-              "polygon": "_qnbI~}cH?_owH~{|F??~ugC_etB??~wnD",
-              "timezone": "Europe/London",
-              "urls": [
-                       "https://stars-uk-leicester-tripgo.skedgo.com/satapp",
-                       "https://inflationary-uk-leicester-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": -35.28161,
-                         "lng": 149.12863,
-                         "timezone": "Australia/Sydney",
-                         "title": "Canberra, ACT, Australia"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "AU_ACT_Canberra",
-              "polygon": "vjqzEa{lj[w~jD??{xaDv~jD?",
-              "timezone": "Australia/Sydney",
-              "urls": [
-                       "https://darkages-au-act-canberra-tripgo.skedgo.com/satapp",
-                       "https://granduni-au-act-canberra-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 38.7138,
-                         "lng": -9.13936,
-                         "timezone": "Portugal",
-                         "title": "Lisbon, Portugal"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "PT_Lisbon",
-              "polygon": "}rwmF~jby@?opxD|rkC??npxD",
-              "timezone": "Portugal",
-              "urls": [
-                       "https://matter-pt-lisbon-tripgo.skedgo.com/satapp",
-                       "https://granduni-pt-lisbon-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 56.16295,
-                         "lng": 10.20312,
-                         "timezone": "Europe/Copenhagen",
-                         "title": "Aarhus, Denmark"
-                         },
-                         {
-                         "lat": 57.04881,
-                         "lng": 9.9216,
-                         "timezone": "Europe/Copenhagen",
-                         "title": "Aalborg, Denmark"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_nextbike-flensburg",
-                        "wa_wal"
-                        ],
-              "name": "DK_Continental",
-              "polygon": "ovntIowdn@oikF~`f@onqC__pR~wkHoihJnggAngaI~zm@~zm@nnT`poCn|k@l|k@~heA_fiAnrbBmbd@~{B|lmK",
-              "timezone": "Europe/Copenhagen",
-              "urls": [
-                       "https://matter-dk-continental-tripgo.skedgo.com/satapp",
-                       "https://granduni-dk-continental-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 62.3921,
-                         "lng": 17.30989,
-                         "timezone": "Europe/Stockholm",
-                         "title": "Sundsvall, Sweden"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "SE_Sundsvall",
-              "polygon": "igpsJuyfiAyvD{luAuao@_se@aqnApihCudiByl[mwbAjqh@wejB??o{|l@bkqO?pOtv}i@",
-              "timezone": "Europe/Stockholm",
-              "urls": [
-                       "https://matter-se-sundsvall-tripgo.skedgo.com/satapp",
-                       "https://darkages-se-sundsvall-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 29.766,
-                         "lng": -95.368,
-                         "timezone": "America/Chicago",
-                         "title": "Houston, TX, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_houston",
-                        "wa_wal"
-                        ],
-              "name": "US_TX_Houston",
-              "polygon": "o{oqDnwfiQoalE??otfGnalE?",
-              "timezone": "America/Chicago",
-              "urls": [
-                       "https://inflationary-us-tx-houston-tripgo.skedgo.com/satapp",
-                       "https://darkages-us-tx-houston-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 51.47789,
-                         "lng": -3.17829,
-                         "timezone": "Europe/London",
-                         "title": "Cardiff, UK"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "UK_Wales",
-              "polygon": "_fpeI~eq`@?_f`M~s`B??_cmAnxtI??~inO",
-              "timezone": "Europe/London",
-              "urls": [
-                       "https://hadron-uk-wales-tripgo.skedgo.com/satapp",
-                       "https://stars-uk-wales-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 47.21852,
-                         "lng": -1.55451,
-                         "timezone": "Europe/Paris",
-                         "title": "Nantes, France"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_bicloo",
-                        "wa_wal"
-                        ],
-              "name": "FR_R_Nantes",
-              "polygon": "mip~G~t{Iqdm@??izxApdm@?",
-              "timezone": "Europe/Paris",
-              "urls": [
-                       "https://matter-fr-r-nantes-tripgo.skedgo.com/satapp",
-                       "https://darkages-fr-r-nantes-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 57.15,
-                         "lng": -2.09,
-                         "timezone": "Europe/London",
-                         "title": "Aberdeen, UK"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "UK_NorthScotland",
-              "polygon": "_aisJ~nyo@?_oyo@~nh\\??~nyo@",
-              "timezone": "Europe/London",
-              "urls": [
-                       "https://hadron-uk-northscotland-tripgo.skedgo.com/satapp",
-                       "https://stars-uk-northscotland-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 39.99329,
-                         "lng": -83.06924,
-                         "timezone": "America/New_York",
-                         "title": "Columbus, OH, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_cogo",
-                        "wa_wal"
-                        ],
-              "name": "US_OH_Columbus",
-              "polygon": "aezqFvwzzN_omA??gzcB~nmA?",
-              "timezone": "America/New_York",
-              "urls": [
-                       "https://inflationary-us-oh-columbus-tripgo.skedgo.com/satapp",
-                       "https://matter-us-oh-columbus-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 40.72559,
-                         "lng": -112.07068,
-                         "timezone": "US/Mountain",
-                         "title": "Salt Lake City, UT, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_greenbikeslc",
-                        "wa_wal"
-                        ],
-              "name": "US_UT_SaltLakeCity",
-              "polygon": "efbrFrtbnTslmJ??ksbGrlmJ?",
-              "timezone": "US/Mountain",
-              "urls": [
-                       "https://baryogenesis-us-ut-saltlakecity-tripgo.skedgo.com/satapp",
-                       "https://inflationary-us-ut-saltlakecity-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 41.72822,
-                         "lng": -72.66819,
-                         "timezone": "America/New_York",
-                         "title": "Hartford, CT, USA"
-                         },
-                         {
-                         "lat": 41.04685,
-                         "lng": -73.56502,
-                         "timezone": "America/New_York",
-                         "title": "Stamford, CT, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "US_CT_Hartford",
-              "polygon": "ypzyF~u`aMupNys^{qiDulOxiB_d{D`lAgjmClivBej@zd@fzG|wKagB|oFzsMdycA|zmIohOnva@",
-              "timezone": "America/New_York",
-              "urls": [
-                       "https://baryogenesis-us-ct-hartford-tripgo.skedgo.com/satapp",
-                       "https://stars-us-ct-hartford-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 46.52183,
-                         "lng": 6.6327,
-                         "timezone": "Europe/Zurich",
-                         "title": "Lausanne, Switzerland"
-                         },
-                         {
-                         "lat": 46.20333,
-                         "lng": 6.14093,
-                         "timezone": "Europe/Zurich",
-                         "title": "Geneva, Switzerland"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s",
-                        "wa_wal"
-                        ],
-              "name": "CH_SouthWestSwitzerland",
-              "polygon": "ynvuG{iul@{iv@htlIu{sChhC?s}pI",
-              "timezone": "Europe/Zurich",
-              "urls": [
-                       "https://matter-ch-southwestswitzerland-tripgo.skedgo.com/satapp",
-                       "https://darkages-ch-southwestswitzerland-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 33.45106,
-                         "lng": -112.08928,
-                         "timezone": "America/Phoenix",
-                         "title": "Phoenix, AZ, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_SoBi20",
-                        "wa_wal"
-                        ],
-              "name": "US_AZ_Phoenix",
-              "polygon": "ejqjErwrnTk|qAsa{@cFm{lChpfBq|Hl`m@dp{A",
-              "timezone": "America/Phoenix",
-              "urls": [
-                       "https://inflationary-us-az-phoenix-tripgo.skedgo.com/satapp",
-                       "https://baryogenesis-us-az-phoenix-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 39.7809,
-                         "lng": -89.64767,
-                         "timezone": "America/Chicago",
-                         "title": "Springfield, IL, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "US_IL_Springfield",
-              "polygon": "_|hqFnktbPm_eD??_owHl_eD?",
-              "timezone": "America/Chicago",
-              "urls": [
-                       "https://baryogenesis-us-il-springfield-tripgo.skedgo.com/satapp",
-                       "https://hadron-us-il-springfield-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 45.4234,
-                         "lng": -75.6968,
-                         "timezone": "America/Montreal",
-                         "title": "Ottawa, ON, Canada"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_SoBi41",
-                        "wa_wal"
-                        ],
-              "name": "CA_ON_Ottawa",
-              "polygon": "_p`qG~iupM_xnD??_kiF~wnD?",
-              "timezone": "America/Montreal",
-              "urls": [
-                       "https://baryogenesis-ca-on-ottawa-tripgo.skedgo.com/satapp",
-                       "https://matter-ca-on-ottawa-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 50.64514,
-                         "lng": 5.57342,
-                         "timezone": "Europe/Brussels",
-                         "title": "Liege, Belgium"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "pt_ltd_SCHOOLBUS",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_li-bia-velo",
-                        "wa_wal"
-                        ],
-              "name": "BE_SouthEastBelgium",
-              "polygon": "}qcpH_zj\\oyLa]{}DayBy_G}jG_kAfh@}RjvFiUlpAkytB??ayiDw_@c}AuPmdDecCk}EvdD{~F_pA}fMllBqfEmk@akFf`@uvKtv@ihCnxBgQra@_gM|gJ}bInBgfDlbBe_AxDe|HhqAecC`nM`sFrqD`}Et|Dw_CmQotKvjA_lKhbExXpXabDbwDgn@|gIxlD~eDmzHvhDwv@heChdIytB|eFfzExcFvq@eb@pnAptA~n@nmIf}B`fDle@l~Bv~Cgy@vfDoYbfAhlGvgDem@tuAxnCkx@piDuiD_\\_\\`pDxqAb^|UnoGizCroBf]hlGnaG|Z`wAfaKnaFf`BreBrbCbnDu[`fDjrGdoB_xBf~CrvDhnA`jF|}EzpBr_BfvBbtCq~GzrBx}Cb_Kvv@an@ujD~nIqmHbmC_NmImdEnqB{pCd~DleBppActFbpDjSzgDfsDjiFd_@~eC|lEpo@h}CzXv_Fde@~qMak@~uLrvFrbD_tBjmGngDnoR{wCt|CknLdpBmoEfzJnjAt{IcpCdaByrCi~CqbDllHo~@lqWyfJnvJeoGdgTb{@dgKqd@jyKw{FqcBwtEhsC_~CevDw`Deb@wdDncFe|AdeIs{C_N",
-              "timezone": "Europe/Brussels",
-              "urls": [
-                       "https://hadron-be-southeastbelgium-tripgo.skedgo.com/satapp",
-                       "https://darkages-be-southeastbelgium-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 38.44047,
-                         "lng": -122.71443,
-                         "timezone": "America/Los_Angeles",
-                         "title": "Santa Rosa, CA, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "US_CA_SantaRosa",
-              "polygon": "w_}iFzqjnVw}{@ydG{lDgbEfjAuoHdrfAsioAhhL}tMfvOmiIfiK`]h}@rcA{Tz`IbiApf\\g~i@zdxA",
-              "timezone": "America/Los_Angeles",
-              "urls": [
-                       "https://baryogenesis-us-ca-santarosa-tripgo.skedgo.com/satapp",
-                       "https://stars-us-ca-santarosa-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 52.24663,
-                         "lng": 21.0145,
-                         "timezone": "Europe/Warsaw",
-                         "title": "Warsaw, Poland"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s",
-                        "wa_wal"
-                        ],
-              "name": "PL_Warsaw",
-              "polygon": "mt~bIsejcC`rmBeclIvlyDzsgHhozA~agEg~yEtwpHkijEe_aD",
-              "timezone": "Europe/Warsaw",
-              "urls": [
-                       "https://matter-pl-warsaw-tripgo.skedgo.com/satapp",
-                       "https://darkages-pl-warsaw-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 39.1048,
-                         "lng": -84.5114,
-                         "timezone": "America/New_York",
-                         "title": "Cincinnati, OH, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s",
-                        "wa_wal"
-                        ],
-              "name": "US_OH_Cincinnati",
-              "polygon": "ujsnFjz_eO{sVieoAmm@{km@ddy@pGnqj@|zV`}Fdj{@",
-              "timezone": "America/New_York",
-              "urls": [
-                       "https://inflationary-us-oh-cincinnati-tripgo.skedgo.com/satapp",
-                       "https://matter-us-oh-cincinnati-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 36.16727,
-                         "lng": -115.1361,
-                         "timezone": "America/Los_Angeles",
-                         "title": "Las Vegas, NV, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "US_NV_LasVegas",
-              "polygon": "okv|Edod_UuZmedAh}iAcpm@xuAdqlB",
-              "timezone": "America/Los_Angeles",
-              "urls": [
-                       "https://baryogenesis-us-nv-lasvegas-tripgo.skedgo.com/satapp",
-                       "https://hadron-us-nv-lasvegas-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 39.745,
-                         "lng": -104.994,
-                         "timezone": "America/Denver",
-                         "title": "Denver, CO, USA"
-                         },
-                         {
-                         "lat": 40.016,
-                         "lng": -105.265,
-                         "timezone": "America/Denver",
-                         "title": "Boulder, CO, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s",
-                        "wa_wal"
-                        ],
-              "name": "US_CO_Denver",
-              "polygon": "oaxoF~~ocS}iwC??_qaF|iwC?",
-              "timezone": "America/Denver",
-              "urls": [
-                       "https://lepton-us-co-denver-tripgo.skedgo.com/satapp",
-                       "https://baryogenesis-us-co-denver-tripgo.skedgo.com/satapp",
-                       "https://stars-us-co-denver-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 46.0706,
-                         "lng": 11.1196,
-                         "timezone": "Europe/Rome",
-                         "title": "Trento, Italy"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s",
-                        "wa_wal"
-                        ],
-              "name": "IT_Trentino",
-              "polygon": "_{xuG_pb~@oe}C??oezGne}C?",
-              "timezone": "Europe/Rome",
-              "urls": [
-                       "https://matter-it-trentino-tripgo.skedgo.com/satapp",
-                       "https://darkages-it-trentino-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 43.03499,
-                         "lng": -87.9225,
-                         "timezone": "US/Central",
-                         "title": "Milwaukee, WI, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_bublr-bikes",
-                        "wa_wal"
-                        ],
-              "name": "US_WI_Milwaukee",
-              "polygon": "gsibG~`h{Oc}fE??{raDb}fE?",
-              "timezone": "US/Central",
-              "urls": [
-                       "https://baryogenesis-us-wi-milwaukee-tripgo.skedgo.com/satapp",
-                       "https://hadron-us-wi-milwaukee-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 45.465,
-                         "lng": 9.187,
-                         "timezone": "Europe/Rome",
-                         "title": "Milan, Italy"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s",
-                        "wa_wal"
-                        ],
-              "name": "IT_Milano",
-              "polygon": "s`prGyhjs@{|wC??crdFz|wC?",
-              "timezone": "Europe/Rome",
-              "urls": [
-                       "https://matter-it-milano-tripgo.skedgo.com/satapp",
-                       "https://darkages-it-milano-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 65.01175,
-                         "lng": 25.47462,
-                         "timezone": "Europe/Helsinki",
-                         "title": "Oulu, Finland"
-                         },
-                         {
-                         "lat": 62.89325,
-                         "lng": 27.67825,
-                         "timezone": "Europe/Helsinki",
-                         "title": "Kuopio, Finland"
-                         },
-                         {
-                         "lat": 66.49717,
-                         "lng": 25.72326,
-                         "timezone": "Europe/Helsinki",
-                         "title": "Rovaniemi, Finland"
-                         },
-                         {
-                         "lat": 62.60052,
-                         "lng": 29.76201,
-                         "timezone": "Europe/Helsinki",
-                         "title": "Joensuu, Finland"
-                         },
-                         {
-                         "lat": 68.41972,
-                         "lng": 27.41074,
-                         "timezone": "Europe/Helsinki",
-                         "title": "Saariselkä, Finland"
-                         },
-                         {
-                         "lat": 67.33187,
-                         "lng": 23.78911,
-                         "timezone": "Europe/Stockholm",
-                         "title": "Kolari, Finland"
-                         },
-                         {
-                         "lat": 64.07229,
-                         "lng": 24.53387,
-                         "timezone": "Europe/Helsinki",
-                         "title": "Ylivieska, Finland"
-                         },
-                         {
-                         "lat": 64.12877,
-                         "lng": 29.52018,
-                         "timezone": "Europe/Helsinki",
-                         "title": "Kuhmo, Finland"
-                         },
-                         {
-                         "lat": 65.96445,
-                         "lng": 29.1887,
-                         "timezone": "Europe/Helsinki",
-                         "title": "Kuusamo, Finland"
-                         },
-                         {
-                         "lat": 67.29246,
-                         "lng": 28.15847,
-                         "timezone": "Europe/Helsinki",
-                         "title": "Savukoski, Finland"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "FI_NorthFinland",
-              "polygon": "opioK_`brC_ycC~dtBoinB_ieA_ieA~|tAovs@nqPoofBotL_qdB~bgIszkBby}Fioi@alsBwiGsooB`hlBmmtDxyK{o|Bam^eumC`ze@csgEwgp@s}gAbiAqh~@yjTirV_nh@lgJyytAc}b@cxu@eomBuz^k|rHrnjAckaF`vp@wvn@zypAzmoAz`nG}|pF|lq[cngJn`wFncpJo_h@~mhBoljB~pdBnwH~yuE_xq@~c_DokXn{sEobd@~~{B_`qA~~{B_g^n_eD_g^n{vAoe`@?owH~``H",
-              "timezone": "Europe/Helsinki",
-              "urls": [
-                       "https://matter-fi-northfinland-tripgo.skedgo.com/satapp",
-                       "https://granduni-fi-northfinland-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 34.044,
-                         "lng": -118.248,
-                         "timezone": "America/Los_Angeles",
-                         "title": "Los Angeles, CA, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s",
-                        "wa_wal"
-                        ],
-              "name": "US_CA_LosAngeles",
-              "polygon": "otpjEnl_uU_ibE??o|bL~hbE?",
-              "timezone": "America/Los_Angeles",
-              "urls": [
-                       "https://lepton-us-ca-losangeles-tripgo.skedgo.com/satapp",
-                       "https://baryogenesis-us-ca-losangeles-tripgo.skedgo.com/satapp",
-                       "https://stars-us-ca-losangeles-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 44.49434,
-                         "lng": 11.34314,
-                         "timezone": "Europe/Rome",
-                         "title": "Bologna, Italy"
-                         },
-                         {
-                         "lat": 44.83563,
-                         "lng": 11.62035,
-                         "timezone": "Europe/Rome",
-                         "title": "Ferrera, Italy"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s",
-                        "wa_wal"
-                        ],
-              "name": "IT_Bologna",
-              "polygon": "ogurG_wl`A?_kfJ~vyE??~jfJ",
-              "timezone": "Europe/Rome",
-              "urls": [
-                       "https://matter-it-bologna-tripgo.skedgo.com/satapp",
-                       "https://darkages-it-bologna-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 38.11127,
-                         "lng": 13.35344,
-                         "timezone": "Europe/Rome",
-                         "title": "Palermo, Italy"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "IT_Palermo",
-              "polygon": "ybigF}k|oAaoJbwByfQ`dCisCcaV~eG}eMdoPygLtmKdn@rVl_d@",
-              "timezone": "Europe/Rome",
-              "urls": [
-                       "https://matter-it-palermo-tripgo.skedgo.com/satapp",
-                       "https://darkages-it-palermo-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 31.77743,
-                         "lng": 35.22472,
-                         "timezone": "Israel",
-                         "title": "Jerusalem, Israel"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_telofun",
-                        "wa_wal"
-                        ],
-              "name": "Israel",
-              "polygon": "gwj~Dg}qoE_at@mtm@ukmAijp@c{uAqxUqsjA{sSm{u@w~_@yjBsnsAg_WglA{wKa~PreJggk@vgo@krKlcd@`mE|_X|sHruOnq]ddeAlyCtdmAnyCzwjAxpNlqmBn`GlifDrst@zi_B|}[|iVmr@{\\f|i@qoaJzrlC",
-              "timezone": "Israel",
-              "urls": [
-                       "https://granduni-israel-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 56.9494,
-                         "lng": 24.10518,
-                         "timezone": "Europe/Riga",
-                         "title": "Riga, Latvia"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_sixt-riga",
-                        "wa_wal"
-                        ],
-              "name": "LV_Riga",
-              "polygon": "wdyyIsxrpCwku@??y~pBvku@?",
-              "timezone": "Europe/Riga",
-              "urls": [
-                       "https://hadron-lv-riga-tripgo.skedgo.com/satapp",
-                       "https://granduni-lv-riga-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 50.37545,
-                         "lng": -4.14256,
-                         "timezone": "Europe/London",
-                         "title": "Plymouth, UK"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s",
-                        "wa_wal"
-                        ],
-              "name": "UK_SouthWestEngland",
-              "polygon": "_pbxH~xkb@?_isXnezG??~hsX",
-              "timezone": "Europe/London",
-              "urls": [
-                       "https://hadron-uk-southwestengland-tripgo.skedgo.com/satapp",
-                       "https://stars-uk-southwestengland-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 46.94828,
-                         "lng": 7.4515,
-                         "timezone": "Europe/Zurich",
-                         "title": "Bern, Switzerland"
-                         },
-                         {
-                         "lat": 47.55922,
-                         "lng": 7.58825,
-                         "timezone": "Europe/Zurich",
-                         "title": "Basel, Switzerland"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s",
-                        "wa_wal"
-                        ],
-              "name": "CH_NorthWestSwitzerland",
-              "polygon": "wwdaHu}yh@eiXoy{Dp{mE??|krK",
-              "timezone": "Europe/Zurich",
-              "urls": [
-                       "https://matter-ch-northwestswitzerland-tripgo.skedgo.com/satapp",
-                       "https://darkages-ch-northwestswitzerland-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 38.57797,
-                         "lng": -121.498,
-                         "timezone": "America/Los_Angeles",
-                         "title": "Sacramento, CA, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_SoBi124",
-                        "wa_wal"
-                        ],
-              "name": "US_CA_Sacramento",
-              "polygon": "qlznFj}qfV~{p@uurDjf~Cp_YftCriyE",
-              "timezone": "America/Los_Angeles",
-              "urls": [
-                       "https://baryogenesis-us-ca-sacramento-tripgo.skedgo.com/satapp",
-                       "https://stars-us-ca-sacramento-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 59.43722,
-                         "lng": 24.74537,
-                         "timezone": "Europe/Tallinn",
-                         "title": "Tallin, Estonia"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_sixt-jalgrattarent-tallinn",
-                        "wa_wal"
-                        ],
-              "name": "Estonia",
-              "polygon": "gst|I{xpaCwouM??s{sj@vouM?",
-              "timezone": "Europe/Tallinn",
-              "urls": [
-                       "https://matter-estonia-tripgo.skedgo.com/satapp",
-                       "https://darkages-estonia-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 39.15195,
-                         "lng": -94.53121,
-                         "timezone": "US/Central",
-                         "title": "Kansas City, MO, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_kansascity",
-                        "wa_wal"
-                        ],
-              "name": "US_MO_KansasCity",
-              "polygon": "m_dlFvw`bQie`B??we_Che`B?",
-              "timezone": "US/Central",
-              "urls": [
-                       "https://inflationary-us-mo-kansascity-tripgo.skedgo.com/satapp",
-                       "https://matter-us-mo-kansascity-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 54.6,
-                         "lng": -5.93,
-                         "timezone": "Europe/Dublin",
-                         "title": "Belfast, Northern Ireland"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_belfastbikes-belfast",
-                        "wa_wal"
-                        ],
-              "name": "IE_NorthIreland",
-              "polygon": "_ckqI~lcbA?of}]~qvDoofBnfrB??n{mMn{vA??nzuR",
-              "timezone": "Europe/Dublin",
-              "urls": [
-                       "https://matter-ie-northireland-tripgo.skedgo.com/satapp",
-                       "https://darkages-ie-northireland-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 45.9565,
-                         "lng": 8.93397,
-                         "timezone": "Europe/Zurich",
-                         "title": "Lugano, Switzerland"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s",
-                        "wa_wal"
-                        ],
-              "name": "CH_SouthEastSwitzerland",
-              "polygon": "kvb|G{xal@cecAg~cMjVoheDb{xCucAjqlBtpmHo`^`zyBtrAlvzAtmLfhgB",
-              "timezone": "Europe/Zurich",
-              "urls": [
-                       "https://matter-ch-southeastswitzerland-tripgo.skedgo.com/satapp",
-                       "https://darkages-ch-southeastswitzerland-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 63.43658,
-                         "lng": 10.39894,
-                         "timezone": "Europe/Oslo",
-                         "title": "Trondheim, Norway"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "NO_MiddleNorway",
-              "polygon": "ak_`L}ionAhjoBcxeUf`i@j_d@faOx}q@zmm@kmj@ll_@vbHx~gBthfDjo~@|vAndKd|{CbabDdoQngiCvxwDpdR{dxAnlw@y`Flyc@b`e@{rIzk`Db`zAhdqDfedGiuOqecDtqqc@",
-              "timezone": "Europe/Oslo",
-              "urls": [
-                       "https://matter-no-middlenorway-tripgo.skedgo.com/satapp",
-                       "https://darkages-no-middlenorway-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": -43.531,
-                         "lng": 172.637,
-                         "timezone": "NZ",
-                         "title": "Christchurch, New Zealand"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_nextbike-christchurch",
-                        "wa_wal"
-                        ],
-              "name": "NZ_S_Christchurch",
-              "polygon": "~dztF_i|t^?onmr@~luj@??nnmr@",
-              "timezone": "NZ",
-              "urls": [
-                       "https://darkages-nz-s-christchurch-tripgo.skedgo.com/satapp",
-                       "https://granduni-nz-s-christchurch-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 38.8976,
-                         "lng": -77.0365,
-                         "timezone": "America/New_York",
-                         "title": "Washington, DC, USA"
-                         },
-                         {
-                         "lat": 39.2907,
-                         "lng": -76.6093,
-                         "timezone": "America/New_York",
-                         "title": "Baltimore, MD, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s",
-                        "wa_wal"
-                        ],
-              "name": "US_DC_Washington",
-              "polygon": "oq|iFnbyxMoalE??_buFnalE?",
-              "timezone": "America/New_York",
-              "urls": [
-                       "https://baryogenesis-us-dc-washington-tripgo.skedgo.com/satapp",
-                       "https://inflationary-us-dc-washington-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 41.38741,
-                         "lng": 2.16861,
-                         "timezone": "Europe/Madrid",
-                         "title": "Barcelona, Spain"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_bicing",
-                        "wa_wal"
-                        ],
-              "name": "ES_CT_Barcelona",
-              "polygon": "oswzF_rsHorbB??o|hDnrbB?",
-              "timezone": "Europe/Madrid",
-              "urls": [
-                       "https://matter-es-ct-barcelona-tripgo.skedgo.com/satapp",
-                       "https://granduni-es-ct-barcelona-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 40.71669,
-                         "lng": -74.00614,
-                         "timezone": "America/New_York",
-                         "title": "New York City, NY, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s",
-                        "wa_wal"
-                        ],
-              "name": "US_NY_NewYorkCity",
-              "polygon": "oecvFnzhdM_}tA??o~oE~|tA?",
-              "timezone": "America/New_York",
-              "urls": [
-                       "https://baryogenesis-us-ny-newyorkcity-tripgo.skedgo.com/satapp",
-                       "https://hadron-us-ny-newyorkcity-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 47.05055,
-                         "lng": 8.30547,
-                         "timezone": "Europe/Zurich",
-                         "title": "Lucerne, Switzerland"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s",
-                        "wa_wal"
-                        ],
-              "name": "CH_Lucerne",
-              "polygon": "{xk_H{icn@ymE}hbKvr}@taB`xu@|h_K",
-              "timezone": "Europe/Zurich",
-              "urls": [
-                       "https://matter-ch-lucerne-tripgo.skedgo.com/satapp",
-                       "https://darkages-ch-lucerne-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 41.50132,
-                         "lng": -81.69516,
-                         "timezone": "America/New_York",
-                         "title": "Cleveland, OH, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_SoBi93",
-                        "wa_wal"
-                        ],
-              "name": "US_OH_Cleveland",
-              "polygon": "kpk}FdngpNjqYidP~kf@taB|eZhsuAk`^ngx@gg\\rG",
-              "timezone": "America/New_York",
-              "urls": [
-                       "https://inflationary-us-oh-cleveland-tripgo.skedgo.com/satapp",
-                       "https://matter-us-oh-cleveland-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 60.38568,
-                         "lng": 5.33622,
-                         "timezone": "Europe/Oslo",
-                         "title": "Bergen, Norway"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_bergen-bysykkel",
-                        "wa_wal"
-                        ],
-              "name": "NO_Bergen",
-              "polygon": "snyrJctcX?}rub@r`cEhoFn~DbbkDuqMbxc[",
-              "timezone": "Europe/Oslo",
-              "urls": [
-                       "https://matter-no-bergen-tripgo.skedgo.com/satapp",
-                       "https://darkages-no-bergen-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 45.072,
-                         "lng": 7.689,
-                         "timezone": "Europe/Rome",
-                         "title": "Turin, Italy"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s",
-                        "wa_wal"
-                        ],
-              "name": "IT_Torino",
-              "polygon": "opojGo_jg@o}wJ??m}wJn}wJ?",
-              "timezone": "Europe/Rome",
-              "urls": [
-                       "https://matter-it-torino-tripgo.skedgo.com/satapp",
-                       "https://darkages-it-torino-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": -12.4542,
-                         "lng": 130.8391,
-                         "timezone": "Australia/Darwin",
-                         "title": "Darwin, NT, Australia"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "ps_shu",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "AU_NT_Darwin",
-              "polygon": "~ovmA_ho{W_g{C??_xnD~f{C?",
-              "timezone": "Australia/Darwin",
-              "urls": [
-                       "https://darkages-au-nt-darwin-tripgo.skedgo.com/satapp",
-                       "https://granduni-au-nt-darwin-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": -34.92861,
-                         "lng": 138.59996,
-                         "timezone": "Australia/Adelaide",
-                         "title": "Adelaide, SA, Australia"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "ps_shu",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "AU_SA_Adelaide",
-              "polygon": "~{vvEwa}kYooxC??_pvBnoxC?",
-              "timezone": "Australia/Adelaide",
-              "urls": [
-                       "https://granduni-au-sa-adelaide-tripgo.skedgo.com/satapp",
-                       "https://darkages-au-sa-adelaide-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 42.95859,
-                         "lng": -78.88581,
-                         "timezone": "US/Eastern",
-                         "title": "Buffalo, NY, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_SoBi78",
-                        "wa_wal"
-                        ],
-              "name": "US_NY_Buffalo",
-              "polygon": "kejdG~eo`N_qHc@elDbuAmaEz@s~A~j@g_B`jA{XxlDihLt`HshFgQoqAnxLkf@tSm}A_hAsqAzNodAqRgfA_xAce@yEayAzK{|Aps@q[wJkhDu~B?cxlAhdf@e`h@z|c@nr@ftb@tlf@`sTt~xAe~PhiTw`d@eew@",
-              "timezone": "US/Eastern",
-              "urls": [
-                       "https://baryogenesis-us-ny-buffalo-tripgo.skedgo.com/satapp",
-                       "https://hadron-us-ny-buffalo-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 39.76865,
-                         "lng": -86.15792,
-                         "timezone": "America/Indianapolis",
-                         "title": "Indianapolis, IN, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_indiana-pacers-bikeshare",
-                        "wa_wal"
-                        ],
-              "name": "US_IN_Indianapolis",
-              "polygon": "olspF~dbnO_ieA??_`qA~heA?",
-              "timezone": "America/Indianapolis",
-              "urls": [
-                       "https://baryogenesis-us-in-indianapolis-tripgo.skedgo.com/satapp",
-                       "https://hadron-us-in-indianapolis-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 59.32512,
-                         "lng": 18.07109,
-                         "timezone": "Europe/Stockholm",
-                         "title": "Stockholm, Sweden"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "SE_Stockholm",
-              "polygon": "s}opJapiqBzwnEkaiG`z_G??h`c_@}roM?",
-              "timezone": "Europe/Stockholm",
-              "urls": [
-                       "https://matter-se-stockholm-tripgo.skedgo.com/satapp",
-                       "https://darkages-se-stockholm-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": -31.95299,
-                         "lng": 115.85747,
-                         "timezone": "Australia/Perth",
-                         "title": "Perth, WA, Australia"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "ps_shu",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "AU_WA_Perth",
-              "polygon": "~qtwE_sxvT_zwl@??_oyo@~ywl@?",
-              "timezone": "Australia/Perth",
-              "urls": [
-                       "https://granduni-au-wa-perth-tripgo.skedgo.com/satapp",
-                       "https://darkages-au-wa-perth-tripgo.skedgo.com/satapp",
-                       "https://baryogenesis-au-wa-perth-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 61.499,
-                         "lng": 23.762,
-                         "timezone": "Europe/Helsinki",
-                         "title": "Tampere, Finland"
-                         },
-                         {
-                         "lat": 60.45262,
-                         "lng": 22.26139,
-                         "timezone": "Europe/Helsinki",
-                         "title": "Turku, Finland"
-                         },
-                         {
-                         "lat": 62.24482,
-                         "lng": 25.74709,
-                         "timezone": "Europe/Helsinki",
-                         "title": "Jyväskylä, Finland"
-                         },
-                         {
-                         "lat": 61.4851,
-                         "lng": 21.79743,
-                         "timezone": "Europe/Helsinki",
-                         "title": "Pori, Finland"
-                         },
-                         {
-                         "lat": 63.09505,
-                         "lng": 21.61719,
-                         "timezone": "Europe/Helsinki",
-                         "title": "Vaasa, Finland"
-                         },
-                         {
-                         "lat": 61.68887,
-                         "lng": 27.27285,
-                         "timezone": "Europe/Helsinki",
-                         "title": "Mikkeli, Finland"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "FI_MiddleFinland",
-              "polygon": "_fopJoeiqBocmN_ycCopxD_dvO_pRo}zF~s`BocvBnwHohyCnu~A_~fD~`f@onqC~f^__yFnnT_o}@nzD_vdGnsw@_yF~`f@_g^nkX_laA~`f@~gpBne`@~iZokX~eiAnggA~efE_vJn{vAnyo@onT_pRn~rAnwHnjcAoxzA~bjEne`@~lVne`@~qy@~oR~xcC~_qA~bmA~lV~jlB~kaAoaoAnjcA~bmA_yFndkAnwHndkA~wq@nkX_yF~r_S",
-              "timezone": "Europe/Helsinki",
-              "urls": [
-                       "https://matter-fi-middlefinland-tripgo.skedgo.com/satapp",
-                       "https://granduni-fi-middlefinland-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 54.9769,
-                         "lng": -1.61078,
-                         "timezone": "Europe/London",
-                         "title": "Newcastle, UK"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "UK_NorthEngland",
-              "polygon": "_pskI~uxV?~lpG_g{C~`f@_vgC_rjTnkoK_yzN?~{mZ",
-              "timezone": "Europe/London",
-              "urls": [
-                       "https://hadron-uk-northengland-tripgo.skedgo.com/satapp",
-                       "https://stars-uk-northengland-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": -36.84448,
-                         "lng": 174.76771,
-                         "timezone": "Pacific/Auckland",
-                         "title": "Auckland, New Zealand"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s",
-                        "wa_wal"
-                        ],
-              "name": "NZ_N_Auckland",
-              "polygon": "nhhjFodd|_@_nvY??odpd@~mvY?",
-              "timezone": "Pacific/Auckland",
-              "urls": [
-                       "https://darkages-nz-n-auckland-tripgo.skedgo.com/satapp",
-                       "https://granduni-nz-n-auckland-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 51.89657,
-                         "lng": -8.48548,
-                         "timezone": "Europe/Dublin",
-                         "title": "Cork, Ireland"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s",
-                        "wa_wal"
-                        ],
-              "name": "IE_SouthIreland",
-              "polygon": "_fpeI~lcbA?ozuR~wnD??ohsKn{vAnljBnpxDnl{U?~hbE",
-              "timezone": "Europe/Dublin",
-              "urls": [
-                       "https://matter-ie-southireland-tripgo.skedgo.com/satapp",
-                       "https://darkages-ie-southireland-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 47.502,
-                         "lng": 19.047,
-                         "timezone": "Europe/Budapest",
-                         "title": "Budapest, Hungary"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_bubi",
-                        "wa_wal"
-                        ],
-              "name": "HU_Budapest",
-              "polygon": "_lf~GoeiqBoweC??_vgCnweC?",
-              "timezone": "Europe/Budapest",
-              "urls": [
-                       "https://hadron-hu-budapest-tripgo.skedgo.com/satapp",
-                       "https://darkages-hu-budapest-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 43.603,
-                         "lng": 1.442,
-                         "timezone": "Europe/Paris",
-                         "title": "Toulouse, France"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_velo",
-                        "wa_wal"
-                        ],
-              "name": "FR_N_Toulouse",
-              "polygon": "oo}gG_kiFodkA??_w|AndkA?",
-              "timezone": "Europe/Paris",
-              "urls": [
-                       "https://matter-fr-n-toulouse-tripgo.skedgo.com/satapp",
-                       "https://darkages-fr-n-toulouse-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 55.95392,
-                         "lng": -3.18553,
-                         "timezone": "Europe/London",
-                         "title": "Edinburgh, UK"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s",
-                        "wa_wal"
-                        ],
-              "name": "UK_SouthScotland",
-              "polygon": "oiivI~nyo@?_oyo@~qy@nihJ~iwC~r|V",
-              "timezone": "Europe/London",
-              "urls": [
-                       "https://hadron-uk-southscotland-tripgo.skedgo.com/satapp",
-                       "https://stars-uk-southscotland-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 69.64882,
-                         "lng": 18.95598,
-                         "timezone": "Europe/Oslo",
-                         "title": "Tromsø , Norway"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "NO_NorthNorway",
-              "polygon": "{yn|K{dtdBopnB`daUoavR{kkv@zizB}w|z@lxrGr|uD~eqBpiqKqtl@ftcAslkA{llBoqhAlaiG`h`@jooGdoiDfzcBdmkAb~}Dsu`@x}rNehsApihCtv]x~lElj_Ctwg@kf`@hsiJlfbBdomBk|YfdwB",
-              "timezone": "Europe/Oslo",
-              "urls": [
-                       "https://matter-no-northnorway-tripgo.skedgo.com/satapp",
-                       "https://darkages-no-northnorway-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 53.48,
-                         "lng": -2.241,
-                         "timezone": "Europe/London",
-                         "title": "Manchester, UK"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "UK_GM_Manchester",
-              "polygon": "_{qhI~ocS?_||FnalE??~{|F",
-              "timezone": "Europe/London",
-              "urls": [
-                       "https://stars-uk-gm-manchester-tripgo.skedgo.com/satapp",
-                       "https://inflationary-uk-gm-manchester-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 43.667,
-                         "lng": -79.379,
-                         "timezone": "America/Toronto",
-                         "title": "Toronto, ON, Canada"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s",
-                        "wa_wal"
-                        ],
-              "name": "CA_ON_Toronto",
-              "polygon": "_lrnG~d}jN?o~iM~ooC?fpz@fi|Dvud@ku[fn@s|Adb@uIry@lH`cB{N`rA~Thd@c_@vXqTfaB|V`aAzCnf@oNn_@m\\n_@wHh^{BfQcI`a@mBf_@jG~Svb@zb@t[nLvPhBtN`g@bdAxHeR`O{YpMwPnQyGrHiBnMk@vh@dUtAr~|H",
-              "timezone": "America/Toronto",
-              "urls": [
-                       "https://baryogenesis-ca-on-toronto-tripgo.skedgo.com/satapp",
-                       "https://matter-ca-on-toronto-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 51.0458,
-                         "lng": -114.0581,
-                         "timezone": "America/Edmonton",
-                         "title": "Calgary, AB, Canada"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "CA_AB_Calgary",
-              "polygon": "_yysH~gzyT_vgC??o_eD~ugC?",
-              "timezone": "America/Edmonton",
-              "urls": [
-                       "https://baryogenesis-ca-ab-calgary-tripgo.skedgo.com/satapp",
-                       "https://matter-ca-ab-calgary-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 51.75253,
-                         "lng": -1.25384,
-                         "timezone": "Europe/London",
-                         "title": "Oxford, UK"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s",
-                        "wa_wal"
-                        ],
-              "name": "UK_Oxford",
-              "polygon": "oro~H~_kI?_kiF~yuE??~jiF",
-              "timezone": "Europe/London",
-              "urls": [
-                       "https://hadron-uk-oxford-tripgo.skedgo.com/satapp",
-                       "https://stars-uk-oxford-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 21.30455,
-                         "lng": -157.85568,
-                         "timezone": "US/Hawaii",
-                         "title": "Honolulu, HI, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "US_HI_Honolulu",
-              "polygon": "kq~_Cvbie]sx`C??gtjDrx`C?",
-              "timezone": "US/Hawaii",
-              "urls": [
-                       "https://inflationary-us-hi-honolulu-tripgo.skedgo.com/satapp",
-                       "https://baryogenesis-us-hi-honolulu-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 52.37115,
-                         "lng": 4.89793,
-                         "timezone": "Europe/Amsterdam",
-                         "title": "Amsterdam, Netherlands"
-                         },
-                         {
-                         "lat": 52.07049,
-                         "lng": 4.30626,
-                         "timezone": "Europe/Amsterdam",
-                         "title": "The Hague, Netherlands"
-                         },
-                         {
-                         "lat": 51.92321,
-                         "lng": 4.47479,
-                         "timezone": "Europe/Amsterdam",
-                         "title": "Rotterdam, Netherlands"
-                         },
-                         {
-                         "lat": 52.09125,
-                         "lng": 5.1194,
-                         "timezone": "Europe/Amsterdam",
-                         "title": "Utrecht, Netherlands"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s",
-                        "wa_wal"
-                        ],
-              "name": "NL_W_Randstad",
-              "polygon": "op}zH_eeV__dI??ovmH~~cI?",
-              "timezone": "Europe/Amsterdam",
-              "urls": [
-                       "https://hadron-nl-w-randstad-tripgo.skedgo.com/satapp",
-                       "https://darkages-nl-w-randstad-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": -27.4651,
-                         "lng": 153.0175,
-                         "timezone": "Australia/Brisbane",
-                         "title": "Brisbane, QLD, Australia"
-                         },
-                         {
-                         "lat": -28.0142,
-                         "lng": 153.4191,
-                         "timezone": "Australia/Brisbane",
-                         "title": "Gold Coast, QLD, Australia"
-                         },
-                         {
-                         "lat": -26.6527,
-                         "lng": 153.0744,
-                         "timezone": "Australia/Brisbane",
-                         "title": "Sunshine Coast, QLD, Australia"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "ps_shu",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_citycycle",
-                        "wa_wal"
-                        ],
-              "name": "AU_QLD_Southern",
-              "polygon": "~k}lD_lcs[_hxa@??}b~T~gxa@?",
-              "timezone": "Australia/Brisbane",
-              "urls": [
-                       "https://darkages-au-qld-southern-tripgo.skedgo.com/satapp",
-                       "https://granduni-au-qld-southern-tripgo.skedgo.com/satapp",
-                       "https://baryogenesis-au-qld-southern-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 27.965,
-                         "lng": -82.458,
-                         "timezone": "US/Eastern",
-                         "title": "Tampa, FL, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_SoBi11",
-                        "wa_wal"
-                        ],
-              "name": "US_FL_Tampa",
-              "polygon": "_|dcD`l~xN_mpG??ag{C~lpG?",
-              "timezone": "US/Eastern",
-              "urls": [
-                       "https://inflationary-us-fl-tampa-tripgo.skedgo.com/satapp",
-                       "https://matter-us-fl-tampa-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 44.654,
-                         "lng": -63.573,
-                         "timezone": "America/Halifax",
-                         "title": "Halifax, NS, Canada"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "CA_NS_Halifax",
-              "polygon": "_{~mG~m_eK_etB??_vgC~dtB?",
-              "timezone": "America/Halifax",
-              "urls": [
-                       "https://baryogenesis-ca-ns-halifax-tripgo.skedgo.com/satapp",
-                       "https://matter-ca-ns-halifax-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 45.529,
-                         "lng": -73.541,
-                         "timezone": "America/Montreal",
-                         "title": "Montreal, QC, Canada"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_bixi-montreal",
-                        "wa_wal"
-                        ],
-              "name": "CA_QC_Montreal",
-              "polygon": "_atqG`gbeM_`kI??_~cH~_kI?",
-              "timezone": "America/Montreal",
-              "urls": [
-                       "https://baryogenesis-ca-qc-montreal-tripgo.skedgo.com/satapp",
-                       "https://matter-ca-qc-montreal-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 38.62934,
-                         "lng": -90.19565,
-                         "timezone": "US/Central",
-                         "title": "Saint Louis, MO, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "US_MO_SaintLouis",
-              "polygon": "_lijFjy}jP{oyAmwyCtzsA_rsCroqBvqtD",
-              "timezone": "US/Central",
-              "urls": [
-                       "https://inflationary-us-mo-saintlouis-tripgo.skedgo.com/satapp",
-                       "https://matter-us-mo-saintlouis-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 49.26123,
-                         "lng": -123.1139,
-                         "timezone": "America/Vancouver",
-                         "title": "Vancouver, BC, Canada"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_mobibikes",
-                        "wa_wal"
-                        ],
-              "name": "CA_BC_Vancouver",
-              "polygon": "_iajH~bd{VotfG??_vxVntfG?",
-              "timezone": "America/Vancouver",
-              "urls": [
-                       "https://baryogenesis-ca-bc-vancouver-tripgo.skedgo.com/satapp",
-                       "https://matter-ca-bc-vancouver-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 46.25463,
-                         "lng": 20.1486,
-                         "timezone": "Europe/Budapest",
-                         "title": "Szeged, Hungary"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "HU_Szeged",
-              "polygon": "md|xG_zbyBy`Y??_al@x`Y?",
-              "timezone": "Europe/Budapest",
-              "urls": [
-                       "https://hadron-hu-szeged-tripgo.skedgo.com/satapp",
-                       "https://darkages-hu-szeged-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 32.782,
-                         "lng": -96.8,
-                         "timezone": "America/Chicago",
-                         "title": "Dallas, TX, USA"
-                         },
-                         {
-                         "lat": 32.755,
-                         "lng": -97.325,
-                         "timezone": "America/Chicago",
-                         "title": "Fort Worth, TX, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_fortworth",
-                        "wa_wal"
-                        ],
-              "name": "US_TX_Dallas",
-              "polygon": "}qcdEnxrsQqalE??_~cHpalE?",
-              "timezone": "America/Chicago",
-              "urls": [
-                       "https://inflationary-us-tx-dallas-tripgo.skedgo.com/satapp",
-                       "https://darkages-us-tx-dallas-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 44.839,
-                         "lng": -0.58,
-                         "timezone": "Europe/Paris",
-                         "title": "Bordeaux, France"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "FR_B_Bordeaux",
-              "polygon": "udbmG`{tGq`cH??s`aJp`cH?",
-              "timezone": "Europe/Paris",
-              "urls": [
-                       "https://matter-fr-b-bordeaux-tripgo.skedgo.com/satapp",
-                       "https://darkages-fr-b-bordeaux-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 48.116,
-                         "lng": -1.679,
-                         "timezone": "Europe/Paris",
-                         "title": "Rennes, France"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "FR_E_Rennes",
-              "polygon": "_tbcH~reKorbB??_|_CnrbB?",
-              "timezone": "Europe/Paris",
-              "urls": [
-                       "https://matter-fr-e-rennes-tripgo.skedgo.com/satapp",
-                       "https://darkages-fr-e-rennes-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "SE_NorthSweden",
-              "polygon": "ogbiKabzqAwkpCex}CsuaDs_No~[y{|Dite@~hRge{BeldEae_ArdkAwphCmteFpxRq~qCwfnBgnc@lk^sdtI{rvB}d_@ugFqjkBvieEyyfR|veM{zrBny_HhpuC?`u_y@",
-              "timezone": "Europe/Stockholm",
-              "urls": [
-                       "https://matter-se-northsweden-tripgo.skedgo.com/satapp",
-                       "https://darkages-se-northsweden-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 51.05383,
-                         "lng": 3.72501,
-                         "timezone": "Europe/Brussels",
-                         "title": "Ghent, Belgium"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "BE_NorthWestBelgium",
-              "polygon": "_{nxHa`{QoiBcmt@raGe~B|yJjKh|Dq|HwCshPiqF`{@m|BkmMp~De~Yh}AguLdgH_Ne`AygPbIw`Gtl@y}@ouBgsGmfAo~DdEclFwlHoiU|wiB??dz_EyiFt{InuAxnFnXh{JvtCh{Ln{Dr~A~rC`cEm{A|aC|LxcBwnBliC|^jfD_gAjdEi}NfwNq_@n}MitFh`FoiAopAoyIfyBkkDyyEslGfgCgSvqBo}A~eBecAe_@{mHtrA{iCdwB",
-              "timezone": "Europe/Brussels",
-              "urls": [
-                       "https://hadron-be-northwestbelgium-tripgo.skedgo.com/satapp",
-                       "https://darkages-be-northwestbelgium-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 53.558,
-                         "lng": -113.49,
-                         "timezone": "America/Edmonton",
-                         "title": "Edmonton, AB, Canada"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "CA_AB_Edmonton",
-              "polygon": "_sucI~rxvT_etB??_xnD~dtB?",
-              "timezone": "America/Edmonton",
-              "urls": [
-                       "https://baryogenesis-ca-ab-edmonton-tripgo.skedgo.com/satapp",
-                       "https://matter-ca-ab-edmonton-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 29.94138,
-                         "lng": -90.08237,
-                         "timezone": "US/Central",
-                         "title": "New Orleans, LA, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "US_LA_NewOrleans",
-              "polygon": "c{duDduhfPm_eA??glkCl_eA?",
-              "timezone": "US/Central",
-              "urls": [
-                       "https://inflationary-us-la-neworleans-tripgo.skedgo.com/satapp",
-                       "https://baryogenesis-us-la-neworleans-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 25.795,
-                         "lng": -80.225,
-                         "timezone": "US/Eastern",
-                         "title": "Miami, FL, USA"
-                         },
-                         {
-                         "lat": 26.122,
-                         "lng": -80.137,
-                         "timezone": "US/Eastern",
-                         "title": "Fort Lauderdale, FL, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s",
-                        "wa_wal"
-                        ],
-              "name": "US_FL_Miami",
-              "polygon": "_fwuC~y~mN_ulL??_zuE~tlL?",
-              "timezone": "US/Eastern",
-              "urls": [
-                       "https://inflationary-us-fl-miami-tripgo.skedgo.com/satapp",
-                       "https://matter-us-fl-miami-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 55.60529,
-                         "lng": 13.00016,
-                         "timezone": "Europe/Stockholm",
-                         "title": "Malmö, Sweden"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s",
-                        "wa_wal"
-                        ],
-              "name": "SE_SouthSweden",
-              "polygon": "_|}rI_vnmAodkA~wq@_{m@~tu@oweC~pdB?olli@~f{Cnj}HnkuCnsqHnyo@~tiP",
-              "timezone": "Europe/Stockholm",
-              "urls": [
-                       "https://matter-se-southsweden-tripgo.skedgo.com/satapp",
-                       "https://darkages-se-southsweden-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 59.93425,
-                         "lng": 30.32312,
-                         "timezone": "Europe/Moscow",
-                         "title": "Saint Petersburg, Russia"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "RU_NW_SaintPetersburg",
-              "polygon": "uj|iJiqhnDowgE??}i}OnwgE?",
-              "timezone": "Europe/Moscow",
-              "urls": [
-                       "https://matter-ru-nw-saintpetersburg-tripgo.skedgo.com/satapp",
-                       "https://darkages-ru-nw-saintpetersburg-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 40.44073,
-                         "lng": -80.00042,
-                         "timezone": "America/New_York",
-                         "title": "Pittsburgh, PA, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_healthy-ride-pittsburgh-pittsburgh",
-                        "wa_wal"
-                        ],
-              "name": "US_PA_Pittsburgh",
-              "polygon": "_huuFpg`iN}qh@ewBurKkqyB~`n@vXple@zaZdtAjtx@",
-              "timezone": "America/New_York",
-              "urls": [
-                       "https://inflationary-us-pa-pittsburgh-tripgo.skedgo.com/satapp",
-                       "https://darkages-us-pa-pittsburgh-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": -23.55392,
-                         "lng": -46.62735,
-                         "timezone": "America/Sao_Paulo",
-                         "title": "São Paulo, Brazil"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s",
-                        "wa_wal"
-                        ],
-              "name": "BR_SP_SaoPaulo",
-              "polygon": "n||pCntq|G_o}@nwH_yF~cb@onT_db@oqPowH_|B_xq@nqP_|Bn}@obd@nnTozDnm_A~kaA~uJnnT",
-              "timezone": "America/Sao_Paulo",
-              "urls": [
-                       "https://inflationary-br-sp-saopaulo-tripgo.skedgo.com/satapp",
-                       "https://darkages-br-sp-saopaulo-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": -30.02932,
-                         "lng": -51.21725,
-                         "timezone": "America/Sao_Paulo",
-                         "title": "Porto Alegre, Brazil"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_bikepoa",
-                        "wa_wal"
-                        ],
-              "name": "BR_PortoAlegre",
-              "polygon": "|uuwDp|jxHirkA??mqkAhrkA?",
-              "timezone": "America/Sao_Paulo",
-              "urls": [
-                       "https://inflationary-br-portoalegre-tripgo.skedgo.com/satapp",
-                       "https://darkages-br-portoalegre-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 50.84656,
-                         "lng": 4.3517,
-                         "timezone": "Europe/Brussels",
-                         "title": "Brussels, Belgium"
-                         },
-                         {
-                         "lat": 51.22111,
-                         "lng": 4.39971,
-                         "timezone": "Europe/Brussels",
-                         "title": "Antwerp, Belgium"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s",
-                        "wa_wal"
-                        ],
-              "name": "BE_NorthEastBelgium",
-              "polygon": "sjaxHiuiXklJauNygDzpCwKmqW|xBwkJuvRv_CwdDo`^zvAgvChqFnpAzs@wyP}~Ns`YphC{_OleKpd@glDuqM_|B{zPegBkiCdaBkyHvcGsxDzqFruEhxGqhJvfEqs@qp@_`JrqBijHdiFdiBbQ}bTehAkb@neAwcM_dBasCatBkmGx[yiEdvDimGhlGe_@r{CaoPriA_\\eSecP|[krEtxDyJmrAaiG|oD{vFp|C`uHfuAoyCl}GxdG}YxqBtoDxcBj_@ikBv{EzuAtyC`}E~{@qnEjuGjkEbpEr}Hzk@d}DhpHm|@piAutF|kDwg@jfFrlC?hdjH",
-              "timezone": "Europe/Brussels",
-              "urls": [
-                       "https://hadron-be-northeastbelgium-tripgo.skedgo.com/satapp",
-                       "https://darkages-be-northeastbelgium-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 58.96633,
-                         "lng": 5.73138,
-                         "timezone": "Europe/Oslo",
-                         "title": "Stavanger, Norway"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_bysykkelen",
-                        "wa_wal"
-                        ],
-              "name": "NO_Rogaland",
-              "polygon": "gcqlJqbgv@fe}E}c|@f`|Cr_NlbLlxx\\{ftK_mE",
-              "timezone": "Europe/Oslo",
-              "urls": [
-                       "https://matter-no-rogaland-tripgo.skedgo.com/satapp",
-                       "https://darkages-no-rogaland-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 33.75563,
-                         "lng": -84.38884,
-                         "timezone": "US/Eastern",
-                         "title": "Atlanta, GA, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_SoBi31",
-                        "wa_wal"
-                        ],
-              "name": "US_GA_Atlanta",
-              "polygon": "gjdjEhldeOgjmE??i`uEfjmE?",
-              "timezone": "US/Eastern",
-              "urls": [
-                       "https://inflationary-us-ga-atlanta-tripgo.skedgo.com/satapp",
-                       "https://baryogenesis-us-ga-atlanta-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 53.37988,
-                         "lng": -1.46952,
-                         "timezone": "Europe/London",
-                         "title": "Sheffield, UK"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "UK_Sheffield",
-              "polygon": "_fpeI~cyK?o`qNnljB??n`qN",
-              "timezone": "Europe/London",
-              "urls": [
-                       "https://hadron-uk-sheffield-tripgo.skedgo.com/satapp",
-                       "https://stars-uk-sheffield-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 63.82566,
-                         "lng": 20.26307,
-                         "timezone": "Europe/Stockholm",
-                         "title": "Umea, Sweden"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "SE_Umea",
-              "polygon": "oadaK{`}gAgy~@ahd@osmAizxA{vYgwsAjpIyxlDcx|@ocW?ezxx@bgdG~puU?nrgn@",
-              "timezone": "Europe/Stockholm",
-              "urls": [
-                       "https://matter-se-umea-tripgo.skedgo.com/satapp",
-                       "https://darkages-se-umea-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 62.47181,
-                         "lng": 6.14873,
-                         "timezone": "Europe/Oslo",
-                         "title": "Alesund, Norway"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "NO_Oppland",
-              "polygon": "}eurJyzdXy~_G{m}BempDyloHlgfDazpc@x~iBfb\\vpYqdkAp`h@i{fAp`{@ria@~hZ~flA",
-              "timezone": "Europe/Oslo",
-              "urls": [
-                       "https://matter-no-oppland-tripgo.skedgo.com/satapp",
-                       "https://darkages-no-oppland-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 53.34845,
-                         "lng": -6.25954,
-                         "timezone": "Europe/Dublin",
-                         "title": "Dublin, Ireland"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_dublinbikes",
-                        "wa_wal"
-                        ],
-              "name": "IE_Dublin",
-              "polygon": "_sx_Inktn@onnG??ob{KnnnG?",
-              "timezone": "Europe/Dublin",
-              "urls": [
-                       "https://matter-ie-dublin-tripgo.skedgo.com/satapp",
-                       "https://darkages-ie-dublin-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 43.07476,
-                         "lng": -89.38376,
-                         "timezone": "US/Central",
-                         "title": "Madison, WI, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_madison",
-                        "wa_wal"
-                        ],
-              "name": "US_WI_Madison",
-              "polygon": "gsibGzkzaPg}gC??khsEf}gC?",
-              "timezone": "US/Central",
-              "urls": [
-                       "https://baryogenesis-us-wi-madison-tripgo.skedgo.com/satapp",
-                       "https://hadron-us-wi-madison-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 48.427,
-                         "lng": -123.364,
-                         "timezone": "America/Vancouver",
-                         "title": "Victoria, BC, Canada"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_nextbike-victoria",
-                        "wa_wal"
-                        ],
-              "name": "CA_BC_Victoria",
-              "polygon": "oyneH~jitV_w|A??_acD~v|A?",
-              "timezone": "America/Vancouver",
-              "urls": [
-                       "https://baryogenesis-ca-bc-victoria-tripgo.skedgo.com/satapp",
-                       "https://matter-ca-bc-victoria-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 42.96336,
-                         "lng": -85.66809,
-                         "timezone": "US/Eastern",
-                         "title": "Grand Rapids, MI, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "US_MI_GrandRapids",
-              "polygon": "{eidGjrqkOchtA??a{|AbhtA?",
-              "timezone": "US/Eastern",
-              "urls": [
-                       "https://inflationary-us-mi-grandrapids-tripgo.skedgo.com/satapp",
-                       "https://matter-us-mi-grandrapids-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 59.37991,
-                         "lng": 13.50295,
-                         "timezone": "Europe/Stockholm",
-                         "title": "Karlstad, Sweden"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "SE_Karlstad",
-              "polygon": "s}opJcbczA|roM?d|AberW_osCkFiq`@a}m@mrGmvl@vdi@{f^gfb@g`h@wu_@ybHicgAxl[owMakt@ayZ|sSikKgk^|K}yh@i`x@_`~@srW`bD}vi@goK",
-              "timezone": "Europe/Stockholm",
-              "urls": [
-                       "https://matter-se-karlstad-tripgo.skedgo.com/satapp",
-                       "https://darkages-se-karlstad-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": 32.71463,
-                         "lng": -117.16377,
-                         "timezone": "US/Pacific",
-                         "title": "San Diego, CA, USA"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "cy_bic-s_decobike-san-diego",
-                        "wa_wal"
-                        ],
-              "name": "US_CA_SanDiego",
-              "polygon": "_rbkEh`qmUu`Gqa{@hga@cd~E~cgCoq]hqSpbaF",
-              "timezone": "US/Pacific",
-              "urls": [
-                       "https://baryogenesis-us-ca-sandiego-tripgo.skedgo.com/satapp",
-                       "https://stars-us-ca-sandiego-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": -16.9204,
-                         "lng": 145.771,
-                         "timezone": "Australia/Brisbane",
-                         "title": "Cairns, QLD, Australia"
-                         },
-                         {
-                         "lat": -19.2593,
-                         "lng": 146.822,
-                         "timezone": "Australia/Brisbane",
-                         "title": "Townsville, QLD, Australia"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "ps_tax",
-                        "ps_shu",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "AU_QLD_Northern",
-              "polygon": "~gmcC_mmvZ_sv^??_x_X~rv^?",
-              "timezone": "Australia/Brisbane",
-              "urls": [
-                       "https://darkages-au-qld-northern-tripgo.skedgo.com/satapp",
-                       "https://granduni-au-qld-northern-tripgo.skedgo.com/satapp"
-                       ]
-              },
-              {
-              "cities": [
-                         {
-                         "lat": -33.86749,
-                         "lng": 151.20699,
-                         "timezone": "Australia/Sydney",
-                         "title": "Sydney, NSW, Australia"
-                         },
-                         {
-                         "lat": -32.92676,
-                         "lng": 151.77358,
-                         "timezone": "Australia/Sydney",
-                         "title": "Newcastle, NSW, Australia"
-                         },
-                         {
-                         "lat": -34.42573,
-                         "lng": 150.90462,
-                         "timezone": "Australia/Sydney",
-                         "title": "Wollongong, NSW, Australia"
-                         }
-                         ],
-              "modes": [
-                        "pt_pub",
-                        "pt_ltd_SCHOOLBUS",
-                        "ps_tax",
-                        "ps_shu",
-                        "me_car",
-                        "me_mot",
-                        "cy_bic",
-                        "wa_wal"
-                        ],
-              "name": "AU_NSW_Sydney",
-              "polygon": "nwcvE_fno[owyR??mcjRnwyR?",
-              "timezone": "Australia/Sydney",
-              "urls": [
-                       "https://granduni-au-nsw-sydney-tripgo.skedgo.com/satapp",
-                       "https://darkages-au-nsw-sydney-tripgo.skedgo.com/satapp",
-                       "https://inflationary-au-nsw-sydney-tripgo.skedgo.com/satapp"
-                       ]
-              }
-              ]
+    {
+      "name": "DK_Continental",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Copenhagen",
+      "cities": [
+        {
+          "lat": 56.16295,
+          "lng": 10.20312,
+          "identifier": "DK.Aarhus",
+          "title": "Aarhus, Denmark",
+          "timezone": "Europe/Copenhagen",
+          "region": "DK_Continental"
+        },
+        {
+          "lat": 57.04881,
+          "lng": 9.9216,
+          "identifier": "DK.Aalborg",
+          "title": "Aalborg, Denmark",
+          "timezone": "Europe/Copenhagen",
+          "region": "DK_Continental"
+        }
+      ],
+      "polygon": "ovntIowdn@oikF~`f@onqC__pR~wkHoihJnggAngaI~zm@~zm@nnT`poCn|k@l|k@~heA_fiArpq@ox]}sBdabBipEptXo|CglAsy@rxD~bB~lElmF~kQbj@`jIqcAxtAlNzoC~_Bf`@|r@n|Bz{@vu@l[xYcy@nlH`\\sVxRjp@m}@zrBfHbcDaiD|sBohAwu@ewCvqSlNf|FkKtaHudD|tOmVptKjc@x|Cz@xaC}r@dfBnI`}EjhAfdBqTv{CfP|~DayAjjHqGvdI_lQ~`J{lSdv_@y{VdppAwflCztp@",
+      "urls": [
+        "https://energy.skedgo.com/satapp",
+        "https://andromeda.skedgo.com/satapp",
+        "https://matter.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "UK_NorthScotland",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/London",
+      "cities": [
+        {
+          "lat": 57.15,
+          "lng": -2.09,
+          "identifier": "GB.SCT.Aberdeen",
+          "title": "Aberdeen, UK",
+          "timezone": "Europe/London",
+          "region": "UK_NorthScotland"
+        }
+      ],
+      "polygon": "_aisJ~nyo@?_oyo@~nh\\??~nyo@",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://andromeda.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "AU_SA_Adelaide",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Australia/Adelaide",
+      "cities": [
+        {
+          "lat": -34.92861,
+          "lng": 138.59996,
+          "identifier": "AU.SA.Adelaide",
+          "title": "Adelaide, SA, Australia",
+          "timezone": "Australia/Adelaide",
+          "region": "AU_SA_Adelaide"
+        }
+      ],
+      "polygon": "~{vvEwa}kYooxC??_pvBnoxC?",
+      "urls": [
+        "https://granduni.skedgo.com/satapp",
+        "https://darkages.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "SA_03_AlUla",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tnc_alula-jeeny",
+        "ps_tnc_alula-lamar",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Asia/Riyadh",
+      "cities": [
+        {
+          "lat": 26.6142,
+          "lng": 37.92081,
+          "identifier": "SA.03.Al-'Ula",
+          "title": "Al-'Ula, Saudi Arabia",
+          "timezone": "Asia/Riyadh",
+          "region": "SA_03_AlUla"
+        }
+      ],
+      "polygon": "{f{aD{adfF?csa@vif@??bsa@",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://darkages.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "NO_Oppland",
+      "modes": [
+        "in_air",
+        "pt_pub",
+        "pt_ltd_SCHOOLBUS",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Oslo",
+      "cities": [
+        {
+          "lat": 62.47181,
+          "lng": 6.14873,
+          "identifier": "NO.Alesund",
+          "title": "Alesund, Norway",
+          "timezone": "Europe/Oslo",
+          "region": "NO_Oppland"
+        }
+      ],
+      "polygon": "}eurJyzdXy~_G{m}BempDyloHlgfDazpc@x~iBfb\\vpYqdkAp`h@i{fAp`{@ria@~hZ~flA",
+      "urls": [
+        "https://energy.skedgo.com/satapp",
+        "https://andromeda.skedgo.com/satapp",
+        "https://matter.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "AU_NT_AliceSprings",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Australia/Darwin",
+      "cities": [
+        {
+          "lat": -23.7014,
+          "lng": 133.879,
+          "identifier": "AU.NT.Alice-Springs",
+          "title": "Alice Springs, NT, Australia",
+          "timezone": "Australia/Darwin",
+          "region": "AU_NT_AliceSprings"
+        }
+      ],
+      "polygon": "~nnqC_wlnX_etB??oljB~dtB?",
+      "urls": [
+        "https://granduni.skedgo.com/satapp",
+        "https://darkages.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "NL_NH_Amsterdam",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_car-s",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Amsterdam",
+      "cities": [
+        {
+          "lat": 52.37115,
+          "lng": 4.89793,
+          "identifier": "NL.NH.Amsterdam",
+          "title": "Amsterdam, Netherlands",
+          "timezone": "Europe/Amsterdam",
+          "region": "NL_NH_Amsterdam"
+        }
+      ],
+      "polygon": "_o}}Hu_t_@q[r`Y{p@fwe@uuAdz`Akf@~|m@avqCinc@btuC{hkAzp@gwe@p[s`Y",
+      "urls": [
+        "https://recombination.skedgo.com/satapp",
+        "https://hadron.skedgo.com/satapp",
+        "https://energy.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_MI_AnnArbor",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "US/Eastern",
+      "cities": [
+        {
+          "lat": 42.28117,
+          "lng": -83.74701,
+          "identifier": "US.MI.Ann-Arbor",
+          "title": "Ann Arbor, MI, USA",
+          "timezone": "US/Eastern",
+          "region": "US_MI_AnnArbor"
+        }
+      ],
+      "polygon": "gkifGrel{NfriAia@nxZrpd@~}x@vXngP{i@zr]lTxhZ{K~mg@iCpHfuCneAv~pBgniHb{@_Xim`A_q@kvzAfhUbP",
+      "urls": [
+        "https://baryogenesis.skedgo.com/satapp",
+        "https://lepton.skedgo.com/satapp",
+        "https://matter.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_GA_Atlanta",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "US/Eastern",
+      "cities": [
+        {
+          "lat": 33.75563,
+          "lng": -84.38884,
+          "identifier": "US.GA.Atlanta",
+          "title": "Atlanta, GA, USA",
+          "timezone": "US/Eastern",
+          "region": "US_GA_Atlanta"
+        }
+      ],
+      "polygon": "gjdjEhldeOgjmE??i`uEfjmE?",
+      "urls": [
+        "https://lepton.skedgo.com/satapp",
+        "https://matter.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "NZ_N_Auckland",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Pacific/Auckland",
+      "cities": [
+        {
+          "lat": -36.84449,
+          "lng": 174.76771,
+          "identifier": "NZ.N.Auckland",
+          "title": "Auckland, New Zealand",
+          "timezone": "Pacific/Auckland",
+          "region": "NZ_N_Auckland"
+        }
+      ],
+      "polygon": "nhhjFodd|_@_nvY??odpd@~mvY?",
+      "urls": [
+        "https://granduni.skedgo.com/satapp",
+        "https://energy.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "DE_BV_Augsburg",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Berlin",
+      "cities": [
+        {
+          "lat": 48.37129,
+          "lng": 10.90095,
+          "identifier": "DE.BV.Augsburg",
+          "title": "Augsburg, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_BV_Augsburg"
+        },
+        {
+          "lat": 48.39831,
+          "lng": 9.99105,
+          "identifier": "DE.BV.Ulm",
+          "title": "Ulm, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_BV_Augsburg"
+        }
+      ],
+      "polygon": "e`tbH{s{s@syuAu|j@epcEu|fG|g_AmybCny|AiooAvl|@jvpBrhcClw_CgmBv}CkdDfuC~[vfFmqCzrB_\\wXyhBjxCsqAzKtd@~gG}jB`|E`uBvXshCnbL}dCal@cfBtAok@nfBpA`lCneA`_B~jAps@xpAha@fc@dn@fdChCjjA|{g@k`Sr~Vc_Fx|i@lMvpBwmAxqB|Fj}Amb@bbDsi@pzCap@bnKdtAzfGr~@njC`zAfaKas@vnCatBha@mt@jhCg{BoTkt@pwDetAzaCdm@vpB`jA}_DhdAst@p_Cvv@n@dwBy_BthEmZ`kFeuCyeAoRvsAu`A~j@gr@aN{z@st@kZ{cB}_A|aCxu@pnBwQf}@ooBhp@ofAxjA",
+      "urls": [
+        "https://recombination.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_TX_Austin",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/Chicago",
+      "cities": [
+        {
+          "lat": 30.263,
+          "lng": -97.741,
+          "identifier": "US.TX.Austin",
+          "title": "Austin, TX, USA",
+          "timezone": "America/Chicago",
+          "region": "US_TX_Austin"
+        },
+        {
+          "lat": 29.425,
+          "lng": -98.495,
+          "identifier": "US.TX.San-Antonio",
+          "title": "San Antonio, TX, USA",
+          "timezone": "America/Chicago",
+          "region": "US_TX_Austin"
+        }
+      ],
+      "polygon": "ohuoD~|f{Q_brJ??_brJ~arJ?",
+      "urls": [
+        "https://energy.skedgo.com/satapp",
+        "https://darkages.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "AR_B_BahiaBlanca",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/Argentina/Buenos_Aires",
+      "cities": [
+        {
+          "lat": -38.7194,
+          "lng": -62.2686,
+          "identifier": "AR.B.Bahia-Blanca",
+          "title": "Bahia Blanca, Argentina",
+          "timezone": "America/Argentina/Buenos_Aires",
+          "region": "AR_B_BahiaBlanca"
+        }
+      ],
+      "polygon": "xyulFneo|Jqb}@??wrjBpb}@?",
+      "urls": [
+        "https://granduni.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "ES_CT_Barcelona",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Madrid",
+      "cities": [
+        {
+          "lat": 41.38741,
+          "lng": 2.16861,
+          "identifier": "ES.CT.Barcelona",
+          "title": "Barcelona, Spain",
+          "timezone": "Europe/Madrid",
+          "region": "ES_CT_Barcelona"
+        }
+      ],
+      "polygon": "}djzFszgHahHen@_}cBkks@oyGk~jDlyYmnXzcgAt{vBhtRxqmA",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://energy.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "IE_NorthIreland",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Dublin",
+      "cities": [
+        {
+          "lat": 54.6,
+          "lng": -5.93,
+          "identifier": "IE.NIR.Belfast",
+          "title": "Belfast, Northern Ireland",
+          "timezone": "Europe/Dublin",
+          "region": "IE_NorthIreland"
+        }
+      ],
+      "polygon": "_ckqI~lcbA?of}]~qvDoofBnfrB??n{mMn{vA??nzuR",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "BR_MG_BeloHorizonte",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/Sao_Paulo",
+      "cities": [
+        {
+          "lat": -19.91766,
+          "lng": -43.93396,
+          "identifier": "BR.MG.Belo-Horizonte",
+          "title": "Belo Horizonte, Brazil",
+          "timezone": "America/Sao_Paulo",
+          "region": "BR_MG_BeloHorizonte"
+        }
+      ],
+      "polygon": "pquwBhq`kGveHykJptRqGfwNzsSphEbsOufMnyCkjYkdEskNgzG",
+      "urls": [
+        "https://hadron.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "NO_Bergen",
+      "modes": [
+        "in_air",
+        "pt_pub",
+        "pt_ltd_SCHOOLBUS",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Oslo",
+      "cities": [
+        {
+          "lat": 60.38883,
+          "lng": 5.32984,
+          "identifier": "NO.Bergen",
+          "title": "Bergen, Norway",
+          "timezone": "Europe/Oslo",
+          "region": "NO_Bergen"
+        }
+      ],
+      "polygon": "snyrJctcX?}rub@r`cEhoFn~DbbkDuqMbxc[",
+      "urls": [
+        "https://energy.skedgo.com/satapp",
+        "https://andromeda.skedgo.com/satapp",
+        "https://matter.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "DE_BE_Berlin",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Berlin",
+      "cities": [
+        {
+          "lat": 52.52115,
+          "lng": 13.41035,
+          "identifier": "DE.BE.Berlin",
+          "title": "Berlin, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_BE_Berlin"
+        },
+        {
+          "lat": 52.396,
+          "lng": 13.0617,
+          "identifier": "DE.BE.Potsdam",
+          "title": "Potsdam, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_BE_Berlin"
+        }
+      ],
+      "polygon": "}yx}HecqkAar~B}ce@CoauGjxAvXbfDz{DtfB}i@tm@gfOnuFcpJzvCwcMpjQwgWjtGqgVdhHqjI|rFdrDxdFowDzpHjkHzcD~sHvpXmkHreGe_Wx_OnTdvGjfDfuCcgHhrDmdErhJbrDgoj@zblL",
+      "urls": [
+        "https://recombination.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "CH_NorthWestSwitzerland",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Zurich",
+      "cities": [
+        {
+          "lat": 46.94828,
+          "lng": 7.4515,
+          "identifier": "CH.BS.Bern",
+          "title": "Bern, Switzerland",
+          "timezone": "Europe/Zurich",
+          "region": "CH_NorthWestSwitzerland"
+        },
+        {
+          "lat": 47.55922,
+          "lng": 7.58825,
+          "identifier": "CH.BS.Basel",
+          "title": "Basel, Switzerland",
+          "timezone": "Europe/Zurich",
+          "region": "CH_NorthWestSwitzerland"
+        }
+      ],
+      "polygon": "ssb|Gigte@uxEigIuhFanKq{AzaCaiAj[uzNeoEk|EpfEenHueLrc@wpBajCwrMqf@sdFq{Cs{Cq|AylDl@qnB_kAm}AysAduCqjBmkAypAiwCl@_wAm_BdPoeDofMiuCazFiy@ppAkiEamGexFi_LebHtcAelBi}La|BdPey@ciGkpD`dCnm@b`EdYraMxTfzGevCse@meEc`E}vDswCekAohDgk@ohDk{FtcAkwAm|Gr~AggIqvAy}HhzAa|EwTsbG`i@{K~fGb`E|^szI~xAqnBcfAgbEa\\etIrJecJwhD_kIsfAvyDw`CaxA`v@kcKibHzK_fEabKqt@glA|A_fBiwAwg@lj@auBdc@opAmnBeuCtTadCmw@uhE|wFdn@lj@rbGn~B_|EccAooGtcgD??dz{GqbDm{K",
+      "urls": [
+        "https://recombination.skedgo.com/satapp",
+        "https://hadron.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "DE_NW_Bielefeld",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Berlin",
+      "cities": [
+        {
+          "lat": 52.03153,
+          "lng": 8.5359,
+          "identifier": "DE.NW.Bielefeld",
+          "title": "Bielefeld, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_NW_Bielefeld"
+        }
+      ],
+      "polygon": "}mhyHoecq@cmfBt|nAmxkBkg`FnhwC_nsB`}z@txdG",
+      "urls": [
+        "https://recombination.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "ES_PV_Bilbao",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Madrid",
+      "cities": [
+        {
+          "lat": 43.26315,
+          "lng": -2.93568,
+          "identifier": "ES.PV.Bilbao",
+          "title": "Bilbao, Spain",
+          "timezone": "Europe/Madrid",
+          "region": "ES_PV_Bilbao"
+        },
+        {
+          "lat": 43.31833,
+          "lng": -1.97196,
+          "identifier": "ES.PV.San-Sebastián",
+          "title": "San Sebastián, Spain",
+          "timezone": "Europe/Madrid",
+          "region": "ES_PV_Bilbao"
+        },
+        {
+          "lat": 42.84634,
+          "lng": -2.67251,
+          "identifier": "ES.PV.Vitoria-Gasteiz",
+          "title": "Vitoria Gasteiz, Spain",
+          "timezone": "Europe/Madrid",
+          "region": "ES_PV_Bilbao"
+        },
+        {
+          "lat": 42.81828,
+          "lng": -1.64187,
+          "identifier": "ES.PV.Pamplona",
+          "title": "Pamplona, Spain",
+          "timezone": "Europe/Madrid",
+          "region": "ES_PV_Bilbao"
+        }
+      ],
+      "polygon": "ulzfGvsbTguj@uap@_uFcfaCxlAwqfCbg[czRhzDgqEvQ}lPdjIabDhvqAyiKdpOpjO{_JtorCeXhttC",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://energy.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "UK_Birmingham",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/London",
+      "cities": [
+        {
+          "lat": 52.48603,
+          "lng": -1.89261,
+          "identifier": "GB.ENG.Birmingham",
+          "title": "Birmingham, UK",
+          "timezone": "Europe/London",
+          "region": "UK_Birmingham"
+        }
+      ],
+      "polygon": "_qnbI~kuP?_~cH~ugC??~}cH",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://andromeda.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_ID_Boise",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/Denver",
+      "cities": [
+        {
+          "lat": 43.61583,
+          "lng": -116.20167,
+          "identifier": "US.ID.Boise",
+          "title": "Boise, ID, USA",
+          "timezone": "America/Denver",
+          "region": "US_ID_Boise"
+        }
+      ],
+      "polygon": "{z}iGbbvgUadIaL_TqoCebCw{_Bfo@c`d@|rDivH~jOmwFh_IhBdcCn|A`vOsuDteEvpErfAbeXgtFbweAzrAjnUmhNp`a@_qZB",
+      "urls": [
+        "https://baryogenesis.skedgo.com/satapp",
+        "https://energy.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "IT_Bologna",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Rome",
+      "cities": [
+        {
+          "lat": 44.49434,
+          "lng": 11.34314,
+          "identifier": "IT.Bologna",
+          "title": "Bologna, Italy",
+          "timezone": "Europe/Rome",
+          "region": "IT_Bologna"
+        },
+        {
+          "lat": 44.83563,
+          "lng": 11.62035,
+          "identifier": "IT.Ferrara",
+          "title": "Ferrara, Italy",
+          "timezone": "Europe/Rome",
+          "region": "IT_Bologna"
+        },
+        {
+          "lat": 44.64603,
+          "lng": 10.92607,
+          "identifier": "IT.Modena",
+          "title": "Modena, Italy",
+          "timezone": "Europe/Rome",
+          "region": "IT_Bologna"
+        },
+        {
+          "lat": 44.41767,
+          "lng": 12.1991,
+          "identifier": "IT.Ravenna",
+          "title": "Ravenna, Italy",
+          "timezone": "Europe/Rome",
+          "region": "IT_Bologna"
+        }
+      ],
+      "polygon": "ogurG_wl`A?_kfJ~vyE??~jfJ",
+      "urls": [
+        "https://matter.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "FR_B_Bordeaux",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Paris",
+      "cities": [
+        {
+          "lat": 44.839,
+          "lng": -0.58,
+          "identifier": "FR.B.Bordeaux",
+          "title": "Bordeaux, France",
+          "timezone": "Europe/Paris",
+          "region": "FR_B_Bordeaux"
+        }
+      ],
+      "polygon": "udbmG`{tGq`cH??s`aJp`cH?",
+      "urls": [
+        "https://hadron.skedgo.com/satapp",
+        "https://recombination.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_MA_Boston",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/New_York",
+      "cities": [
+        {
+          "lat": 42.36071,
+          "lng": -71.0577,
+          "identifier": "US.MA.Boston",
+          "title": "Boston, MA, USA",
+          "timezone": "America/New_York",
+          "region": "US_MA_Boston"
+        }
+      ],
+      "polygon": "ovg|Ft}aqLab\\zcB}oZxkg@icQ{KotB_Ud^bjGoi|C?sle@{sdAi[qbaFdvcI??`diF",
+      "urls": [
+        "https://matter.skedgo.com/satapp",
+        "https://darkages.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "DE_HB_Bremen",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_car-s",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Berlin",
+      "cities": [
+        {
+          "lat": 53.07848,
+          "lng": 8.80468,
+          "identifier": "DE.HB.Bremen",
+          "title": "Bremen, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_HB_Bremen"
+        }
+      ],
+      "polygon": "sr}}H_s|i@oaBrcAqyA`N}rKuqGqkG~gAsRbwBeiDxlDuzE~tBldEzyEaaBr`Sis@lTqEhlMg{Dv{O}`Fse@wfCr}BkgBePjZakF}kA{i@wJ}pC{zBboEmhDal@kt@p_BceC_uB_dAugK}BoiUxkA}hFkt@{wFvoA{gLoi_@qnBe`EwnCi|A`l@gwPuuQmsKgsDitRnaAs_BfuCgjMakFy_U~tB_h@lgU}bA~pOqm_@j`RedJnyq@{eLd|FomCpnBeceB{dgFt`|@mmpFpc{Cq`y@jf|Api_A|bkBvx~E{bm@jywC",
+      "urls": [
+        "https://recombination.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "UK_Bristol",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/London",
+      "cities": [
+        {
+          "lat": 51.45545,
+          "lng": -2.59159,
+          "identifier": "GB.ENG.Bristol",
+          "title": "Bristol, UK",
+          "timezone": "Europe/London",
+          "region": "UK_Bristol"
+        }
+      ],
+      "polygon": "oro~H~kuP?_||F~yuE??~{|F",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://andromeda.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "BE_NorthEastBelgium",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_car-s",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Brussels",
+      "cities": [
+        {
+          "lat": 50.84656,
+          "lng": 4.3517,
+          "identifier": "BE.Brussels",
+          "title": "Brussels, Belgium",
+          "timezone": "Europe/Brussels",
+          "region": "BE_NorthEastBelgium"
+        },
+        {
+          "lat": 51.22111,
+          "lng": 4.39971,
+          "identifier": "BE.Antwerp",
+          "title": "Antwerp, Belgium",
+          "timezone": "Europe/Brussels",
+          "region": "BE_NorthEastBelgium"
+        }
+      ],
+      "polygon": "sjaxHiuiXklJauNygDzpCwKmqW|xBwkJuvRv_CwdDo`^zvAgvChqFnpAzs@wyP}~Ns`YphC{_OleKpd@glDuqM_|B{zPegBkiCdaBkyHvcGsxDzqFruEhxGqhJvfEqs@qp@_`JrqBijHdiFdiBbQ}bTehAkb@neAwcM_dBasCatBkmGx[yiEdvDimGhlGe_@r{CaoPriA_\\eSecP|[krEtxDyJmrAaiG|oD{vFp|C`uHfuAoyCl}GxdG}YxqBtoDxcBj_@ikBv{EzuAtyC`}E~{@qnEjuGjkEbpEr}Hzk@d}DhpHm|@piAutF|kDwg@jfFrlC?hdjHsziB?",
+      "urls": [
+        "https://hadron.skedgo.com/satapp",
+        "https://recombination.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "HU_Budapest",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Budapest",
+      "cities": [
+        {
+          "lat": 47.502,
+          "lng": 19.047,
+          "identifier": "HU.Budapest",
+          "title": "Budapest, Hungary",
+          "timezone": "Europe/Budapest",
+          "region": "HU_Budapest"
+        }
+      ],
+      "polygon": "_lf~GoeiqBoweC??_vgCnweC?",
+      "urls": [
+        "https://hadron.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "AR_C_BuenosAires",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/Argentina/Buenos_Aires",
+      "cities": [
+        {
+          "lat": -34.61439,
+          "lng": -58.44609,
+          "identifier": "AR.C.Buenos-Aires",
+          "title": "Buenos Aires, Argentina",
+          "timezone": "America/Argentina/Buenos_Aires",
+          "region": "AR_C_BuenosAires"
+        }
+      ],
+      "polygon": "xmjwErfshJqbuCx~DiipAkoFwaJymqC`}q@_uf@nw`Aqx{AdnrAs{Zrbz@riPkdFhigA",
+      "urls": [
+        "https://stars.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_NY_Buffalo",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "US/Eastern",
+      "cities": [
+        {
+          "lat": 42.95859,
+          "lng": -78.88581,
+          "identifier": "US.NY.Buffalo",
+          "title": "Buffalo, NY, USA",
+          "timezone": "US/Eastern",
+          "region": "US_NY_Buffalo"
+        }
+      ],
+      "polygon": "kejdG~eo`N_qHc@elDbuAmaEz@s~A~j@g_B`jA{XxlDihLt`HshFgQoqAnxLkf@tSm}A_hAsqAzNodAqRgfA_xAce@yEayAzK{|Aps@q[wJkhDu~B?cxlAhdf@e`h@z|c@nr@ftb@tlf@`sTt~xAe~PhiTw`d@eew@",
+      "urls": [
+        "https://lepton.skedgo.com/satapp",
+        "https://stars.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "AU_TAS",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Australia/Sydney",
+      "cities": [
+        {
+          "lat": -41.07527,
+          "lng": 145.90452,
+          "identifier": "AU.TAS.Burnie",
+          "title": "Burnie, TAS, Australia",
+          "timezone": "Australia/Sydney",
+          "region": "AU_TAS"
+        },
+        {
+          "lat": -41.21241,
+          "lng": 146.34748,
+          "identifier": "AU.TAS.Devonport",
+          "title": "Devonport, TAS, Australia",
+          "timezone": "Australia/Sydney",
+          "region": "AU_TAS"
+        },
+        {
+          "lat": -41.43731,
+          "lng": 147.14126,
+          "identifier": "AU.TAS.Launceston",
+          "title": "Launceston, TAS, Australia",
+          "timezone": "Australia/Sydney",
+          "region": "AU_TAS"
+        },
+        {
+          "lat": -42.88571,
+          "lng": 147.32887,
+          "identifier": "AU.TAS.Hobart",
+          "title": "Hobart, TAS, Australia",
+          "timezone": "Australia/Sydney",
+          "region": "AU_TAS"
+        },
+        {
+          "lat": -41.16297,
+          "lng": 146.14781,
+          "identifier": "AU.TAS.Ulverstone",
+          "title": "Ulverstone, TAS, Australia",
+          "timezone": "Australia/Sydney",
+          "region": "AU_TAS"
+        }
+      ],
+      "polygon": "~cviGolgqZourQ??o_vWnurQ?",
+      "urls": [
+        "https://granduni.skedgo.com/satapp",
+        "https://darkages.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "CA_AB_Calgary",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/Edmonton",
+      "cities": [
+        {
+          "lat": 51.0458,
+          "lng": -114.0581,
+          "identifier": "CA.AB.Calgary",
+          "title": "Calgary, AB, Canada",
+          "timezone": "America/Edmonton",
+          "region": "CA_AB_Calgary"
+        }
+      ],
+      "polygon": "kcabIzfjmTdqcWsmThkX~_kt@ujzWfnc@",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://energy.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "UK_Wales",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/London",
+      "cities": [
+        {
+          "lat": 51.47789,
+          "lng": -3.17829,
+          "identifier": "GB.WLS.Cardiff",
+          "title": "Cardiff, UK",
+          "timezone": "Europe/London",
+          "region": "UK_Wales"
+        }
+      ],
+      "polygon": "_fpeI~eq`@?_f`M~s`B??_cmAnxtI??~inO",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://andromeda.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "BE_SouthWestBelgium",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Brussels",
+      "cities": [
+        {
+          "lat": 50.41203,
+          "lng": 4.44362,
+          "identifier": "BE.Charleroi",
+          "title": "Charleroi, Belgium",
+          "timezone": "Europe/Brussels",
+          "region": "BE_SouthWestBelgium"
+        }
+      ],
+      "polygon": "w|xtHugo\\byrB?rxPl}XzqNf`@xiHzla@hlAvtL}}Ap`SwyA~jFhlAbcUm~CtjJo}Fnc@y{D}_DexBwfL{mFdaEmmCgBzPxsGqg@bcDuvNeuCerGakL}|AzyEj`B~eBjKpxDsoI|mJieGxnI`fDr`YyaCj~FnDxgFuLprLldFvu@bu@vnCehDrsFw_GvbBawOtWyzErbG`_@nyTyyApV{}Bm{BsfAdmFf}ClgD~cBpoMgfEdeOecA|dBk_Ol{BeqHlxCmwAu~BqzDnr@_PvuF_zAn~Ak}AtW{vBz|A?icdI",
+      "urls": [
+        "https://hadron.skedgo.com/satapp",
+        "https://recombination.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_TN_Chattanooga",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "US/Central",
+      "cities": [
+        {
+          "lat": 35.03342,
+          "lng": -85.24408,
+          "identifier": "US.TN.Chattanooga",
+          "title": "Chattanooga, TN, USA",
+          "timezone": "US/Central",
+          "region": "US_TN_Chattanooga"
+        }
+      ],
+      "polygon": "y|ltEb}~gO{he@??o{p@zhe@?",
+      "urls": [
+        "https://lepton.skedgo.com/satapp",
+        "https://stars.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_IL_Chicago",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/Chicago",
+      "cities": [
+        {
+          "lat": 41.87811,
+          "lng": -87.6298,
+          "identifier": "US.IL.Chicago",
+          "title": "Chicago, IL, USA",
+          "timezone": "America/Chicago",
+          "region": "US_IL_Chicago"
+        }
+      ],
+      "polygon": "}ka{F~ek|OakiF??_kiF`kiF?",
+      "urls": [
+        "https://lepton.skedgo.com/satapp",
+        "https://stars.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "NZ_S_Christchurch",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "NZ",
+      "cities": [
+        {
+          "lat": -43.531,
+          "lng": 172.637,
+          "identifier": "NZ.S.Christchurch",
+          "title": "Christchurch, New Zealand",
+          "timezone": "NZ",
+          "region": "NZ_S_Christchurch"
+        }
+      ],
+      "polygon": "~dztF_i|t^?onmr@~luj@??nnmr@",
+      "urls": [
+        "https://granduni.skedgo.com/satapp",
+        "https://energy.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_OH_Cincinnati",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/New_York",
+      "cities": [
+        {
+          "lat": 39.1048,
+          "lng": -84.5114,
+          "identifier": "US.OH.Cincinnati",
+          "title": "Cincinnati, OH, USA",
+          "timezone": "America/New_York",
+          "region": "US_OH_Cincinnati"
+        }
+      ],
+      "polygon": "ujsnFjz_eO{sVieoAmm@{km@ddy@pGnqj@|zV`}Fdj{@",
+      "urls": [
+        "https://matter.skedgo.com/satapp",
+        "https://darkages.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_OH_Cleveland",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/New_York",
+      "cities": [
+        {
+          "lat": 41.50132,
+          "lng": -81.69516,
+          "identifier": "US.OH.Cleveland",
+          "title": "Cleveland, OH, USA",
+          "timezone": "America/New_York",
+          "region": "US_OH_Cleveland"
+        }
+      ],
+      "polygon": "kpk}FdngpNjqYidP~kf@taB|eZhsuAk`^ngx@gg\\rG",
+      "urls": [
+        "https://matter.skedgo.com/satapp",
+        "https://darkages.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "DE_NW_Cologne",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_car-s",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Berlin",
+      "cities": [
+        {
+          "lat": 50.93734,
+          "lng": 6.95984,
+          "identifier": "DE.NW.Cologne",
+          "title": "Cologne, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_NW_Cologne"
+        },
+        {
+          "lat": 50.73722,
+          "lng": 7.09906,
+          "identifier": "DE.NW.Bonn",
+          "title": "Bonn, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_NW_Cologne"
+        },
+        {
+          "lat": 50.7764,
+          "lng": 6.08345,
+          "identifier": "DE.NW.Aachen",
+          "title": "Aachen, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_NW_Cologne"
+        }
+      ],
+      "polygon": "sccsHw}re@su@fdDzTjjNmaDdmFw`GlyCm|J{lPyEvrMciRjqKjUvmO{jJre@oqCdeIc}BqpAln@wnCmn@g{A_yBj_A}nAe_@qmA_vGlp@qbAmqBmoA{nAlr@{eB`N{eB}gA{MnfE{d@cAm_@dmFm_CvIw\\`jAuwC{aCrWnjIsn@`xAvnA`kIef@`qAkcCk}AsjAzpCs~A||@urMoihH~f{Ayl[je[l~jF",
+      "urls": [
+        "https://recombination.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_OH_Columbus",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/New_York",
+      "cities": [
+        {
+          "lat": 39.96217,
+          "lng": -82.99742,
+          "identifier": "US.OH.Columbus",
+          "title": "Columbus, OH, USA",
+          "timezone": "America/New_York",
+          "region": "US_OH_Columbus"
+        }
+      ],
+      "polygon": "aezqFvwzzN_omA??gzcB~nmA?",
+      "urls": [
+        "https://matter.skedgo.com/satapp",
+        "https://darkages.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "DK_Islands",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Copenhagen",
+      "cities": [
+        {
+          "lat": 55.67577,
+          "lng": 12.57073,
+          "identifier": "DK.Copenhagen",
+          "title": "Copenhagen, Denmark",
+          "timezone": "Europe/Copenhagen",
+          "region": "DK_Islands"
+        },
+        {
+          "lat": 55.40378,
+          "lng": 10.40354,
+          "identifier": "DK.Odense",
+          "title": "Odense, Denmark",
+          "timezone": "Europe/Copenhagen",
+          "region": "DK_Islands"
+        }
+      ],
+      "polygon": "ozboImvf{@owsA|`f@o{K?_`qAo_eD_ieA_nbJ~wq@ovs@ndkA_xq@nu~A~iZ_{m@_{dLvx~Aa}jBlpInnxIvxlBl`dK}gk@r}y@oqP~qvDoaoApinB",
+      "urls": [
+        "https://energy.skedgo.com/satapp",
+        "https://andromeda.skedgo.com/satapp",
+        "https://matter.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "IE_SouthIreland",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Dublin",
+      "cities": [
+        {
+          "lat": 51.89657,
+          "lng": -8.48548,
+          "identifier": "IE.Cork",
+          "title": "Cork, Ireland",
+          "timezone": "Europe/Dublin",
+          "region": "IE_SouthIreland"
+        }
+      ],
+      "polygon": "_fpeI~lcbA?ozuR~wnD??ohsKn{vAnljBnpxDnl{U?~hbE",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_TX_Dallas",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/Chicago",
+      "cities": [
+        {
+          "lat": 32.782,
+          "lng": -96.8,
+          "identifier": "US.TX.Dallas",
+          "title": "Dallas, TX, USA",
+          "timezone": "America/Chicago",
+          "region": "US_TX_Dallas"
+        },
+        {
+          "lat": 32.755,
+          "lng": -97.325,
+          "identifier": "US.TX.Fort-Worth",
+          "title": "Fort Worth, TX, USA",
+          "timezone": "America/Chicago",
+          "region": "US_TX_Dallas"
+        }
+      ],
+      "polygon": "}qcdEnxrsQqalE??_~cHpalE?",
+      "urls": [
+        "https://energy.skedgo.com/satapp",
+        "https://darkages.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "AU_NT_Darwin",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Australia/Darwin",
+      "cities": [
+        {
+          "lat": -12.4542,
+          "lng": 130.8391,
+          "identifier": "AU.NT.Darwin",
+          "title": "Darwin, NT, Australia",
+          "timezone": "Australia/Darwin",
+          "region": "AU_NT_Darwin"
+        }
+      ],
+      "polygon": "~ovmA_ho{W_g{C??_xnD~f{C?",
+      "urls": [
+        "https://darkages.skedgo.com/satapp",
+        "https://granduni.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_CO_Denver",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/Denver",
+      "cities": [
+        {
+          "lat": 39.745,
+          "lng": -104.994,
+          "identifier": "US.CO.Denver",
+          "title": "Denver, CO, USA",
+          "timezone": "America/Denver",
+          "region": "US_CO_Denver"
+        },
+        {
+          "lat": 40.01695,
+          "lng": -105.28134,
+          "identifier": "US.CO.Boulder",
+          "title": "Boulder, CO, USA",
+          "timezone": "America/Denver",
+          "region": "US_CO_Denver"
+        }
+      ],
+      "polygon": "oaxoF~~ocS}iwC??_qaF|iwC?",
+      "urls": [
+        "https://lepton.skedgo.com/satapp",
+        "https://stars.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_MI_Detroit",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "US/Eastern",
+      "cities": [
+        {
+          "lat": 42.33693,
+          "lng": -83.0507,
+          "identifier": "US.MI.Detroit",
+          "title": "Detroit, MI, USA",
+          "timezone": "US/Eastern",
+          "region": "US_MI_Detroit"
+        }
+      ],
+      "polygon": "kzw}Fjpc|NtxBdlLmbaBnr@_flAbPuq[yza@mpBehjBqKu}|@ji_@xbHtxt@~_~@|sq@b{n@f}KdqPdiu@v}q@",
+      "urls": [
+        "https://baryogenesis.skedgo.com/satapp",
+        "https://lepton.skedgo.com/satapp",
+        "https://matter.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "SA_04_Dhahran",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Asia/Riyadh",
+      "cities": [
+        {
+          "lat": 26.42088,
+          "lng": 50.08899,
+          "identifier": "SA.04.Dhahran",
+          "title": "Dhahran, Saudi Arabia",
+          "timezone": "Asia/Riyadh",
+          "region": "SA_04_Dhahran"
+        }
+      ],
+      "polygon": "g`kaDa~hnHmgr@ydu@va_@gimA~d~CrtWdkPdqzC",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://darkages.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "DE_NW_Dortmund",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_car-s",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Berlin",
+      "cities": [
+        {
+          "lat": 51.51396,
+          "lng": 7.46439,
+          "identifier": "DE.NW.Dortmund",
+          "title": "Dortmund, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_NW_Dortmund"
+        },
+        {
+          "lat": 51.4818,
+          "lng": 7.2154,
+          "identifier": "DE.NW.Bochum",
+          "title": "Bochum, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_NW_Dortmund"
+        },
+        {
+          "lat": 51.2715,
+          "lng": 7.2006,
+          "identifier": "DE.NW.Wuppertal",
+          "title": "Wuppertal, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_NW_Dortmund"
+        },
+        {
+          "lat": 51.4586,
+          "lng": 7.0166,
+          "identifier": "DE.NW.Essen",
+          "title": "Essen, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_NW_Dortmund"
+        },
+        {
+          "lat": 51.9562,
+          "lng": 7.6278,
+          "identifier": "DE.NW.Münster",
+          "title": "Münster, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_NW_Dortmund"
+        },
+        {
+          "lat": 51.9609,
+          "lng": 7.6289,
+          "identifier": "DE.NW.Gelsenkirchen",
+          "title": "Gelsenkirchen, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_NW_Dortmund"
+        }
+      ],
+      "polygon": "}iwvHmb|i@kk_Bxmc@yjq@xwQqwLvkDsuDkcKuh@ut@csCsWy{@oeEiwBhRi@hyBqj@lEwgEteLys@vmIgkBbAckBwv@mr@q~GejAwXcm@k_Ac`Cal@iBcdOoeAerDuyCkq@ewA}_Dyi@uH{]axG}oDmxCyfBqs@uTs}B`PgxBggAgnFkrArgBuo@|q@zcl@{nvCjtfBaaoApnmAxgaDfpBvgeA",
+      "urls": [
+        "https://recombination.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "IE_Dublin",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Dublin",
+      "cities": [
+        {
+          "lat": 53.34845,
+          "lng": -6.25954,
+          "identifier": "IE.Dublin",
+          "title": "Dublin, Ireland",
+          "timezone": "Europe/Dublin",
+          "region": "IE_Dublin"
+        }
+      ],
+      "polygon": "_sx_Inktn@onnG??ob{KnnnG?",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_MN_Duluth",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/Chicago",
+      "cities": [
+        {
+          "lat": 46.78831,
+          "lng": -92.10036,
+          "identifier": "US.MN.Duluth",
+          "title": "Duluth, MN, USA",
+          "timezone": "America/Chicago",
+          "region": "US_MN_Duluth"
+        }
+      ],
+      "polygon": "sdzhHbna`QxxRcx}CoaF{rlCbhe@{zrBd{\\gbjAfgRub^fwb@{p_BanT}uu@kqLslq@~_]ig`@gvDiyYlhC{wbBdaS_wXyqB}nr@t_Diuf@psLcsObsoF~xfOvm\\fxv@lpaB?|wLngJb~]p}gAb}n@tmTjgGufQltPsmT~oNpGraNxyPsdNhxiMuy_L~lEcflH?~vq@ghjB",
+      "urls": [
+        "https://baryogenesis.skedgo.com/satapp",
+        "https://lepton.skedgo.com/satapp",
+        "https://matter.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "DE_NW_Dusseldorf",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_car-s",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Berlin",
+      "cities": [
+        {
+          "lat": 51.22652,
+          "lng": 6.77704,
+          "identifier": "DE.NW.Düsseldorf",
+          "title": "Düsseldorf, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_NW_Dusseldorf"
+        },
+        {
+          "lat": 51.435,
+          "lng": 6.7608,
+          "identifier": "DE.NW.Duisburg",
+          "title": "Duisburg, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_NW_Dusseldorf"
+        },
+        {
+          "lat": 51.1924,
+          "lng": 6.4309,
+          "identifier": "DE.NW.Mönchengladbach",
+          "title": "Mönchengladbach, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_NW_Dusseldorf"
+        }
+      ],
+      "polygon": "eblvHg`yb@ueJc|cFgr`Dx_}@}cBrdFfdEjgXbl`DrvrBm}yCmbbBiy@f{A{_Af_LtcBtt@rz@_uBvgBfR{VnyCy_BdhB}Bt`Hc}Avg@iq@lvDjk@vaBgJbtCzRtpBaj@nmBup@|fA}Jwu@ab@ePi`BtbG`h@vzDgNnr@bXhp@jm@l`ApKc|@|HytAnYaiAj~Aal@dZyh@zR{tAbyAhCcb@dcJc_B|fGryB~`Db^liCb~Ld_Fmy@cPucGvdGnyCotEqpApwDf`DkwCnYmoAly@bPc~Le_F|jQh}LhsAgn@jBg}FheBueFd|@d|@sj]imXdqh@ttFvtEbtCroAiC|~AwiEtgBglAjx@{aCntE_rC{rgA~sHbmvAmhOpyIbjA`WcyAfs@vX`yCg}@~hCb~ElT~eBcrgB}|PdwyBhld@nfB_iAbQ|eBxcGe_@p`BuaBmLeuC{t@q_BqwdCeuq@xelCrix@btFdrJxMv_CdiEtqGcl`DsvrBgdEkgX|cBsdFfr`Dy_}@teJb|cF",
+      "urls": [
+        "https://recombination.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "UK_SouthScotland",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/London",
+      "cities": [
+        {
+          "lat": 55.95392,
+          "lng": -3.18553,
+          "identifier": "GB.SCT.Edinburgh",
+          "title": "Edinburgh, UK",
+          "timezone": "Europe/London",
+          "region": "UK_SouthScotland"
+        },
+        {
+          "lat": 55.86398,
+          "lng": -4.24918,
+          "identifier": "GB.SCT.Glasgow",
+          "title": "Glasgow, UK",
+          "timezone": "Europe/London",
+          "region": "UK_SouthScotland"
+        }
+      ],
+      "polygon": "oiivI~nyo@?_oyo@~qy@nihJ~iwC~r|V",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://andromeda.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "CA_AB_Edmonton",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/Edmonton",
+      "cities": [
+        {
+          "lat": 53.558,
+          "lng": -113.49,
+          "identifier": "CA.AB.Edmonton",
+          "title": "Edmonton, AB, Canada",
+          "timezone": "America/Edmonton",
+          "region": "CA_AB_Edmonton"
+        }
+      ],
+      "polygon": "qxlyIzo_gVlloAeecx@hzrSumTldDtn`u@",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://energy.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "NL_SouthNetherlands",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_car-s",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Amsterdam",
+      "cities": [
+        {
+          "lat": 51.44128,
+          "lng": 5.47564,
+          "identifier": "NL.Eindhoven",
+          "title": "Eindhoven, Netherlands",
+          "timezone": "Europe/Amsterdam",
+          "region": "NL_SouthNetherlands"
+        },
+        {
+          "lat": 51.56101,
+          "lng": 5.09225,
+          "identifier": "NL.Tilburg",
+          "title": "Tilburg, Netherlands",
+          "timezone": "Europe/Amsterdam",
+          "region": "NL_SouthNetherlands"
+        },
+        {
+          "lat": 51.58912,
+          "lng": 4.77579,
+          "identifier": "NL.Breda",
+          "title": "Breda, Netherlands",
+          "timezone": "Europe/Amsterdam",
+          "region": "NL_SouthNetherlands"
+        }
+      ],
+      "polygon": "wh_{HohmS?sjbO`y@ok@rfBvfFbl@mEhDk~FzkC{`It_GtrAleC_`PtfHzpC|zF}mJziG}dHfrH}pC`cMv_ClT{aCvvFhCpnDlsElLzpCx_Jn`GxqEdeIzoB_hAneHja@edCgwNfbAwpBnkE~Md_HdaVdnDjaL~eGbqDnk@b`EywDv}C~sAnqF|uFe~EbaDdPsfAgiHng@}tMjjHl`A`aB{bNlaG`]rfFl}Acq@feDdu@vzDxvCknA|zC`nElgBeaEn`Dha@hO|bTq_@|~`@~@b}KsfI{tAybA`zFw|D~eBemC{K}yPypNabMquE_ePwmImmBmdEujBppAzt@liIc~DtcAcOpqR_qF~fSy{Gnr@chDvmIbsEh}L`Gptb@{lApnBwuEor@abAfuCj_AtfF}q@vfFqyNvtLgmFy{DirEtaBiDvfF~eN~hR}aA~{\\o_CxbHuzImwO}yB~zKpgM|mPlZ~qZahJlTvdDncWh~No~GbbBliIwQdcJgzB|i@jL|zK~fNnuPz{HzsS~cHrd]ez@f}WgaHlTw`Ghg`@nzB~_Pj`EucA|a@roSicFfaKcgFdfCaeK{HyqmA?",
+      "urls": [
+        "https://recombination.skedgo.com/satapp",
+        "https://hadron.skedgo.com/satapp",
+        "https://energy.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "DE_HE_Frankfurt",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Berlin",
+      "cities": [
+        {
+          "lat": 50.11042,
+          "lng": 8.68314,
+          "identifier": "DE.HE.Frankfurt",
+          "title": "Frankfurt, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_HE_Frankfurt"
+        },
+        {
+          "lat": 50.0817,
+          "lng": 8.2415,
+          "identifier": "DE.HE.Wiesbaden",
+          "title": "Wiesbaden, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_HE_Frankfurt"
+        },
+        {
+          "lat": 50.0005,
+          "lng": 8.2773,
+          "identifier": "DE.HE.Mainz",
+          "title": "Mainz, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_HE_Frankfurt"
+        }
+      ],
+      "polygon": "okvmHox_q@{lmEnn{AujFemrLv~dEt{{BtO`kpCbhN|tgA",
+      "urls": [
+        "https://recombination.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "AU_VIC_West",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Australia/Melbourne",
+      "cities": [
+        {
+          "lat": -38.1489,
+          "lng": 144.36104,
+          "identifier": "AU.VIC.Geelong",
+          "title": "Geelong, VIC, Australia",
+          "timezone": "Australia/Melbourne",
+          "region": "AU_VIC_West"
+        },
+        {
+          "lat": -36.72278,
+          "lng": 144.43973,
+          "identifier": "AU.VIC.Bendigo",
+          "title": "Bendigo, VIC, Australia",
+          "timezone": "Australia/Melbourne",
+          "region": "AU_VIC_West"
+        },
+        {
+          "lat": -37.51899,
+          "lng": 143.77287,
+          "identifier": "AU.VIC.Ballarat",
+          "title": "Ballarat, VIC, Australia",
+          "timezone": "Australia/Melbourne",
+          "region": "AU_VIC_West"
+        }
+      ],
+      "polygon": "hfcnEgrj{Y`qd@eeqBctKww\\eMkb_AlpPq~j@rn^o_d@z_k@q|H~ab@_bOaoh@iyYbMirVpeTapJlrGwvn@vcVqpo@|vc@hhCj~d@apJd~@}re@daYewB`zi@mhtAzil@wr{@xkZghNttc@yn}@w_m@mu[{oJ}oU?sxXJzK`_cIwsAlrA`biAlie@ney@txn@}nDtip@{u`Ap`_@dbt@dgyB~t~A`J~`gR",
+      "urls": [
+        "https://granduni.skedgo.com/satapp",
+        "https://darkages.skedgo.com/satapp",
+        "https://hadron.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "BE_NorthWestBelgium",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_car-s",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Brussels",
+      "cities": [
+        {
+          "lat": 51.05383,
+          "lng": 3.72501,
+          "identifier": "BE.Ghent",
+          "title": "Ghent, Belgium",
+          "timezone": "Europe/Brussels",
+          "region": "BE_NorthWestBelgium"
+        },
+        {
+          "lat": 51.2085,
+          "lng": 3.2249,
+          "identifier": "BE.Bruges",
+          "title": "Bruges, Belgium",
+          "timezone": "Europe/Brussels",
+          "region": "BE_NorthWestBelgium"
+        }
+      ],
+      "polygon": "_{nxHa`{QoiBcmt@raGe~B|yJjKh|Dq|HwCshPiqF`{@m|BkmMp~De~Yh}AguLdgH_Ne`AygPbIw`Gtl@y}@ouBgsGmfAo~DdEclFwlHoiU|wiB??dz_EyiFt{InuAxnFnXh{JvtCh{Ln{Dr~A~rC`cEm{A|aC|LxcBwnBliC|^jfD_gAjdEi}NfwNq_@n}MitFh`FoiAopAoyIfyBkkDyyEslGfgCgSvqBo}A~eBecAe_@{mHtrA{iCdwBglt@_bkB",
+      "urls": [
+        "https://hadron.skedgo.com/satapp",
+        "https://recombination.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "SE_Gothenburg",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Stockholm",
+      "cities": [
+        {
+          "lat": 57.70723,
+          "lng": 11.96702,
+          "identifier": "SE.Gothenburg",
+          "title": "Gothenburg, Sweden",
+          "timezone": "Europe/Stockholm",
+          "region": "SE_Gothenburg"
+        }
+      ],
+      "polygon": "uzrbJqjfwBrhfGjvI?`r}p@shfG|nr@",
+      "urls": [
+        "https://energy.skedgo.com/satapp",
+        "https://andromeda.skedgo.com/satapp",
+        "https://matter.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_MI_GrandRapids",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "US/Eastern",
+      "cities": [
+        {
+          "lat": 42.96336,
+          "lng": -85.66809,
+          "identifier": "US.MI.Grand-Rapids",
+          "title": "Grand Rapids, MI, USA",
+          "timezone": "US/Eastern",
+          "region": "US_MI_GrandRapids"
+        }
+      ],
+      "polygon": "{eidGjrqkOchtA??a{|AbhtA?",
+      "urls": [
+        "https://baryogenesis.skedgo.com/satapp",
+        "https://matter.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "FR_V_Grenoble",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Paris",
+      "cities": [
+        {
+          "lat": 45.18821,
+          "lng": 5.72439,
+          "identifier": "FR.V.Grenoble",
+          "title": "Grenoble, France",
+          "timezone": "Europe/Paris",
+          "region": "FR_V_Grenoble"
+        }
+      ],
+      "polygon": "gwgqGof}]gzgAnggAo_h@?_uu@onqC?oweCncsF??n~oE",
+      "urls": [
+        "https://recombination.skedgo.com/satapp",
+        "https://hadron.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "NL_NorthNetherlands",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_car-s",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Amsterdam",
+      "cities": [
+        {
+          "lat": 53.21946,
+          "lng": 6.56684,
+          "identifier": "NL.Groningen",
+          "title": "Groningen, Netherlands",
+          "timezone": "Europe/Amsterdam",
+          "region": "NL_NorthNetherlands"
+        }
+      ],
+      "polygon": "sv_fIulo_@_jLwbtF~kPc~JzpJujr@~o_@qyOj`AgwNbm@q_Y`xIa{@rvN}pCx_D~lEz}Fe_@tpScyA~vJfsDv~YleV~k_@bjAv|AzaCykAf_Lfk@rkIcmAnyCjMbhYpdB|dH~cAsrAleBlc@?nxoGsh~DxQ",
+      "urls": [
+        "https://recombination.skedgo.com/satapp",
+        "https://hadron.skedgo.com/satapp",
+        "https://energy.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "DE_NI_Gottingen",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Berlin",
+      "cities": [
+        {
+          "lat": 51.53244,
+          "lng": 9.93602,
+          "identifier": "DE.NI.Göttingen",
+          "title": "Göttingen, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_NI_Gottingen"
+        },
+        {
+          "lat": 51.3124,
+          "lng": 9.4924,
+          "identifier": "DE.NI.Kassel",
+          "title": "Kassel, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_NI_Gottingen"
+        }
+      ],
+      "polygon": "_j_tHqf}l@ea{Av{ZkxlAu|_Dszz@wwdG`uQcz`IpmdEh`yBdyGrsiPjwCz}f@",
+      "urls": [
+        "https://recombination.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "CA_NS_Halifax",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/Halifax",
+      "cities": [
+        {
+          "lat": 44.64548,
+          "lng": -63.57573,
+          "identifier": "CA.NS.Halifax",
+          "title": "Halifax, NS, Canada",
+          "timezone": "America/Halifax",
+          "region": "CA_NS_Halifax"
+        }
+      ],
+      "polygon": "_{~mG~m_eK_etB??_vgC~dtB?",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://energy.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "DE_HH_Hamburg",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Berlin",
+      "cities": [
+        {
+          "lat": 53.555,
+          "lng": 9.97877,
+          "identifier": "DE.HH.Hamburg",
+          "title": "Hamburg, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_HH_Hamburg"
+        },
+        {
+          "lat": 53.86525,
+          "lng": 10.68516,
+          "identifier": "DE.HH.Lübeck",
+          "title": "Lübeck, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_HH_Hamburg"
+        }
+      ],
+      "polygon": "kgxbIsrsw@sl|C|vy@yvCmqh@e{c@_ngIe_W_lq@|e~EnCcD~phJ",
+      "urls": [
+        "https://recombination.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "DE_NI_Hanover",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Berlin",
+      "cities": [
+        {
+          "lat": 52.37662,
+          "lng": 9.73423,
+          "identifier": "DE.NI.Hanover",
+          "title": "Hanover, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_NI_Hanover"
+        },
+        {
+          "lat": 52.1317,
+          "lng": 11.6403,
+          "identifier": "DE.NI.Magdeburg",
+          "title": "Magdeburg, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_NI_Hanover"
+        },
+        {
+          "lat": 52.2647,
+          "lng": 10.5248,
+          "identifier": "DE.NI.Braunschwaig",
+          "title": "Braunschwaig, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_NI_Hanover"
+        },
+        {
+          "lat": 52.40382,
+          "lng": 12.55636,
+          "identifier": "DE.NI.Brandenburg",
+          "title": "Brandenburg, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_NI_Hanover"
+        }
+      ],
+      "polygon": "cv{_Im{su@yp|Ash_AGexfJv``@kf|Hhl~Bfde@bzfBplgGaaRzqaIauvCncsB",
+      "urls": [
+        "https://recombination.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_CT_Hartford",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/New_York",
+      "cities": [
+        {
+          "lat": 41.76509,
+          "lng": -72.67374,
+          "identifier": "US.CT.Hartford",
+          "title": "Hartford, CT, USA",
+          "timezone": "America/New_York",
+          "region": "US_CT_Hartford"
+        },
+        {
+          "lat": 41.05363,
+          "lng": -73.53936,
+          "identifier": "US.CT.Stamford",
+          "title": "Stamford, CT, USA",
+          "timezone": "America/New_York",
+          "region": "US_CT_Hartford"
+        }
+      ],
+      "polygon": "ypzyF~u`aMupNys^{qiDulOxiB_d{D`lAgjmClivBej@zd@fzG|wKagB|oFzsMdycA|zmIohOnva@",
+      "urls": [
+        "https://lepton.skedgo.com/satapp",
+        "https://stars.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "FI_SouthFinland",
+      "modes": [
+        "in_air",
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Helsinki",
+      "cities": [
+        {
+          "lat": 60.173,
+          "lng": 24.941,
+          "identifier": "FI.Helsinki",
+          "title": "Helsinki, Finland",
+          "timezone": "Europe/Helsinki",
+          "region": "FI_SouthFinland"
+        },
+        {
+          "lat": 60.98266,
+          "lng": 25.66113,
+          "identifier": "FI.Lahti",
+          "title": "Lahti, Finland",
+          "timezone": "Europe/Helsinki",
+          "region": "FI_SouthFinland"
+        },
+        {
+          "lat": 60.86823,
+          "lng": 26.70358,
+          "identifier": "FI.Kouvola",
+          "title": "Kouvola, Finland",
+          "timezone": "Europe/Helsinki",
+          "region": "FI_SouthFinland"
+        },
+        {
+          "lat": 60.99305,
+          "lng": 24.46072,
+          "identifier": "FI.Hämeenlinna",
+          "title": "Hämeenlinna, Finland",
+          "timezone": "Europe/Helsinki",
+          "region": "FI_SouthFinland"
+        },
+        {
+          "lat": 61.05548,
+          "lng": 28.1892,
+          "identifier": "FI.Lappeenranta",
+          "title": "Lappeenranta, Finland",
+          "timezone": "Europe/Helsinki",
+          "region": "FI_SouthFinland"
+        }
+      ],
+      "polygon": "_~rkJoyfiC_uu@_mVotLoaoAnzD_`qA_{m@ovs@_}tAnu~AokXoqmC_xq@oqPoh\\_ry@o|k@_xnD_~i@oyo@nxzAo~oE_yFop{@nqPojcA_xq@n_h@ozDoe`@~oR_ieAoggAou{EnkX_ieA_jZ_vJoqP_uu@_mVojcAn|k@_ieA~lpG~zdL~yxA~olG",
+      "urls": [
+        "https://andromeda.skedgo.com/satapp",
+        "https://matter.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "VN_SG_HoChiMinhCity",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Asia/Ho_Chi_Minh",
+      "cities": [
+        {
+          "lat": 10.77084,
+          "lng": 106.69853,
+          "identifier": "VN.SG.Ho-Chi-Minh-City",
+          "title": "Ho Chi Minh City, Vietnam",
+          "timezone": "Asia/Ho_Chi_Minh",
+          "region": "VN_SG_HoChiMinhCity"
+        }
+      ],
+      "polygon": "_mf~@_s|gSobaD??_vgCnbaD?",
+      "urls": [
+        "https://darkages.skedgo.com/satapp",
+        "https://granduni.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_HI_Honolulu",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "US/Hawaii",
+      "cities": [
+        {
+          "lat": 21.30455,
+          "lng": -157.85568,
+          "identifier": "US.HI.Honolulu",
+          "title": "Honolulu, HI, USA",
+          "timezone": "US/Hawaii",
+          "region": "US_HI_Honolulu"
+        }
+      ],
+      "polygon": "kq~_Cvbie]sx`C??gtjDrx`C?",
+      "urls": [
+        "https://lepton.skedgo.com/satapp",
+        "https://matter.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_TX_Houston",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/Chicago",
+      "cities": [
+        {
+          "lat": 29.766,
+          "lng": -95.368,
+          "identifier": "US.TX.Houston",
+          "title": "Houston, TX, USA",
+          "timezone": "America/Chicago",
+          "region": "US_TX_Houston"
+        }
+      ],
+      "polygon": "o{oqDnwfiQoalE??otfGnalE?",
+      "urls": [
+        "https://energy.skedgo.com/satapp",
+        "https://darkages.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_IN_Indianapolis",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/Indianapolis",
+      "cities": [
+        {
+          "lat": 39.76865,
+          "lng": -86.15792,
+          "identifier": "US.IN.Indianapolis",
+          "title": "Indianapolis, IN, USA",
+          "timezone": "America/Indianapolis",
+          "region": "US_IN_Indianapolis"
+        }
+      ],
+      "polygon": "olspF~dbnO_ieA??_`qA~heA?",
+      "urls": [
+        "https://lepton.skedgo.com/satapp",
+        "https://stars.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "DE_BV_Ingolstadt",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Berlin",
+      "cities": [
+        {
+          "lat": 48.76424,
+          "lng": 11.42464,
+          "identifier": "DE.BV.Ingolstadt",
+          "title": "Ingolstadt, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_BV_Ingolstadt"
+        },
+        {
+          "lat": 49.02031,
+          "lng": 12.10166,
+          "identifier": "DE.BV.Regensburg",
+          "title": "Regensburg, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_BV_Ingolstadt"
+        }
+      ],
+      "polygon": "q{ofHurbdAmqzAxomA_n~B_uoIrlRslCtcDgoQjhG}gAp_CkfD|ZoeKewBzi@~kBacUh`GmpLxrYsd]djDre@roCcvHizAqmHftMsvVvjLuaB|wEmpLs`CucAkXeaKhsD}eMj`LsqGcl@kvIb|JeaKbtJeeIbfG|nD`bBvaB~hAauEtzA|S_Pv_C|dCse@`qBre@pu@_z@fyC}ZrvAhyBv~AfB|eBha@bOtkAn`BjrB`Nbh@ibAru@noEng@ruCzaCoxCrrLixE|zKlgAh{AqfDrgKdvDbiGyK|nD`cGchBvuIthEviBchB`fLjdEddIplNt_E|rNqGnnM``BliIdPjkHbhCfaKzhGxkJvg@|nDrVpwJrnF`pDznFvmIx~AvoDa}dA~bcDykE|flAb}Mlfg@",
+      "urls": [
+        "https://recombination.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "Israel",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Israel",
+      "cities": [
+        {
+          "lat": 31.77743,
+          "lng": 35.22472,
+          "identifier": "IL.Jerusalem",
+          "title": "Jerusalem, Israel",
+          "timezone": "Israel",
+          "region": "Israel"
+        },
+        {
+          "lat": 32.05784,
+          "lng": 34.77728,
+          "identifier": "IL.Tel-Aviv",
+          "title": "Tel Aviv, Israel",
+          "timezone": "Israel",
+          "region": "Israel"
+        },
+        {
+          "lat": 32.81975,
+          "lng": 34.99454,
+          "identifier": "IL.Haifa",
+          "title": "Haifa, Israel",
+          "timezone": "Israel",
+          "region": "Israel"
+        }
+      ],
+      "polygon": "gwj~Dg}qoE_at@mtm@ukmAijp@c{uAqxUqsjA{sSm{u@w~_@yjBsnsAg_WglA{wKa~PreJggk@vgo@krKlcd@`mE|_X|sHruOnq]ddeAlyCtdmAnyCzwjAxpNlqmBn`GlifDrst@zi_B|}[|iVmr@{\\f|i@qoaJzrlC",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://granduni.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_MO_KansasCity",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "US/Central",
+      "cities": [
+        {
+          "lat": 39.15195,
+          "lng": -94.53121,
+          "identifier": "US.MO.Kansas-City",
+          "title": "Kansas City, MO, USA",
+          "timezone": "US/Central",
+          "region": "US_MO_KansasCity"
+        }
+      ],
+      "polygon": "m_dlFvw`bQie`B??we_Che`B?",
+      "urls": [
+        "https://matter.skedgo.com/satapp",
+        "https://darkages.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "DE_BW_Karlsruhe",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Berlin",
+      "cities": [
+        {
+          "lat": 49.00686,
+          "lng": 8.40375,
+          "identifier": "DE.BW.Karlsruhe",
+          "title": "Karlsruhe, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_BW_Karlsruhe"
+        },
+        {
+          "lat": 49.48767,
+          "lng": 8.46587,
+          "identifier": "DE.BW.Mannheim",
+          "title": "Mannheim, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_BW_Karlsruhe"
+        },
+        {
+          "lat": 49.40175,
+          "lng": 8.6851,
+          "identifier": "DE.BW.Heidelberg",
+          "title": "Heidelberg, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_BW_Karlsruhe"
+        },
+        {
+          "lat": 49.14244,
+          "lng": 9.21015,
+          "identifier": "DE.BW.Heilbronn",
+          "title": "Heilbronn, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_BW_Karlsruhe"
+        }
+      ],
+      "polygon": "ycnkHimr}@jpbAhzzAebNrcf@gtClqWae@dmFaxBvhKqiAtf]lGxyg@xxDlac@rmDniU~eIl}XzeHx~Tl@|nDygFvyPmrHzb\\ozAmdB_bCvnTu{F`mQ~J|dBqIjb@}p@d_@qoBdaEnaBrnBsj@rjDzbBrlCsqDprLr~AruE`M|}PmqmBojdBchNwnhAeU_kpC~cxAktwD",
+      "urls": [
+        "https://recombination.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "SE_Karlstad",
+      "modes": [
+        "pt_pub",
+        "pt_ltd_SCHOOLBUS",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Stockholm",
+      "cities": [
+        {
+          "lat": 59.37991,
+          "lng": 13.50295,
+          "identifier": "SE.Karlstad",
+          "title": "Karlstad, Sweden",
+          "timezone": "Europe/Stockholm",
+          "region": "SE_Karlstad"
+        }
+      ],
+      "polygon": "s}opJcbczA|roM?d|AberW_osCkFiq`@a}m@mrGmvl@vdi@{f^gfb@g`h@wu_@ybHicgAxl[owMakt@ayZ|sSikKgk^|K}yh@i`x@_`~@srW`bD}vi@goK",
+      "urls": [
+        "https://energy.skedgo.com/satapp",
+        "https://andromeda.skedgo.com/satapp",
+        "https://matter.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "DE_SH_Kiel",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Berlin",
+      "cities": [
+        {
+          "lat": 54.32352,
+          "lng": 10.1227,
+          "identifier": "DE.SH.Kiel",
+          "title": "Kiel, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_SH_Kiel"
+        },
+        {
+          "lat": 54.79337,
+          "lng": 9.44854,
+          "identifier": "DE.SH.Flensburg",
+          "title": "Flensburg, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_SH_Kiel"
+        }
+      ],
+      "polygon": "isygI}cgw@h~Ctjn@a|\\tauBc{]~`wBaljBawnAs|oAsah@bzHe`QbeLkxThiPuxJzH{hF`~BmiIk[ylDfUuaBkeAefCe@ooGxr@{cBiu@kuDdj@mhOxvCgwNjFa~P~aD__VjtBflA~qBoaApf@cdOo~Cc`E{n@abAcVsnElzAo|Byg@m_GwpIm`Xd_AyxE`}Cdn@h}D{iW`y@ukl@hr@}pq@byZgwe@n_QwlvDrpk@aoz@lh]|tiBpoWpwr@jwc@h_cI",
+      "urls": [
+        "https://recombination.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_NV_LasVegas",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/Los_Angeles",
+      "cities": [
+        {
+          "lat": 36.16727,
+          "lng": -115.1361,
+          "identifier": "US.NV.Las-Vegas",
+          "title": "Las Vegas, NV, USA",
+          "timezone": "America/Los_Angeles",
+          "region": "US_NV_LasVegas"
+        }
+      ],
+      "polygon": "gpgiFxx_wTvvrLiVbhd@vmXkbVldaBtfrDsgY~dJn~Gljt@|Z}wDxgLyzZmTuthStszY",
+      "urls": [
+        "https://lepton.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp",
+        "https://stars.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "CH_SouthWestSwitzerland",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Zurich",
+      "cities": [
+        {
+          "lat": 46.52183,
+          "lng": 6.6327,
+          "identifier": "CH.GE.Lausanne",
+          "title": "Lausanne, Switzerland",
+          "timezone": "Europe/Zurich",
+          "region": "CH_SouthWestSwitzerland"
+        },
+        {
+          "lat": 46.20333,
+          "lng": 6.14093,
+          "identifier": "CH.GE.Geneva",
+          "title": "Geneva, Switzerland",
+          "timezone": "Europe/Zurich",
+          "region": "CH_SouthWestSwitzerland"
+        }
+      ],
+      "polygon": "si{xGeapc@mz@|nDmvCglAkyCarIon@_mE{MqzI_nDzrBqqJ}wF{dDkfDquHbzRsgDqnBexB|gAwoOolNe`ErfGqpTsv_@?ot{GvdwC?imIz{LprAvbSldBblLtwG~hRm|BxpNh`DpuEfxDlrK|VhdPixDp|HmsI|wFetCrjDcyQnnM|sCpuEi~AfsDweLglAkfA~zKokDn`GgaKoyCkjLwmI{cGh}LktE`bDskKeaKxqAjhtAlvNr{ZpaHm`Gnk@c`EhrFkfDviSfwe@lz@|td@ojK{_H",
+      "urls": [
+        "https://recombination.skedgo.com/satapp",
+        "https://hadron.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "UK_Leeds",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/London",
+      "cities": [
+        {
+          "lat": 53.8,
+          "lng": -1.54,
+          "identifier": "GB.ENG.Leeds",
+          "title": "Leeds, UK",
+          "timezone": "Europe/London",
+          "region": "UK_Leeds"
+        }
+      ],
+      "polygon": "_{qhI~cyK?o`qNnljB??n`qN",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://andromeda.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "UK_Leicester",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/London",
+      "cities": [
+        {
+          "lat": 52.63624,
+          "lng": -1.14009,
+          "identifier": "GB.ENG.Leicester",
+          "title": "Leicester, UK",
+          "timezone": "Europe/London",
+          "region": "UK_Leicester"
+        }
+      ],
+      "polygon": "_qnbI~}cH?_owH~{|F??~ugC_etB??~wnD",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://andromeda.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "DE_SN_Leipzig",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Berlin",
+      "cities": [
+        {
+          "lat": 51.33705,
+          "lng": 12.37953,
+          "identifier": "DE.SN.Leipzig",
+          "title": "Leipzig, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_SN_Leipzig"
+        },
+        {
+          "lat": 51.0475,
+          "lng": 13.7404,
+          "identifier": "DE.SN.Dresden",
+          "title": "Dresden, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_SN_Leipzig"
+        },
+        {
+          "lat": 50.9778,
+          "lng": 11.0289,
+          "identifier": "DE.SN.Erfurt",
+          "title": "Erfurt, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_SN_Leipzig"
+        },
+        {
+          "lat": 50.8333,
+          "lng": 12.9193,
+          "identifier": "DE.SN.Chemnitz",
+          "title": "Chemnitz, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_SN_Leipzig"
+        }
+      ],
+      "polygon": "m`ltHstm_AegeEqryB_chBaziGzck@mjkLdjFduCrf@rqA~wB}uAneB`NnpF~qC`uAjzBbjJlzNpnEojI~mFm{BpcFqpAxsDecJfaEadC|wI{w@toGjhItuAchBviBa@lv@e~KfgD}~IxiA_`P`iGe~EtsEj_AzkEqnBvzEhCd~HgrJpsGdPb{InwDn}KztAlaH|sBx`D`xAjbFr{Cf~FhyB`^byA`pDrt@t~FbvHruAbqD~vAucA`fJldEmDxpNsuF|oU{rLquEbcBrzIwjApuEqtKmbFwrAhvIqvDlyNd`B~lEmnDhiThrGx{Dbb@itJ~fEdn@xmBcsOdvHl{Bzd@zvL|d@zvLjyCdwBxdJrne@o_@dlLn~B|nD{\\~lE~{GdPflC|zKnj@~vXrr@ls\\`yJdwBnjHlpLwr@p|H}mEnwDj~IhxHvpAbgHk|BzyErhP`gHjOhi_@teKflAf_FbsO{iIleVzoC`{@sf@`pJfyFvoHiyA|aOreBtmThbChhCpaBa]dfAdhB}c@fjBtfBj|BcoeA|foJ",
+      "urls": [
+        "https://recombination.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "BE_SouthEastBelgium",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_car-s",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Brussels",
+      "cities": [
+        {
+          "lat": 50.64514,
+          "lng": 5.57342,
+          "identifier": "BE.Liege",
+          "title": "Liege, Belgium",
+          "timezone": "Europe/Brussels",
+          "region": "BE_SouthEastBelgium"
+        }
+      ],
+      "polygon": "}qcpHazj\\oyL_]{}DayBy_G}jG_kAfh@}RjvFiUlpAkytB??ayiDw_@c}AuPmdDecCk}EvdD{~F_pA}fMllBqfEmk@akFf`@uvKtv@ihCnxBgQra@_gM|gJ}bInBgfDlbBe_AxDe|H|mBixDlqLdhHrqD`}Et|Dw_CmQotKvjA_lKhbExXxc@wyDfzD{i@pyHb`E~eDmzHvhDyv@heCjdIytB|eFfzExcFvq@eb@pnAptA~n@nmIf}B`fDle@l~Bv~Cgy@vfDoYbfAhlGvgDem@tuAvnCkx@riDuiD_\\a\\`pDzqAb^|UnoGizCroBf]hlGnaG|Z`wAfaKlaFf`BteBrbCbnDu[`fDjrGdoB_xBf~CrvDhnA`jF|}EzpBr_BfvBbtCq~GzrBx}Cb_Kvv@an@ujD~nIqmHbmC_NmImdEnqB}pCd~DneBppActFbpDjSzgDfsDjiFd_@~eC|lEpo@h}CzXv_Fde@~qMak@~uLrvFrbD_tBjmGngDloR{wCv|CknLdpBmoEfzJljAt{IapCdaByrCi~CqbDllHo~@lqWyfJnvJeoGdgTb{@dgKqd@jyKw{FscBwtEjsCa~CgvDu`Dcb@wdDncFe|AdeIs{C_N_oA}pC",
+      "urls": [
+        "https://recombination.skedgo.com/satapp",
+        "https://hadron.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "PT_Lisbon",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Portugal",
+      "cities": [
+        {
+          "lat": 38.7138,
+          "lng": -9.13936,
+          "identifier": "PT.11.Lisbon",
+          "title": "Lisbon, Portugal",
+          "timezone": "Portugal",
+          "region": "PT_Lisbon"
+        }
+      ],
+      "polygon": "}rwmF~jby@?opxD|rkC??npxD",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "UK_Liverpool",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/London",
+      "cities": [
+        {
+          "lat": 53.40328,
+          "lng": -2.98955,
+          "identifier": "GB.ENG.Liverpool",
+          "title": "Liverpool, UK",
+          "timezone": "Europe/London",
+          "region": "UK_Liverpool"
+        }
+      ],
+      "polygon": "e~qhI~ncSQi_}Fjko@fSjPpo}@tlJdpv@rqRlz\\bkZyh@llSqk]puCizgAevBsoj@dykAyv@uSvg}F",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://andromeda.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "SI_Slovenia",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Ljubljana",
+      "cities": [
+        {
+          "lat": 46.05776,
+          "lng": 14.50712,
+          "identifier": "SI.Ljubljana",
+          "title": "Ljubljana, Slovenia",
+          "timezone": "Europe/Ljubljana",
+          "region": "SI_Slovenia"
+        }
+      ],
+      "polygon": "ox}zGae~sArdF}ec@l_Gc}U_r@mbg@tcC}tOcNctKcqDg_Ps~FeaHsnB}kLi{DchCwtK{|LkrBskNupDus[xNgxO`Cu|g@viAeuJhwBicAqq@arK{yEcXcnCebL{`BydJvo@anOkvCibUz}B{lM`_EkePokKblFkuPfo@k~Fq_Ypp@uyDafBguOvUyrMzyFwtLt`IlsF~`Q}kUbfIdjDzzUwfXpiGqaNt~Fr]ixNttt@frHdyM~dMwgHjwCbXxMhtEn\\~gOwvD``InqA|aLvnGuu@hnFxsM~wDf{Ub|BzfKdfIbmJewAbqQ|jOhmHtrOucU~mf@~`D|mD`jLssBzeMjyEjrKhjHtb^hyQsxK|yBl}@cEnkFxdEtnI|xJ_h@v`JamNhjGxnKs]`yHt~DdvLaJnhKgvH||MqbA`|UhuDlc[}aMxjYciUtpSjrL`iGtxIneKxnHdfZ?rtWkfCn_d@vrFhhCtgDfoQ{WxdMkhD|yKzcBfwNo`CbuNanGhfHy}EvFc`Kef]g~Eeve@u|S~e_@ipJ~bZujG|nD}kGshAeqJ_nGycEhbAjtCj{PsrIdwHwlIehBuwDqxIqjOkmR{h@j_N_`DjwFlj@dsUuoRn`G{mDkrHgwEgsA}dOk_^{hAcaP_iMwiE",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://energy.skedgo.com/satapp",
+        "https://darkages.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "UK_London",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/London",
+      "cities": [
+        {
+          "lat": 51.519,
+          "lng": -0.118,
+          "identifier": "GB.ENG.London",
+          "title": "London, UK",
+          "timezone": "Europe/London",
+          "region": "UK_London"
+        }
+      ],
+      "polygon": "owxwH~dtB_t`B??_ibE~s`B?",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://andromeda.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_CA_LosAngeles",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/Los_Angeles",
+      "cities": [
+        {
+          "lat": 34.044,
+          "lng": -118.248,
+          "identifier": "US.CA.Los-Angeles",
+          "title": "Los Angeles, CA, USA",
+          "timezone": "America/Los_Angeles",
+          "region": "US_CA_LosAngeles"
+        }
+      ],
+      "polygon": "aropEn{zpUvDoorDzxs@kkhAjuoAp}s@|rh@dd_Bmon@za}Bu`bAdra@yv{@}{w@",
+      "urls": [
+        "https://lepton.skedgo.com/satapp",
+        "https://stars.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_KY_Louisville",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/Kentucky/Louisville",
+      "cities": [
+        {
+          "lat": 38.24846,
+          "lng": -85.75477,
+          "identifier": "US.KY.Louisville",
+          "title": "Louisville, KY, USA",
+          "timezone": "America/Kentucky/Louisville",
+          "region": "US_KY_Louisville"
+        }
+      ],
+      "polygon": "ahpfFd}}kO}zaB??qbeC|zaB?",
+      "urls": [
+        "https://lepton.skedgo.com/satapp",
+        "https://matter.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "CH_Lucerne",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Zurich",
+      "cities": [
+        {
+          "lat": 47.05055,
+          "lng": 8.30547,
+          "identifier": "CH.LU.Lucerne",
+          "title": "Lucerne, Switzerland",
+          "timezone": "Europe/Zurich",
+          "region": "CH_Lucerne"
+        }
+      ],
+      "polygon": "cuq_Hwgcn@?_beJ~_R||JhzIowDzeGpGtbD|wFgbAqeKryAuaB{pAgzGfbAuaBwm@abDzg@mrKjeBwdGvG{{DnhCgxHk_Ao`GhoEkbC~{JloAl_p@`ieLwnsB?",
+      "urls": [
+        "https://recombination.skedgo.com/satapp",
+        "https://hadron.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "CH_SouthEastSwitzerland",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Zurich",
+      "cities": [
+        {
+          "lat": 46.01175,
+          "lng": 8.95608,
+          "identifier": "CH.TI.Lugano",
+          "title": "Lugano, Switzerland",
+          "timezone": "Europe/Zurich",
+          "region": "CH_SouthEastSwitzerland"
+        }
+      ],
+      "polygon": "qx}{Gwgcn@cop@w_dLrkCufQp|@{`IncE_kFttCuoHynCsoSeyJuaBxDykJurIgzGkhBsxJ`}Ce|F`wBsGz_CclL~uIjfDbnKha@doDx}CtaG}i@j`CzyEz}CglA`xCzyEbeG_fBie@gzGtuD}uGflIzKvvGlwFonBpwM`w@~qIyaEjyNkxCn{BooCyv@}|@liInoCdlLvrJ~qIraPvXfxB}nDytAuoH|oCssFdnEre@juGfxH|_OmpLjrF~sHj}@raMwxBpuEyhE}gAe{C`yJmdC{i@}wAzrBm{BqpAqyDvfFd}@`dCp_@tmIxjDjbQe}@lbF`eIbbDzp@`gOqe@|sHycBbpJa_IxyEqoBrsFc~Gre@y}G{KmjD|i@`~BflAtwAx}CacGjkHjh@pcL`bEzKfuBfsDd~BsjDzyJsnBd`FuI~dDf{AplKzyE|jHtoHxxBzrBdiErxJ~rBtuG|aCm}AjrEhjBraDpyKn}FooChmBv}Cr_GslCljBagHnmBm}AdaE~lElkHp}Bh|@dfCy`ArsFwoA~lExw@x{D{b@hjBckFkfDcgFl~AmyB~lEetCfC}}DjvI{YrxJkqOwrM__C`iGbOtbOowDdvTwsP`eNazDpjOorKnyCquG{yEeiTxv@`~FrjWbqEwv@xmNxuRrhEz|UvqNshPhjO|~IhrApjOtxQfsDplAx~TpyFjdEndBglAlpBldE}Jf_[cuvC?",
+      "urls": [
+        "https://recombination.skedgo.com/satapp",
+        "https://hadron.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "Luxembourg",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Luxembourg",
+      "cities": [
+        {
+          "lat": 49.61169,
+          "lng": 6.12995,
+          "identifier": "LU.Luxembourg",
+          "title": "Luxembourg",
+          "timezone": "Europe/Luxembourg",
+          "region": "Luxembourg"
+        }
+      ],
+      "polygon": "_lmmHuxpb@cJ{sA__@iAawAg`Do\\tSi^uWuFjkBcsA|[qdAqxD{|@rHki@qs@qm@~Myc@}bCqhCkDqxAtqGgkB{YqaBq}Bc`BpzBlh@veBkb@fvCsgCgf@yJpd@{kGf|EdLzjEmfEf{Ak[kd@q}@ho@axB_k@eWi~@w}Atf@iYohD{lB`_Ge`@~MqaBasCyaBal@ql@al@meAvI_mAe_@{e@{jEepB{|Dc_A|dBcgBlTscBm_G_g@tWi|@kdAm`ArqAirAsVo~@gdDweFucA_eBu}Ju~Fyg@s_AsdLrxBuf@p}@qwDyWemAgtAoF?ieDpr@soB~aB_k@taA|gA~j@oyCtpBlShiCxJ|GdkAlfBov@f|@xv@b_C}dB~eAf`@lu@uaBdv@tu@bYcoAniApVtg@{i@``@_tB`wBna@kTqkCpkAe_@nc@srDvxA_Nt}Cmm@baBajAjtA_wApMyqBvJwsAb{@uWmTqqAp}BooA|oAmTihAimAuHw|Cr`Ei`Frj@ewHi}@kkB~}@}|Cpq@soBit@}Z{Cwg@ncAqbAny@xeAjc@xtAzk@ibAfr@`l@|Wyh@`~@_D`u@`gBztBaNzt@c~AbnAjnAniBjfD|g@fgCtdB~vBzu@naAvQytAngGn_CntBfdDfEpbAbz@zw@`x@{w@t_@zw@cQ~j@f\\`{@vhBgdDnwCzlDtrD_iApoGmErCll@in@d~D_cA`tD}j@~tBofApv@ul@bAJbyAsd@xo@pOnkF|FpgCaIvpBeKzNjf@hjBhq@us@jn@lqC{K|gAvxAfd@pZ|`ApEnhAr_Bq@bBjgAyd@|pAu]tAkGb~BjqB`xA^faByp@hYhUbaBk]`s@fc@x|B{]pQo^uPqb@hh@kdAjb@kUed@ci@~j@}Tk[kOllBkf@piAtNbcAoY~jBhd@|sB{Rf~@Kb`Bwg@bcAcRxv@ye@|Fcb@`jAkn@nMy]aw@uo@zi@r]dwBc`Av}@",
+      "urls": [
+        "https://recombination.skedgo.com/satapp",
+        "https://hadron.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "AU_QLD_Northern",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Australia/Brisbane",
+      "cities": [
+        {
+          "lat": -21.16036,
+          "lng": 148.83168,
+          "identifier": "AU.QLD.Mackay",
+          "title": "Mackay, QLD, Australia",
+          "timezone": "Australia/Brisbane",
+          "region": "AU_QLD_Northern"
+        },
+        {
+          "lat": -19.2593,
+          "lng": 146.822,
+          "identifier": "AU.QLD.Townsville",
+          "title": "Townsville, QLD, Australia",
+          "timezone": "Australia/Brisbane",
+          "region": "AU_QLD_Northern"
+        },
+        {
+          "lat": -16.9204,
+          "lng": 145.771,
+          "identifier": "AU.QLD.Cairns",
+          "title": "Cairns, QLD, Australia",
+          "timezone": "Australia/Brisbane",
+          "region": "AU_QLD_Northern"
+        }
+      ],
+      "polygon": "~gmcC_mmvZ_sv^??_x_X~rv^?",
+      "urls": [
+        "https://darkages.skedgo.com/satapp",
+        "https://granduni.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_WI_Madison",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "US/Central",
+      "cities": [
+        {
+          "lat": 43.07476,
+          "lng": -89.38376,
+          "identifier": "US.WI.Madison",
+          "title": "Madison, WI, USA",
+          "timezone": "US/Central",
+          "region": "US_WI_Madison"
+        }
+      ],
+      "polygon": "gsibGzkzaPg}gC??khsEf}gC?",
+      "urls": [
+        "https://lepton.skedgo.com/satapp",
+        "https://stars.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "ES_MD_Madrid",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Madrid",
+      "cities": [
+        {
+          "lat": 40.415,
+          "lng": -3.707,
+          "identifier": "ES.M.Madrid",
+          "title": "Madrid, Spain",
+          "timezone": "Europe/Madrid",
+          "region": "ES_MD_Madrid"
+        }
+      ],
+      "polygon": "oittFntzV_o}@??_cmA~n}@?",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://energy.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "ES_IB_Majorca",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Madrid",
+      "cities": [
+        {
+          "lat": 39.57636,
+          "lng": 2.65419,
+          "identifier": "ES.IB.Majorca",
+          "title": "Majorca, Spain",
+          "timezone": "Europe/Madrid",
+          "region": "ES_IB_Majorca"
+        }
+      ],
+      "polygon": "yyzmFq}wLskrD??}fdGrkrD?",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://energy.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "SE_SouthSweden",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Stockholm",
+      "cities": [
+        {
+          "lat": 55.60529,
+          "lng": 13.00016,
+          "identifier": "SE.Malmö",
+          "title": "Malmö, Sweden",
+          "timezone": "Europe/Stockholm",
+          "region": "SE_SouthSweden"
+        }
+      ],
+      "polygon": "_|}rI_vnmAodkA~wq@_{m@~tu@oweC~pdB?olli@~f{Cnj}HnkuCnsqHnyo@~tiP",
+      "urls": [
+        "https://energy.skedgo.com/satapp",
+        "https://andromeda.skedgo.com/satapp",
+        "https://matter.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "UK_GM_Manchester",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/London",
+      "cities": [
+        {
+          "lat": 53.48,
+          "lng": -2.241,
+          "identifier": "GB.ENG.Manchester",
+          "title": "Manchester, UK",
+          "timezone": "Europe/London",
+          "region": "UK_GM_Manchester"
+        }
+      ],
+      "polygon": "ulbfIhwzOypRuw\\ulJmiw@eNa`~@|dpAjFtwBn}j@wxCfygAesSrb^",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://andromeda.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "FR_J_East",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Paris",
+      "cities": [
+        {
+          "lat": 48.9894,
+          "lng": 1.71623,
+          "identifier": "FR.J.Mantes-la-Jolie",
+          "title": "Mantes-la-Jolie, France",
+          "timezone": "Europe/Paris",
+          "region": "FR_J_East"
+        }
+      ],
+      "polygon": "csmjH}agEi}qAsq_EtyBczqAnyiA??|feAnrbB??}feAfavA?hx@l}o@mxSngPex@hf}@x_m@pg{A",
+      "urls": [
+        "https://hadron.skedgo.com/satapp",
+        "https://recombination.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "FR_J_West",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Paris",
+      "cities": [
+        {
+          "lat": 48.95611,
+          "lng": 2.88833,
+          "identifier": "FR.J.Meaux",
+          "title": "Meaux, France",
+          "timezone": "Europe/Paris",
+          "region": "FR_J_West"
+        }
+      ],
+      "polygon": "whngHw}xM?gjm@orbB??fjm@ano@?p`@}nwAzrOa`s@rk^kpeAbs`CwXdqOnq]pxo@uqGlzOkje@|bSx{DcjHjwdD}ad@nqw@",
+      "urls": [
+        "https://hadron.skedgo.com/satapp",
+        "https://recombination.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "AU_VIC_Melbourne",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal",
+        "pt_ltd_MON"
+      ],
+      "timezone": "Australia/Melbourne",
+      "cities": [
+        {
+          "lat": -37.81137,
+          "lng": 144.97183,
+          "identifier": "AU.VIC.Melbourne",
+          "title": "Melbourne, VIC, Australia",
+          "timezone": "Australia/Melbourne",
+          "region": "AU_VIC_Melbourne"
+        }
+      ],
+      "polygon": "vk{gFqwfsZ{bp@pq`A{bo@tjDgpe@{iy@a`BwrrA`ds@ubiBfvfBr~iAxuJ}vQvsLogCdgD`eTrcFdwBkvAjqh@tea@fo_A{lu@ben@",
+      "urls": [
+        "https://granduni.skedgo.com/satapp",
+        "https://darkages.skedgo.com/satapp",
+        "https://hadron.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "MX_DIF_MexicoCity",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_car-s_Carrot",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/Mexico_City",
+      "cities": [
+        {
+          "lat": 19.4284,
+          "lng": -99.1276,
+          "identifier": "MX.DIF.Mexico-City",
+          "title": "Mexico City, Mexico",
+          "timezone": "America/Mexico_City",
+          "region": "MX_DIF_MexicoCity"
+        }
+      ],
+      "polygon": "wdntBnk{}QcdnA??_r_CbdnA?",
+      "urls": [
+        "https://hadron.skedgo.com/satapp",
+        "https://granduni.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_FL_Miami",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "US/Eastern",
+      "cities": [
+        {
+          "lat": 25.795,
+          "lng": -80.225,
+          "identifier": "US.FL.Miami",
+          "title": "Miami, FL, USA",
+          "timezone": "US/Eastern",
+          "region": "US_FL_Miami"
+        },
+        {
+          "lat": 26.122,
+          "lng": -80.137,
+          "identifier": "US.FL.Fort-Lauderdale",
+          "title": "Fort Lauderdale, FL, USA",
+          "timezone": "US/Eastern",
+          "region": "US_FL_Miami"
+        }
+      ],
+      "polygon": "_fwuC~y~mN_ulL??_zuE~tlL?",
+      "urls": [
+        "https://matter.skedgo.com/satapp",
+        "https://darkages.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "IT_Milano",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Rome",
+      "cities": [
+        {
+          "lat": 45.465,
+          "lng": 9.187,
+          "identifier": "IT.Milan",
+          "title": "Milan, Italy",
+          "timezone": "Europe/Rome",
+          "region": "IT_Milano"
+        }
+      ],
+      "polygon": "s`prGyhjs@{|wC??crdFz|wC?",
+      "urls": [
+        "https://matter.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_WI_Milwaukee",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "US/Central",
+      "cities": [
+        {
+          "lat": 43.03499,
+          "lng": -87.9225,
+          "identifier": "US.WI.Milwaukee",
+          "title": "Milwaukee, WI, USA",
+          "timezone": "US/Central",
+          "region": "US_WI_Milwaukee"
+        }
+      ],
+      "polygon": "gsibG~`h{Oc}fE??{raDb}fE?",
+      "urls": [
+        "https://lepton.skedgo.com/satapp",
+        "https://stars.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_MN_Minneapolis",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/Chicago",
+      "cities": [
+        {
+          "lat": 44.977,
+          "lng": -93.2746,
+          "identifier": "US.MN.Minneapolis",
+          "title": "Minneapolis, MN, USA",
+          "timezone": "America/Chicago",
+          "region": "US_MN_Minneapolis"
+        },
+        {
+          "lat": 44.954,
+          "lng": -93.0901,
+          "identifier": "US.MN.St-Paul",
+          "title": "St Paul, MN, USA",
+          "timezone": "America/Chicago",
+          "region": "US_MN_Minneapolis"
+        }
+      ],
+      "polygon": "ofhhGjifcQu{wJ~lEjiM{s_NfavBtjD`by@eggCftlAg}sBbeg@guf@x~`Aha@r{BvucGubBb{mDzWtadI",
+      "urls": [
+        "https://baryogenesis.skedgo.com/satapp",
+        "https://lepton.skedgo.com/satapp",
+        "https://matter.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "CA_QC_Montreal",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/Montreal",
+      "cities": [
+        {
+          "lat": 45.5038,
+          "lng": -73.56857,
+          "identifier": "CA.QC.Montreal",
+          "title": "Montreal, QC, Canada",
+          "timezone": "America/Montreal",
+          "region": "CA_QC_Montreal"
+        }
+      ],
+      "polygon": "_atqG`gbeM_`kI??_~cH~_kI?",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://energy.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "DE_BV_Munich",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Berlin",
+      "cities": [
+        {
+          "lat": 48.13758,
+          "lng": 11.58862,
+          "identifier": "DE.BV.Munich",
+          "title": "Munich, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_BV_Munich"
+        }
+      ],
+      "polygon": "eup`Hivo|@qfcC{o`Coo{@ohoBa}Mofg@rnEcvmAlndAsecDdeD|i@`qJ{nOtzL{tMzdAiqBrkR}|M`yHtoHfhBnjCd~Ae_@dxBrt@vcCfsDnkAcnKcnBwuFpbBsdF~zCyjEpyCka@xlDctCdaEpcFruBsG~iH`sCpiHmT||EbvHyq@vfFw`JzzVweC~eBcIh`FsuC`bDiqBmTgxDabDw`EfxHsxAen@_gBxrM~lA|lEgSf|FlpFv}Cl@j|Gnt@`dChCl{BgeD`kF_kDddDwlB`]pkAptKggAzwFtn@dmFdtAnjC{cCjuDw_Hq}BppDfbEdtAxqHbqIuhEncFal@nk@`sFk]j~FmQvgTw{@rlCh~BtrXzoBzpCgp@bfNhStlO|[zvL~vC`uBnkCaNvxBjwCh}@xiKud@vcM~lD`kF`mDyuFvqAvaB{Q~xL|hBpmHt~D`l@dY`~Pu~EeuChjE`|Qlp@pqRugAzpNemE{rB{oF~qIuaAqGz^fzG{uB~eBwoEwhE`v@|eMnj@jmGcjCrjD{^bgHqqAzaC_v@jjNxyDdwB}NbvH{^`zFsnApuE~aJbjAjPoyC``C}i@rhF{i@zhDh~FrtD_Na\\~tBdcFzqHbiDzpCtzAvpBlvEtuQuZthEfi@vuFumEwX{dAqfEszAbjAaiIiqE_\\bgH`yAzK~^bqDyt@|_DrgChhCasHljC}^|x@_|@`]ecBgqEwhA`bB",
+      "urls": [
+        "https://recombination.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "ES_AN_Malaga",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Madrid",
+      "cities": [
+        {
+          "lat": 36.71654,
+          "lng": -4.42916,
+          "identifier": "ES.AN.Málaga",
+          "title": "Málaga, Spain",
+          "timezone": "Europe/Madrid",
+          "region": "ES_AN_Malaga"
+        }
+      ],
+      "polygon": "uqu~Exh}ZoiX??yeo@niX?",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://energy.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "FR_R_Nantes",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Paris",
+      "cities": [
+        {
+          "lat": 47.21852,
+          "lng": -1.55451,
+          "identifier": "FR.R.Nantes",
+          "title": "Nantes, France",
+          "timezone": "Europe/Paris",
+          "region": "FR_R_Nantes"
+        }
+      ],
+      "polygon": "mip~G~t{Iqdm@??izxApdm@?",
+      "urls": [
+        "https://hadron.skedgo.com/satapp",
+        "https://recombination.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_TN_Nashville",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "US/Central",
+      "cities": [
+        {
+          "lat": 36.16223,
+          "lng": -86.77434,
+          "identifier": "US.TN.Nashville",
+          "title": "Nashville, TN, USA",
+          "timezone": "US/Central",
+          "region": "US_TN_Nashville"
+        }
+      ],
+      "polygon": "emrxEzp}sO_w|D??o_|E~v|D?",
+      "urls": [
+        "https://lepton.skedgo.com/satapp",
+        "https://stars.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_LA_NewOrleans",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "US/Central",
+      "cities": [
+        {
+          "lat": 29.94138,
+          "lng": -90.08237,
+          "identifier": "US.LA.New-Orleans",
+          "title": "New Orleans, LA, USA",
+          "timezone": "US/Central",
+          "region": "US_LA_NewOrleans"
+        }
+      ],
+      "polygon": "c{duDduhfPm_eA??glkCl_eA?",
+      "urls": [
+        "https://lepton.skedgo.com/satapp",
+        "https://matter.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_NY_NewYorkCity",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/New_York",
+      "cities": [
+        {
+          "lat": 40.71669,
+          "lng": -74.00614,
+          "identifier": "US.NY.New-York-City",
+          "title": "New York City, NY, USA",
+          "timezone": "America/New_York",
+          "region": "US_NY_NewYorkCity"
+        }
+      ],
+      "polygon": "oecvFnzhdM_}tA??o~oE~|tA?",
+      "urls": [
+        "https://lepton.skedgo.com/satapp",
+        "https://stars.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "UK_NorthEngland",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/London",
+      "cities": [
+        {
+          "lat": 54.9769,
+          "lng": -1.61078,
+          "identifier": "GB.ENG.Newcastle",
+          "title": "Newcastle, UK",
+          "timezone": "Europe/London",
+          "region": "UK_NorthEngland"
+        }
+      ],
+      "polygon": "_pskI~uxV?~lpG_g{C~`f@_vgC_rjTnkoK_yzN?~{mZ",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://andromeda.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "FR_U_Nice",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Paris",
+      "cities": [
+        {
+          "lat": 43.71008,
+          "lng": 7.26239,
+          "identifier": "FR.U.Nice",
+          "title": "Nice, France",
+          "timezone": "Europe/Paris",
+          "region": "FR_U_Nice"
+        }
+      ],
+      "polygon": "godmG_tbi@?epShhVcjfA_tByae@hKsqGa_DqnBrWi}L~}Inr@nuFo`GptGxtAvkDn`GteDia@hxDpuEnyCxiKzhGnr@jqErxJxyOkdElvc@vzcAwmUvrx@",
+      "urls": [
+        "https://recombination.skedgo.com/satapp",
+        "https://hadron.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "NL_Gelderland",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_car-s",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Amsterdam",
+      "cities": [
+        {
+          "lat": 51.81317,
+          "lng": 5.83541,
+          "identifier": "NL.Nijmegen",
+          "title": "Nijmegen, Netherlands",
+          "timezone": "Europe/Amsterdam",
+          "region": "NL_Gelderland"
+        },
+        {
+          "lat": 52.21003,
+          "lng": 5.96798,
+          "identifier": "NL.Apeldoorn",
+          "title": "Apeldoorn, Netherlands",
+          "timezone": "Europe/Amsterdam",
+          "region": "NL_Gelderland"
+        },
+        {
+          "lat": 51.98436,
+          "lng": 5.90104,
+          "identifier": "NL.Arnhem",
+          "title": "Arnhem, Netherlands",
+          "timezone": "Europe/Amsterdam",
+          "region": "NL_Gelderland"
+        },
+        {
+          "lat": 52.22096,
+          "lng": 6.89548,
+          "identifier": "NL.Enschede",
+          "title": "Enschede, Netherlands",
+          "timezone": "Europe/Amsterdam",
+          "region": "NL_Gelderland"
+        }
+      ],
+      "polygon": "okb`Io_p_@?sapGh{BhJt`DqmHz~@zi@yd@rsFr{Art@qRpwDbuCs}BzdF`l@xjC}|J`L}yQnqC_bOi{DqfE}SycB~~K{bHnZohDnkGg{A`bHfbE`jCl{BfeEycBliB}pCro@|Zv~@xgF{HrgEh@?~|G~gGvT|zE~{BxjE~`Dfn@naAllBpK~eB_CbvNvdEre@vnAhyBtZ|hFxoDrt@}BasCfhAoqFrwE}cNr`EwXnf@tqEhvDx^raE||JzNxtAwbClpFt_BdhHbxB|fMprDhrPmg@zwF{eAvuF`d@jS~w@ihC|}D`@cf@~xFmhBj`LguBly@wj@n{Bxd@jgApF|rHio@v_C}aAn~Aae@kw@{z@~lBnSbWuk@du@jh@neEaMjb@p`@|x@`n@urDt`Bas@rv@y`CnkClE_v@n_Mc~A|dE|gA`l@||@jzBzqAbqG{TnjCqOdn@h|@npAneF}xF`mC{a@i@vaaCyycD?",
+      "urls": [
+        "https://recombination.skedgo.com/satapp",
+        "https://hadron.skedgo.com/satapp",
+        "https://energy.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "JP_Fukuoka",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Asia/Tokyo",
+      "cities": [
+        {
+          "lat": 33.75364,
+          "lng": 130.75133,
+          "identifier": "JP.Nogata",
+          "title": "Nogata, Japan",
+          "timezone": "Asia/Tokyo",
+          "region": "JP_Fukuoka"
+        }
+      ],
+      "polygon": "uulhE_uj{Wn\\j~Ns}ChYmaIpgBk}FllBirKhR}_ArnA_wBGshMk`Rk|HsbGoeCgcJ{iN~Cio@nOiZvlAhMjfA{Mpv@f`DtgGdWtrAlfBx`@rSddAtNjdByeElsEuhBdmFyrEp{Jzg@jqDys@xsGzlAfdDi^vz[{gGnFegN_iAaoJcwMsxCi~Fa~D{gLitN_dZcbNqpAauJ{rBm}CwcMwdP}xn@xp@csOh{LsrI`bGyoFzdAadCsr@y{AqnImsEqsAm}JfoUu`HduIre@zqI{rBzfEglAdyHelL`xHysC|iVty@mWzgf@djKhoNvyQ~{I`}IguC~kFd_Gl_MybKp~LnnEcvIbh_@fgHxnDroAp|QvaS~}O",
+      "urls": [
+        "https://darkages.skedgo.com/satapp",
+        "https://granduni.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "UK_Norwich",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/London",
+      "cities": [
+        {
+          "lat": 52.62747,
+          "lng": 1.30912,
+          "identifier": "GB.ENG.Norwich",
+          "title": "Norwich, UK",
+          "timezone": "Europe/London",
+          "region": "UK_Norwich"
+        }
+      ],
+      "polygon": "_tpzH_ry@?~qy@_||F??_seKnxtI??~_kI",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://andromeda.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "DE_BV_Nuremberg",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Berlin",
+      "cities": [
+        {
+          "lat": 49.45787,
+          "lng": 11.07587,
+          "identifier": "DE.BV.Nuremberg",
+          "title": "Nuremberg, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_BV_Nuremberg"
+        },
+        {
+          "lat": 49.90056,
+          "lng": 10.90027,
+          "identifier": "DE.BV.Bamberg",
+          "title": "Bamberg, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_BV_Nuremberg"
+        },
+        {
+          "lat": 49.47493,
+          "lng": 10.98998,
+          "identifier": "DE.BV.Fürth",
+          "title": "Fürth, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_BV_Nuremberg"
+        },
+        {
+          "lat": 49.59838,
+          "lng": 11.00776,
+          "identifier": "DE.BV.Erlangen",
+          "title": "Erlangen, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_BV_Nuremberg"
+        },
+        {
+          "lat": 49.7943,
+          "lng": 9.9281,
+          "identifier": "DE.BV.Würzburg",
+          "title": "Würzburg, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_BV_Nuremberg"
+        }
+      ],
+      "polygon": "_sfnH{vxw@gjdE}g{Bss@wtyBlbfAcgnJveBllBj@rxDpgDoFdwCtcGdcEsWds@hfDpjKqGwLhxH{xCv}CqpCa{@wnDbgHgrBytAmO|uGa}H~cClZ~uGvjFsnBdhChoFjfA}uGreFwdGxyDqwDljIhhChjFcsOxvBhhCdN_kFroCgkGfbBihCv^gbEtfA_fBhRibEfqC_~J~_Fx}ChoCqeQj|O`wM~~GfjB~nDxrMftHobFpsBsnNnbL_hAj@a`EjyLasChnC_mId~|BtamIwrzCpk}H",
+      "urls": [
+        "https://recombination.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_FL_Orlando",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "US/Eastern",
+      "cities": [
+        {
+          "lat": 28.54212,
+          "lng": -81.37905,
+          "identifier": "US.FL.Orlando",
+          "title": "Orlando, FL, USA",
+          "timezone": "US/Eastern",
+          "region": "US_FL_Orlando"
+        },
+        {
+          "lat": 28.35561,
+          "lng": -80.73208,
+          "identifier": "US.FL.Space-Coast",
+          "title": "Space Coast, FL, USA",
+          "timezone": "US/Eastern",
+          "region": "US_FL_Orlando"
+        }
+      ],
+      "polygon": "}e~hD|adrNe~oH??qoyFd~oH?",
+      "urls": [
+        "https://matter.skedgo.com/satapp",
+        "https://darkages.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "NO_Oslo",
+      "modes": [
+        "in_air",
+        "pt_pub",
+        "pt_ltd_SCHOOLBUS",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Oslo",
+      "cities": [
+        {
+          "lat": 59.91433,
+          "lng": 10.74772,
+          "identifier": "NO.Oslo",
+          "title": "Oslo, Norway",
+          "timezone": "Europe/Oslo",
+          "region": "NO_Oslo"
+        }
+      ],
+      "polygon": "q|plJe~dv@}oEqccDwpaEehN_Wo`sMdbw@c|_Ab_`BxpNhst@ftcAbzCntm@l~\\ka@djPrwg@pkbAmnMx{hAl_d@ft@rlq@exc@rtW~qWllgAhcM~agEdqSnvlB",
+      "urls": [
+        "https://energy.skedgo.com/satapp",
+        "https://andromeda.skedgo.com/satapp",
+        "https://matter.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "CA_ON_Ottawa",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/Montreal",
+      "cities": [
+        {
+          "lat": 45.4234,
+          "lng": -75.6968,
+          "identifier": "CA.ON.Ottawa",
+          "title": "Ottawa, ON, Canada",
+          "timezone": "America/Montreal",
+          "region": "CA_ON_Ottawa"
+        }
+      ],
+      "polygon": "_p`qG~iupM_xnD??_kiF~wnD?",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://energy.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "FI_NorthFinland",
+      "modes": [
+        "in_air",
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Helsinki",
+      "cities": [
+        {
+          "lat": 65.01175,
+          "lng": 25.47462,
+          "identifier": "FI.Oulu",
+          "title": "Oulu, Finland",
+          "timezone": "Europe/Helsinki",
+          "region": "FI_NorthFinland"
+        },
+        {
+          "lat": 62.89325,
+          "lng": 27.67825,
+          "identifier": "FI.Kuopio",
+          "title": "Kuopio, Finland",
+          "timezone": "Europe/Helsinki",
+          "region": "FI_NorthFinland"
+        },
+        {
+          "lat": 66.49717,
+          "lng": 25.72326,
+          "identifier": "FI.Rovaniemi",
+          "title": "Rovaniemi, Finland",
+          "timezone": "Europe/Helsinki",
+          "region": "FI_NorthFinland"
+        },
+        {
+          "lat": 62.60052,
+          "lng": 29.76201,
+          "identifier": "FI.Joensuu",
+          "title": "Joensuu, Finland",
+          "timezone": "Europe/Helsinki",
+          "region": "FI_NorthFinland"
+        },
+        {
+          "lat": 68.41972,
+          "lng": 27.41074,
+          "identifier": "FI.Saariselkä",
+          "title": "Saariselkä, Finland",
+          "timezone": "Europe/Helsinki",
+          "region": "FI_NorthFinland"
+        },
+        {
+          "lat": 67.33187,
+          "lng": 23.78911,
+          "identifier": "FI.Kolari",
+          "title": "Kolari, Finland",
+          "timezone": "Europe/Stockholm",
+          "region": "FI_NorthFinland"
+        },
+        {
+          "lat": 64.07229,
+          "lng": 24.53387,
+          "identifier": "FI.Ylivieska",
+          "title": "Ylivieska, Finland",
+          "timezone": "Europe/Helsinki",
+          "region": "FI_NorthFinland"
+        },
+        {
+          "lat": 64.12877,
+          "lng": 29.52018,
+          "identifier": "FI.Kuhmo",
+          "title": "Kuhmo, Finland",
+          "timezone": "Europe/Helsinki",
+          "region": "FI_NorthFinland"
+        },
+        {
+          "lat": 65.96445,
+          "lng": 29.1887,
+          "identifier": "FI.Kuusamo",
+          "title": "Kuusamo, Finland",
+          "timezone": "Europe/Helsinki",
+          "region": "FI_NorthFinland"
+        },
+        {
+          "lat": 67.29246,
+          "lng": 28.15847,
+          "identifier": "FI.Savukoski",
+          "title": "Savukoski, Finland",
+          "timezone": "Europe/Helsinki",
+          "region": "FI_NorthFinland"
+        }
+      ],
+      "polygon": "opioK_`brC_ycC~dtBoinB_ieA_ieA~|tAovs@nqPoofBotL_qdB~bgIszkBby}Fioi@alsBwiGsooB`hlBmmtDxyK{o|Bam^eumC`ze@csgEwgp@s}gAbiAqh~@yjTirV_nh@lgJyytAc}b@cxu@eomBuz^k|rHrnjAckaF`vp@wvn@zypAzmoAz`nG}|pF|lq[cngJn`wFncpJo_h@~mhBoljB~pdBnwH~yuE_xq@~c_DokXn{sEobd@~~{B_`qA~~{B_g^n_eD_g^n{vAoe`@?owH~``H",
+      "urls": [
+        "https://andromeda.skedgo.com/satapp",
+        "https://matter.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "UK_Oxford",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/London",
+      "cities": [
+        {
+          "lat": 51.75253,
+          "lng": -1.25384,
+          "identifier": "GB.ENG.Oxford",
+          "title": "Oxford, UK",
+          "timezone": "Europe/London",
+          "region": "UK_Oxford"
+        }
+      ],
+      "polygon": "oro~H~_kI?_kiF~yuE??~jiF",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://andromeda.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "IT_Palermo",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Rome",
+      "cities": [
+        {
+          "lat": 38.11557,
+          "lng": 13.36128,
+          "identifier": "IT.Palermo",
+          "title": "Palermo, Italy",
+          "timezone": "Europe/Rome",
+          "region": "IT_Palermo"
+        }
+      ],
+      "polygon": "ybigF}k|oAaoJbwByfQ`dCisCcaV~eG}eMdoPygLtmKdn@rVl_d@",
+      "urls": [
+        "https://matter.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "FR_J_Paris",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Paris",
+      "cities": [
+        {
+          "lat": 48.8545,
+          "lng": 2.33686,
+          "identifier": "FR.J.Paris",
+          "title": "Paris, France",
+          "timezone": "Europe/Paris",
+          "region": "FR_J_Paris"
+        }
+      ],
+      "polygon": "o{rjHmhsK?aetB~pdB??`etB",
+      "urls": [
+        "https://hadron.skedgo.com/satapp",
+        "https://recombination.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "AU_WA_Perth",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Australia/Perth",
+      "cities": [
+        {
+          "lat": -31.95299,
+          "lng": 115.85747,
+          "identifier": "AU.WA.Perth",
+          "title": "Perth, WA, Australia",
+          "timezone": "Australia/Perth",
+          "region": "AU_WA_Perth"
+        },
+        {
+          "lat": -33.65841,
+          "lng": 115.33595,
+          "identifier": "AU.WA.Busselton",
+          "title": "Busselton, WA, Australia",
+          "timezone": "Australia/Perth",
+          "region": "AU_WA_Perth"
+        },
+        {
+          "lat": -33.35634,
+          "lng": 115.662,
+          "identifier": "AU.WA.Bunbury",
+          "title": "Bunbury, WA, Australia",
+          "timezone": "Australia/Perth",
+          "region": "AU_WA_Perth"
+        }
+      ],
+      "polygon": "~qtwE_sxvT_zwl@??_oyo@~ywl@?",
+      "urls": [
+        "https://granduni.skedgo.com/satapp",
+        "https://darkages.skedgo.com/satapp",
+        "https://hadron.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_PA_Philadelphia",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/New_York",
+      "cities": [
+        {
+          "lat": 39.953,
+          "lng": -75.164,
+          "identifier": "US.PA.Philadelphia",
+          "title": "Philadelphia, PA, USA",
+          "timezone": "America/New_York",
+          "region": "US_PA_Philadelphia"
+        }
+      ],
+      "polygon": "oiwpFnhzlMotiC??o~oEntiC?",
+      "urls": [
+        "https://hadron.skedgo.com/satapp",
+        "https://darkages.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_AZ_Phoenix",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/Phoenix",
+      "cities": [
+        {
+          "lat": 33.45106,
+          "lng": -112.08928,
+          "identifier": "US.AZ.Phoenix",
+          "title": "Phoenix, AZ, USA",
+          "timezone": "America/Phoenix",
+          "region": "US_AZ_Phoenix"
+        }
+      ],
+      "polygon": "ejqjErwrnTk|qAsa{@cFm{lChpfBq|Hl`m@dp{A",
+      "urls": [
+        "https://lepton.skedgo.com/satapp",
+        "https://stars.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "SE_NorthSweden",
+      "modes": [
+        "pt_pub",
+        "pt_ltd_SCHOOLBUS",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Stockholm",
+      "cities": [
+        {
+          "lat": 65.31348,
+          "lng": 21.48994,
+          "identifier": "SE.Piteå",
+          "title": "Piteå, Sweden",
+          "timezone": "Europe/Stockholm",
+          "region": "SE_NorthSweden"
+        },
+        {
+          "lat": 67.13458,
+          "lng": 20.65994,
+          "identifier": "SE.Gällivare",
+          "title": "Gällivare, Sweden",
+          "timezone": "Europe/Stockholm",
+          "region": "SE_NorthSweden"
+        },
+        {
+          "lat": 67.85394,
+          "lng": 20.22715,
+          "identifier": "SE.Kiruna",
+          "title": "Kiruna, Sweden",
+          "timezone": "Europe/Stockholm",
+          "region": "SE_NorthSweden"
+        }
+      ],
+      "polygon": "ogbiKabzqAwkpCex}CsuaDs_No~[y{|Dite@~hRge{BeldEae_ArdkAwphCmteFpxRq~qCwfnBgnc@lk^sdtI{rvB}d_@ugFqjkBvieEyyfR|veM{zrBny_HhpuC?`u_y@",
+      "urls": [
+        "https://energy.skedgo.com/satapp",
+        "https://andromeda.skedgo.com/satapp",
+        "https://matter.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_PA_Pittsburgh",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/New_York",
+      "cities": [
+        {
+          "lat": 40.44073,
+          "lng": -80.00042,
+          "identifier": "US.PA.Pittsburgh",
+          "title": "Pittsburgh, PA, USA",
+          "timezone": "America/New_York",
+          "region": "US_PA_Pittsburgh"
+        }
+      ],
+      "polygon": "_huuFpg`iN}qh@ewBurKkqyB~`n@vXple@zaZdtAjtx@",
+      "urls": [
+        "https://hadron.skedgo.com/satapp",
+        "https://darkages.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "UK_SouthWestEngland",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/London",
+      "cities": [
+        {
+          "lat": 50.37545,
+          "lng": -4.14256,
+          "identifier": "GB.ENG.Plymouth",
+          "title": "Plymouth, UK",
+          "timezone": "Europe/London",
+          "region": "UK_SouthWestEngland"
+        }
+      ],
+      "polygon": "_pbxH~xkb@?_isXnezG??~hsX",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://andromeda.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_OR_Portland",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "US/Pacific",
+      "cities": [
+        {
+          "lat": 45.525,
+          "lng": -122.676,
+          "identifier": "US.OR.Portland",
+          "title": "Portland, OR, USA",
+          "timezone": "US/Pacific",
+          "region": "US_OR_Portland"
+        }
+      ],
+      "polygon": "_ur~F~~uxVootY??_pcSnotY?",
+      "urls": [
+        "https://matter.skedgo.com/satapp",
+        "https://darkages.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "BR_PortoAlegre",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/Sao_Paulo",
+      "cities": [
+        {
+          "lat": -30.02932,
+          "lng": -51.21725,
+          "identifier": "BR.Porto-Alegre",
+          "title": "Porto Alegre, Brazil",
+          "timezone": "America/Sao_Paulo",
+          "region": "BR_PortoAlegre"
+        }
+      ],
+      "polygon": "|uuwDp|jxHirkA??mqkAhrkA?",
+      "urls": [
+        "https://hadron.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "CZ_A_Prague",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Prague",
+      "cities": [
+        {
+          "lat": 50.07546,
+          "lng": 14.43686,
+          "identifier": "CZ.A.Prague",
+          "title": "Prague, Czech Republic",
+          "timezone": "Europe/Prague",
+          "region": "CZ_A_Prague"
+        }
+      ],
+      "polygon": "kepnH_`tsAmhcD??ubgHlhcD?",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_RI_Providence",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "US/Eastern",
+      "cities": [
+        {
+          "lat": 41.82399,
+          "lng": -71.41283,
+          "identifier": "US.RI.Providence",
+          "title": "Providence, RI, USA",
+          "timezone": "US/Eastern",
+          "region": "US_RI_Providence"
+        }
+      ],
+      "polygon": "odg{FpixuLm_AguI_zMvu@kf@cgHctqBvIceAyfqAtoWcAws@ezG|oRchBndZcyc@pe`@weAfkbArgpAdcB~aOih`@~qw@",
+      "urls": [
+        "https://lepton.skedgo.com/satapp",
+        "https://matter.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "CA_QC_QuebecCity",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Canada/Eastern",
+      "cities": [
+        {
+          "lat": 46.81299,
+          "lng": -71.22448,
+          "identifier": "CA.QC.Quebec-City",
+          "title": "Quebec City, QC, Canada",
+          "timezone": "Canada/Eastern",
+          "region": "CA_QC_QuebecCity"
+        }
+      ],
+      "polygon": "_`yzG~j_tL_t`B??}ugC~s`B?",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://energy.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "FR_E_Rennes",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Paris",
+      "cities": [
+        {
+          "lat": 48.116,
+          "lng": -1.679,
+          "identifier": "FR.E.Rennes",
+          "title": "Rennes, France",
+          "timezone": "Europe/Paris",
+          "region": "FR_E_Rennes"
+        }
+      ],
+      "polygon": "_tbcH~reKorbB??_|_CnrbB?",
+      "urls": [
+        "https://hadron.skedgo.com/satapp",
+        "https://recombination.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_NV_Reno",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/Los_Angeles",
+      "cities": [
+        {
+          "lat": 39.51454,
+          "lng": -119.80252,
+          "identifier": "US.NV.Reno",
+          "title": "Reno, NV, USA",
+          "timezone": "America/Los_Angeles",
+          "region": "US_NV_Reno"
+        }
+      ],
+      "polygon": "}}~lFtaq{Um`kQk{@`Z{foc@jocUh\\jnHlbp]",
+      "urls": [
+        "https://lepton.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp",
+        "https://stars.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "LV_Riga",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Riga",
+      "cities": [
+        {
+          "lat": 56.9494,
+          "lng": 24.10518,
+          "identifier": "LV.Riga",
+          "title": "Riga, Latvia",
+          "timezone": "Europe/Riga",
+          "region": "LV_Riga"
+        }
+      ],
+      "polygon": "wdyyIsxrpCwku@??y~pBvku@?",
+      "urls": [
+        "https://hadron.skedgo.com/satapp",
+        "https://granduni.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "BR_RJ_RioDeJaneiro",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/Sao_Paulo",
+      "cities": [
+        {
+          "lat": -22.90413,
+          "lng": -43.17597,
+          "identifier": "BR.RJ.Rio-de-Janeiro",
+          "title": "Rio de Janeiro, Brazil",
+          "timezone": "America/Sao_Paulo",
+          "region": "BR_RJ_RioDeJaneiro"
+        }
+      ],
+      "polygon": "`j`kCjwgjGuku@|sHsaPirVkqRa{|Asf@oey@tyj@q_Y`{u@abDhuVvrwC",
+      "urls": [
+        "https://hadron.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "IT_Rome",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Rome",
+      "cities": [
+        {
+          "lat": 41.877,
+          "lng": 12.481,
+          "identifier": "IT.Rome",
+          "title": "Rome, Italy",
+          "timezone": "Europe/Rome",
+          "region": "IT_Rome"
+        }
+      ],
+      "polygon": "o_hzFokbfAoalE??o|eHnalE?",
+      "urls": [
+        "https://matter.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "DE_MV_Rostock",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Berlin",
+      "cities": [
+        {
+          "lat": 54.08795,
+          "lng": 12.13496,
+          "identifier": "DE.MV.Rostock",
+          "title": "Rostock, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_MV_Rostock"
+        }
+      ],
+      "polygon": "}}wbIyh{bAo`~EsJi_kCeypNzw}Dw_mBdiB|aCjwHyv@ttAxU~kQowH`yAg`@baAbSh`C}QruCcwA`}G_NrtBqhEblIrg@vgEoUneDe|@f|@sjDxmFwXxBurAz_Ise@`mIuyD~yDst@trGoc@g@ihC`uBucAvkJhxHjuCtwE~cFefChaPhqEpwIhbQrxGrgVr_N_fBxFhktG{f`@`l|H",
+      "urls": [
+        "https://recombination.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "NL_ZH_Rotterdam",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_car-s",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Amsterdam",
+      "cities": [
+        {
+          "lat": 51.92321,
+          "lng": 4.47479,
+          "identifier": "NL.ZH.Rotterdam",
+          "title": "Rotterdam, Netherlands",
+          "timezone": "Europe/Amsterdam",
+          "region": "NL_ZH_Rotterdam"
+        },
+        {
+          "lat": 52.07049,
+          "lng": 4.30626,
+          "identifier": "NL.ZH.The-Hague",
+          "title": "The Hague, Netherlands",
+          "timezone": "Europe/Amsterdam",
+          "region": "NL_ZH_Rotterdam"
+        },
+        {
+          "lat": 52.09125,
+          "lng": 5.1194,
+          "identifier": "NL.ZH.Utrecht",
+          "title": "Utrecht, Netherlands",
+          "timezone": "Europe/Amsterdam",
+          "region": "NL_ZH_Rotterdam"
+        }
+      ],
+      "polygon": "kq}zHs~s_@hHl{mHy~k@uaYcgz@}i|A~_G{nvDr|~A`@",
+      "urls": [
+        "https://hadron.skedgo.com/satapp",
+        "https://recombination.skedgo.com/satapp",
+        "https://energy.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "DE_SL_Saarbrucken",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Berlin",
+      "cities": [
+        {
+          "lat": 49.23944,
+          "lng": 6.99333,
+          "identifier": "DE.SL.Saarbrücken",
+          "title": "Saarbrücken, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_SL_Saarbrucken"
+        }
+      ],
+      "polygon": "}wylHqzxe@akPnaA{sAslCyhBr{C{lCcwBg`FwmIkoEdPo{HycMweMk_A_gAwv@ey@fxH|E|_Dgr@b`EitDp~GxtAbyAeChhCqxCbjAokFr_NcmDpnBu|B_Nc`@pdFwrHtqGuxJfsDsnJchBe}C_wA_lAdn@yjDuaBgRwfFw~BqGkqAl{BedCk_AqHm{Bi|A}gAub@waB{zAa_KqhBzK{~DadCo^qfEprAihCeiBo~GwnGhlMklLssFc{@x{DczD|i@}v`@_tpGl`mEqk{AjtmBnodBkgG|_[euGfkGe|H|aOtgEt`H`aFb}KuRpsQ{]x`IyeChxHb_DjfDt`@vfF{aNduCyfBdcJuxA|nDft@~lEai@|wFbfEijBzkEf|Fm~AliIfQfzGqyD~jFytBihCucAbPzd@|_DasGdmFedDb{@sqA|}DgtIzxKqmCkfD{xEjkHaiBwXahGdxSrrAh_L",
+      "urls": [
+        "https://recombination.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_CA_Sacramento",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/Los_Angeles",
+      "cities": [
+        {
+          "lat": 38.57797,
+          "lng": -121.498,
+          "identifier": "US.CA.Sacramento",
+          "title": "Sacramento, CA, USA",
+          "timezone": "America/Los_Angeles",
+          "region": "US_CA_Sacramento"
+        }
+      ],
+      "polygon": "qlznFj}qfV~{p@uurDjf~Cp_YftCriyE",
+      "urls": [
+        "https://lepton.skedgo.com/satapp",
+        "https://stars.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_MO_SaintLouis",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "US/Central",
+      "cities": [
+        {
+          "lat": 38.62934,
+          "lng": -90.19565,
+          "identifier": "US.MO.Saint-Louis",
+          "title": "Saint Louis, MO, USA",
+          "timezone": "US/Central",
+          "region": "US_MO_SaintLouis"
+        }
+      ],
+      "polygon": "_lijFjy}jP{oyAmwyCtzsA_rsCroqBvqtD",
+      "urls": [
+        "https://matter.skedgo.com/satapp",
+        "https://darkages.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_UT_SaltLakeCity",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "US/Mountain",
+      "cities": [
+        {
+          "lat": 40.76169,
+          "lng": -111.90101,
+          "identifier": "US.UT.Salt-Lake-City",
+          "title": "Salt Lake City, UT, USA",
+          "timezone": "US/Mountain",
+          "region": "US_UT_SaltLakeCity"
+        }
+      ],
+      "polygon": "efbrFrtbnTslmJ??ksbGrlmJ?",
+      "urls": [
+        "https://lepton.skedgo.com/satapp",
+        "https://stars.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_CA_SanDiego",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/Los_Angeles",
+      "cities": [
+        {
+          "lat": 32.71463,
+          "lng": -117.16377,
+          "identifier": "US.CA.San-Diego",
+          "title": "San Diego, CA, USA",
+          "timezone": "America/Los_Angeles",
+          "region": "US_CA_SanDiego"
+        }
+      ],
+      "polygon": "_rbkEh`qmUu`Gqa{@hga@cd~E~cgCoq]hqSpbaF",
+      "urls": [
+        "https://lepton.skedgo.com/satapp",
+        "https://stars.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_CA_SanFrancisco",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/Los_Angeles",
+      "cities": [
+        {
+          "lat": 37.77952,
+          "lng": -122.41379,
+          "identifier": "US.CA.San-Francisco",
+          "title": "San Francisco, CA, USA",
+          "timezone": "America/Los_Angeles",
+          "region": "US_CA_SanFrancisco"
+        },
+        {
+          "lat": 37.33661,
+          "lng": -121.88573,
+          "identifier": "US.CA.San-Jose",
+          "title": "San Jose, CA, USA",
+          "timezone": "America/Los_Angeles",
+          "region": "US_CA_SanFrancisco"
+        },
+        {
+          "lat": 37.80302,
+          "lng": -122.27025,
+          "identifier": "US.CA.Oakland",
+          "title": "Oakland, CA, USA",
+          "timezone": "America/Los_Angeles",
+          "region": "US_CA_SanFrancisco"
+        }
+      ],
+      "polygon": "og|_F~}inVotfG??_owHntfG?",
+      "urls": [
+        "https://lepton.skedgo.com/satapp",
+        "https://stars.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_CA_SantaRosa",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/Los_Angeles",
+      "cities": [
+        {
+          "lat": 38.44047,
+          "lng": -122.71443,
+          "identifier": "US.CA.Santa-Rosa",
+          "title": "Santa Rosa, CA, USA",
+          "timezone": "America/Los_Angeles",
+          "region": "US_CA_SantaRosa"
+        }
+      ],
+      "polygon": "w_}iFzqjnVw}{@ydG{lDgbEfjAuoHdrfAsioAhhL}tMfvOmiIfiK`]h}@rcA{Tz`IbiApf\\g~i@zdxA",
+      "urls": [
+        "https://lepton.skedgo.com/satapp",
+        "https://stars.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "CL_SA_Santiago",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/Santiago",
+      "cities": [
+        {
+          "lat": -33.44863,
+          "lng": -70.66269,
+          "identifier": "CL.SA.Santiago",
+          "title": "Santiago, Chile",
+          "timezone": "America/Santiago",
+          "region": "CL_SA_Santiago"
+        }
+      ],
+      "polygon": "`~plErwuoLogiA??_hrAngiA?",
+      "urls": [
+        "https://hadron.skedgo.com/satapp",
+        "https://granduni.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_WA_Seattle",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "US/Pacific",
+      "cities": [
+        {
+          "lat": 47.616,
+          "lng": -122.327,
+          "identifier": "US.WA.Seattle",
+          "title": "Seattle, WA, USA",
+          "timezone": "US/Pacific",
+          "region": "US_WA_Seattle"
+        }
+      ],
+      "polygon": "_b`|G~n}nV_~cH??_owH~}cH?",
+      "urls": [
+        "https://lepton.skedgo.com/satapp",
+        "https://darkages.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "UK_Sheffield",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/London",
+      "cities": [
+        {
+          "lat": 53.38252,
+          "lng": -1.46851,
+          "identifier": "GB.ENG.Sheffield",
+          "title": "Sheffield, UK",
+          "timezone": "Europe/London",
+          "region": "UK_Sheffield"
+        }
+      ],
+      "polygon": "_fpeI~cyK?o`qNnljB??n`qN",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://andromeda.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "AU_VIC_East",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Australia/Melbourne",
+      "cities": [
+        {
+          "lat": -36.37482,
+          "lng": 145.40558,
+          "identifier": "AU.VIC.Shepparton",
+          "title": "Shepparton, VIC, Australia",
+          "timezone": "Australia/Melbourne",
+          "region": "AU_VIC_East"
+        }
+      ],
+      "polygon": "b{niFmgauZjvAcph@a}EugBw`DylTsgLteCiyJl_RctfBedjAs_s@nthBvJ~pHi`cIrfAym@wkcAzzXuyiArbMykx@sbM_`~@~aW}xeAaf[{byAk`Bi{fA~a\\}j_AxgvB_og@f}WzlPrzjCmkmJj_kI~y{GyKns|Mi}~B~yaF",
+      "urls": [
+        "https://granduni.skedgo.com/satapp",
+        "https://darkages.skedgo.com/satapp",
+        "https://hadron.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "SG_Singapore",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Asia/Singapore",
+      "cities": [
+        {
+          "lat": 1.27945,
+          "lng": 103.84157,
+          "identifier": "SG.Singapore",
+          "title": "Singapore",
+          "timezone": "Asia/Singapore",
+          "region": "SG_Singapore"
+        }
+      ],
+      "polygon": "{diGymkwRgm_@qxUxmV_yz@bkSse@~c[|td@knMxgz@",
+      "urls": [
+        "https://darkages.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "UK_SouthEastEngland",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/London",
+      "cities": [
+        {
+          "lat": 50.91059,
+          "lng": -1.40095,
+          "identifier": "GB.ENG.Southampton",
+          "title": "Southampton, UK",
+          "timezone": "Europe/London",
+          "region": "UK_SouthEastEngland"
+        }
+      ],
+      "polygon": "_pbxH~_kI?__pR~f{C??~~oR",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://andromeda.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_IL_Springfield",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/Chicago",
+      "cities": [
+        {
+          "lat": 39.7809,
+          "lng": -89.64767,
+          "identifier": "US.IL.Springfield",
+          "title": "Springfield, IL, USA",
+          "timezone": "America/Chicago",
+          "region": "US_IL_Springfield"
+        }
+      ],
+      "polygon": "_|hqFnktbPm_eD??_owHl_eD?",
+      "urls": [
+        "https://lepton.skedgo.com/satapp",
+        "https://stars.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_MA_Springfield",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/New_York",
+      "cities": [
+        {
+          "lat": 42.10101,
+          "lng": -72.58701,
+          "identifier": "US.MA.Springfield",
+          "title": "Springfield, MA, USA",
+          "timezone": "America/New_York",
+          "region": "US_MA_Springfield"
+        }
+      ],
+      "polygon": "y`{_Gpbt_Mwm`C}`o@l|H}knJ`{cCkCd`AtrpA{qAiC_G``zC{qAfrPq@dnMxkEbx@`b@x_IieFoUedBpkvBbFpaM",
+      "urls": [
+        "https://matter.skedgo.com/satapp",
+        "https://darkages.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "NO_Rogaland",
+      "modes": [
+        "in_air",
+        "pt_pub",
+        "pt_ltd_SCHOOLBUS",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Oslo",
+      "cities": [
+        {
+          "lat": 58.96633,
+          "lng": 5.73138,
+          "identifier": "NO.Stavanger",
+          "title": "Stavanger, Norway",
+          "timezone": "Europe/Oslo",
+          "region": "NO_Rogaland"
+        }
+      ],
+      "polygon": "gcqlJqbgv@fe}E}c|@f`|Cr_NlbLlxx\\{ftK_mE",
+      "urls": [
+        "https://energy.skedgo.com/satapp",
+        "https://andromeda.skedgo.com/satapp",
+        "https://matter.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "SE_Stockholm",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Stockholm",
+      "cities": [
+        {
+          "lat": 59.32512,
+          "lng": 18.07109,
+          "identifier": "SE.Stockholm",
+          "title": "Stockholm, Sweden",
+          "timezone": "Europe/Stockholm",
+          "region": "SE_Stockholm"
+        }
+      ],
+      "polygon": "s}opJapiqBzwnEkaiG`z_G??h`c_@}roM?",
+      "urls": [
+        "https://energy.skedgo.com/satapp",
+        "https://andromeda.skedgo.com/satapp",
+        "https://matter.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "FR_A_Strasbourg",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Paris",
+      "cities": [
+        {
+          "lat": 48.583,
+          "lng": 7.747,
+          "identifier": "FR.A.Strasbourg",
+          "title": "Strasbourg, France",
+          "timezone": "Europe/Paris",
+          "region": "FR_A_Strasbourg"
+        }
+      ],
+      "polygon": "othhH_ngm@?ethAn~HtbLpmBj_H~zCj_AhzDfsDfpJk_A|~CplAtz@fsDfgEzK?dmd@",
+      "urls": [
+        "https://recombination.skedgo.com/satapp",
+        "https://hadron.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "DE_BW_Stuttgart",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Berlin",
+      "cities": [
+        {
+          "lat": 48.77711,
+          "lng": 9.18278,
+          "identifier": "DE.BW.Stuttgart",
+          "title": "Stuttgart, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_BW_Stuttgart"
+        },
+        {
+          "lat": 48.00102,
+          "lng": 7.8395,
+          "identifier": "DE.BW.Freiburg",
+          "title": "Freiburg, Germany",
+          "timezone": "Europe/Berlin",
+          "region": "DE_BW_Stuttgart"
+        }
+      ],
+      "polygon": "s_{aHcm{l@y{F|gA{cN}vAefR{{D}jJs{C_fGazF{qIdeI_fIbP}`Gk_A_qF{pC{rJaaJcbPakFyjCsqG{nJxv@mdJoyCoeHcyAc|BeoEmiFuIwoEvg@{`KooGynN}`UiqDwX_fGelLc^sqGmjN_tHacMqsLptHg`\\lgF}tPcBqiDcdHu|TkfI}}XsmDajUcyDqcc@oG}{g@|iA{h]hvByiKve@{oFdrCkpWddNgjf@t{~BxekDz`wAxzk@{_AzaC|pB{Kx`CdfC}q@|hBudC~dAaaB_NeFdmFzpByeAbgAneKm@pwDfiDpfEfkBhCfrCxqHvrA_fBbjAnaAddBowD_Lw_C~_Am{BjCoqFitArVggAe|Fxk@sqAeu@{~Cr\\g{ApxAewBzyB`]|[nyC|lBkp@prCtjDcIjuDgaCePitApuE~oAztAfdBrqGh`@oyCdc@oaA|eAre@hwAb}KijAfbEndAbjAsWfaKweBlsEseCbPmZh`F~bAxlDmaBzcBfaCthEfjAdpExQdcDzjBl`Alj@btCuq@dkAhwArbGi`@toHsOjzBfzAtt@kXdmFapAnaAodAsVaeB~eBoEt~Bbk@r{Cwa@liClaBzi@hwAv_CbpAhlGhjApkIoEvkDqyAzoCkgAfjBiu@}LdAiyBan@ylDy{@l`A}h@lE}NhjBdoBhcEiKdaBg{@~~BwrAiU_jJlpL",
+      "urls": [
+        "https://recombination.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "SE_Sundsvall",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Stockholm",
+      "cities": [
+        {
+          "lat": 62.3921,
+          "lng": 17.30989,
+          "identifier": "SE.Sundsvall",
+          "title": "Sundsvall, Sweden",
+          "timezone": "Europe/Stockholm",
+          "region": "SE_Sundsvall"
+        }
+      ],
+      "polygon": "igpsJuyfiAyvD{luAuao@_se@aqnApihCudiByl[mwbAjqh@wejB??o{|l@bkqO?pOtv}i@",
+      "urls": [
+        "https://energy.skedgo.com/satapp",
+        "https://andromeda.skedgo.com/satapp",
+        "https://matter.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "AU_NSW_Sydney",
+      "modes": [
+        "pt_pub",
+        "pt_ltd_SCHOOLBUS",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Australia/Sydney",
+      "cities": [
+        {
+          "lat": -33.86749,
+          "lng": 151.20699,
+          "identifier": "AU.NSW.Sydney",
+          "title": "Sydney, NSW, Australia",
+          "timezone": "Australia/Sydney",
+          "region": "AU_NSW_Sydney"
+        },
+        {
+          "lat": -34.41567,
+          "lng": 150.88072,
+          "identifier": "AU.NSW.Wollongong",
+          "title": "Wollongong, NSW, Australia",
+          "timezone": "Australia/Sydney",
+          "region": "AU_NSW_Sydney"
+        },
+        {
+          "lat": -32.92676,
+          "lng": 151.77358,
+          "identifier": "AU.NSW.Newcastle",
+          "title": "Newcastle, NSW, Australia",
+          "timezone": "Australia/Sydney",
+          "region": "AU_NSW_Sydney"
+        },
+        {
+          "lat": -33.31281,
+          "lng": 151.30804,
+          "identifier": "AU.NSW.Central-Coast",
+          "title": "Central Coast, NSW, Australia",
+          "timezone": "Australia/Sydney",
+          "region": "AU_NSW_Sydney"
+        }
+      ],
+      "polygon": "`e|pEggoq[?f``AaerM??mcjRnwyR??dbiP",
+      "urls": [
+        "https://darkages.skedgo.com/satapp",
+        "https://granduni.skedgo.com/satapp",
+        "https://energy.skedgo.com/satapp",
+        "https://hadron.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp",
+        "https://lepton.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "HU_Szeged",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Budapest",
+      "cities": [
+        {
+          "lat": 46.25463,
+          "lng": 20.1486,
+          "identifier": "HU.Szeged",
+          "title": "Szeged, Hungary",
+          "timezone": "Europe/Budapest",
+          "region": "HU_Szeged"
+        }
+      ],
+      "polygon": "md|xG_zbyBy`Y??_al@x`Y?",
+      "urls": [
+        "https://hadron.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "BR_SP_SaoPaulo",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/Sao_Paulo",
+      "cities": [
+        {
+          "lat": -23.55392,
+          "lng": -46.62735,
+          "identifier": "BR.SP.São-Paulo",
+          "title": "São Paulo, Brazil",
+          "timezone": "America/Sao_Paulo",
+          "region": "BR_SP_SaoPaulo"
+        }
+      ],
+      "polygon": "n||pCntq|G_o}@nwH_yF~cb@onT_db@oqPowH_|B_xq@nqP_|Bn}@obd@nnTozDnm_A~kaA~uJnnT",
+      "urls": [
+        "https://hadron.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "Estonia",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Tallinn",
+      "cities": [
+        {
+          "lat": 59.43722,
+          "lng": 24.74537,
+          "identifier": "EE.Tallin",
+          "title": "Tallin, Estonia",
+          "timezone": "Europe/Tallinn",
+          "region": "Estonia"
+        }
+      ],
+      "polygon": "gst|I{xpaCwouM??s{sj@vouM?",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_FL_Tampa",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "US/Eastern",
+      "cities": [
+        {
+          "lat": 27.965,
+          "lng": -82.458,
+          "identifier": "US.FL.Tampa",
+          "title": "Tampa, FL, USA",
+          "timezone": "US/Eastern",
+          "region": "US_FL_Tampa"
+        }
+      ],
+      "polygon": "_|dcD`l~xN_mpG??ag{C~lpG?",
+      "urls": [
+        "https://matter.skedgo.com/satapp",
+        "https://darkages.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "FI_MiddleFinland",
+      "modes": [
+        "in_air",
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Helsinki",
+      "cities": [
+        {
+          "lat": 61.499,
+          "lng": 23.762,
+          "identifier": "FI.Tampere",
+          "title": "Tampere, Finland",
+          "timezone": "Europe/Helsinki",
+          "region": "FI_MiddleFinland"
+        },
+        {
+          "lat": 60.45262,
+          "lng": 22.26139,
+          "identifier": "FI.Turku",
+          "title": "Turku, Finland",
+          "timezone": "Europe/Helsinki",
+          "region": "FI_MiddleFinland"
+        },
+        {
+          "lat": 62.24482,
+          "lng": 25.74709,
+          "identifier": "FI.Jyväskylä",
+          "title": "Jyväskylä, Finland",
+          "timezone": "Europe/Helsinki",
+          "region": "FI_MiddleFinland"
+        },
+        {
+          "lat": 61.4851,
+          "lng": 21.79743,
+          "identifier": "FI.Pori",
+          "title": "Pori, Finland",
+          "timezone": "Europe/Helsinki",
+          "region": "FI_MiddleFinland"
+        },
+        {
+          "lat": 63.09505,
+          "lng": 21.61719,
+          "identifier": "FI.Vaasa",
+          "title": "Vaasa, Finland",
+          "timezone": "Europe/Helsinki",
+          "region": "FI_MiddleFinland"
+        },
+        {
+          "lat": 61.68887,
+          "lng": 27.27285,
+          "identifier": "FI.Mikkeli",
+          "title": "Mikkeli, Finland",
+          "timezone": "Europe/Helsinki",
+          "region": "FI_MiddleFinland"
+        }
+      ],
+      "polygon": "_fopJoeiqBocmN_ycCopxD_dvO_pRo}zF~s`BocvBnwHohyCnu~A_~fD~`f@onqC~f^__yFnnT_o}@nzD_vdGnsw@_yF~`f@_g^nkX_laA~`f@~gpBne`@~iZokX~eiAnggA~efE_vJn{vAnyo@onT_pRn~rAnwHnjcAoxzA~bjEne`@~lVne`@~qy@~oR~xcC~_qA~bmA~lV~jlB~kaAoaoAnjcA~bmA_yFndkAnwHndkA~wq@nkX_yF~r_S",
+      "urls": [
+        "https://andromeda.skedgo.com/satapp",
+        "https://matter.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "CA_ON_ThunderBay",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/Thunder_Bay",
+      "cities": [
+        {
+          "lat": 48.392,
+          "lng": -89.249,
+          "identifier": "CA.ON.Thunder-Bay",
+          "title": "Thunder Bay, ON, Canada",
+          "timezone": "America/Thunder_Bay",
+          "region": "CA_ON_ThunderBay"
+        }
+      ],
+      "polygon": "osveH~xbbPop{@??oweCnp{@?",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://energy.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "AU_QLD_Southern",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Australia/Brisbane",
+      "cities": [
+        {
+          "lat": -27.47957,
+          "lng": 151.48633,
+          "identifier": "AU.QLD.Toowoomba",
+          "title": "Toowoomba, QLD, Australia",
+          "timezone": "Australia/Brisbane",
+          "region": "AU_QLD_Southern"
+        },
+        {
+          "lat": -28.02592,
+          "lng": 153.41091,
+          "identifier": "AU.QLD.Gold-Coast",
+          "title": "Gold Coast, QLD, Australia",
+          "timezone": "Australia/Brisbane",
+          "region": "AU_QLD_Southern"
+        },
+        {
+          "lat": -27.4651,
+          "lng": 153.0175,
+          "identifier": "AU.QLD.Brisbane",
+          "title": "Brisbane, QLD, Australia",
+          "timezone": "Australia/Brisbane",
+          "region": "AU_QLD_Southern"
+        },
+        {
+          "lat": -23.41726,
+          "lng": 150.29559,
+          "identifier": "AU.QLD.Rockhampton",
+          "title": "Rockhampton, QLD, Australia",
+          "timezone": "Australia/Brisbane",
+          "region": "AU_QLD_Southern"
+        },
+        {
+          "lat": -26.66372,
+          "lng": 153.10577,
+          "identifier": "AU.QLD.Sunshine-Coast",
+          "title": "Sunshine Coast, QLD, Australia",
+          "timezone": "Australia/Brisbane",
+          "region": "AU_QLD_Southern"
+        },
+        {
+          "lat": -25.29899,
+          "lng": 152.8339,
+          "identifier": "AU.QLD.Hervey-Bay",
+          "title": "Hervey Bay, QLD, Australia",
+          "timezone": "Australia/Brisbane",
+          "region": "AU_QLD_Southern"
+        },
+        {
+          "lat": -24.01541,
+          "lng": 151.3617,
+          "identifier": "AU.QLD.Gladstone",
+          "title": "Gladstone, QLD, Australia",
+          "timezone": "Australia/Brisbane",
+          "region": "AU_QLD_Southern"
+        },
+        {
+          "lat": -24.96775,
+          "lng": 151.99242,
+          "identifier": "AU.QLD.Bundaberg",
+          "title": "Bundaberg, QLD, Australia",
+          "timezone": "Australia/Brisbane",
+          "region": "AU_QLD_Southern"
+        }
+      ],
+      "polygon": "`x|pDamoh[aosh@_{KykhBmhuOprjAecdOdkpc@pbq@j[``A~TfNbUzTjIzEsCfCeF`PiBJcWr{@}`AzbDqT`w@zElTClEvEvj@bN|LldBfpAxS~T?tWfL|SfCvQpXfdAzb@v`@d_@nj@ju@rm@xSlq@|a@pd@fo@|i@xd@nU|Pa@heD`iGe]p~GvmLjnXz}E~|m@pFx}q@mgGb}b@hfm@nvoAjwqAhdPxtp@pxqBo|NvhpQ",
+      "urls": [
+        "https://darkages.skedgo.com/satapp",
+        "https://granduni.skedgo.com/satapp",
+        "https://energy.skedgo.com/satapp",
+        "https://hadron.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp",
+        "https://lepton.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "CA_ON_Toronto",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/Toronto",
+      "cities": [
+        {
+          "lat": 43.667,
+          "lng": -79.379,
+          "identifier": "CA.ON.Toronto",
+          "title": "Toronto, ON, Canada",
+          "timezone": "America/Toronto",
+          "region": "CA_ON_Toronto"
+        }
+      ],
+      "polygon": "_lrnG~d}jN?o~iM~ooC?fpz@fi|Dvud@ku[fn@s|Adb@uIry@lH`cB{N`rA~Thd@c_@vXqTfaB|V`aAzCnf@oNn_@m\\n_@wHh^{BfQcI`a@mBf_@jG~Svb@zb@t[nLvPhBtN`g@bdAxHeR`O{YpMwPnQyGrHiBnMk@vh@dUtAr~|H",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://energy.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "FR_N_Toulouse",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Paris",
+      "cities": [
+        {
+          "lat": 43.603,
+          "lng": 1.442,
+          "identifier": "FR.N.Toulouse",
+          "title": "Toulouse, France",
+          "timezone": "Europe/Paris",
+          "region": "FR_N_Toulouse"
+        }
+      ],
+      "polygon": "oo}gG_kiFodkA??_w|AndkA?",
+      "urls": [
+        "https://hadron.skedgo.com/satapp",
+        "https://recombination.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "JP_Toyama",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Asia/Tokyo",
+      "cities": [
+        {
+          "lat": 36.69904,
+          "lng": 137.21356,
+          "identifier": "JP.Toyama",
+          "title": "Toyama, Japan",
+          "timezone": "Asia/Tokyo",
+          "region": "JP_Toyama"
+        },
+        {
+          "lat": 36.74316,
+          "lng": 137.01387,
+          "identifier": "JP.Takaoka",
+          "title": "Takaoka, Japan",
+          "timezone": "Asia/Tokyo",
+          "region": "JP_Toyama"
+        }
+      ],
+      "polygon": "i`x`Fai`gYvlHcsOpwa@uxJb}a@nyCzi_@tmT`|E`pJeuEl|s@yqAx~TciCvfFzfMblLtwNnnMvyDfzGmo@~eBqgEc{@mnE|pCiv@d~Ehv@hhCuZnyCjhH~lEpa@b~EunVjeCwog@ytAkoTscA_v@e~Eo{KytAk{Q_mE_vIonM{u@_pU",
+      "urls": [
+        "https://darkages.skedgo.com/satapp",
+        "https://granduni.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "IT_Trentino",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Rome",
+      "cities": [
+        {
+          "lat": 46.0706,
+          "lng": 11.1196,
+          "identifier": "IT.Trento",
+          "title": "Trento, Italy",
+          "timezone": "Europe/Rome",
+          "region": "IT_Trentino"
+        }
+      ],
+      "polygon": "_{xuG_pb~@oe}C??oezGne}C?",
+      "urls": [
+        "https://matter.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "NO_NorthNorway",
+      "modes": [
+        "in_air",
+        "pt_pub",
+        "pt_ltd_SCHOOLBUS",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Oslo",
+      "cities": [
+        {
+          "lat": 69.64925,
+          "lng": 18.95558,
+          "identifier": "NO.Tromsø-",
+          "title": "Tromsø , Norway",
+          "timezone": "Europe/Oslo",
+          "region": "NO_NorthNorway"
+        }
+      ],
+      "polygon": "{yn|K{dtdBopnB`daUoavR{kkv@zizB}w|z@lxrGr|uD~eqBpiqKqtl@ftcAslkA{llBoqhAlaiG`h`@jooGdoiDfzcBdmkAb~}Dsu`@x}rNehsApihCtv]x~lElj_Ctwg@kf`@hsiJlfbBdomBk|YfdwB",
+      "urls": [
+        "https://energy.skedgo.com/satapp",
+        "https://andromeda.skedgo.com/satapp",
+        "https://matter.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "NO_MiddleNorway",
+      "modes": [
+        "in_air",
+        "pt_pub",
+        "pt_ltd_SCHOOLBUS",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Oslo",
+      "cities": [
+        {
+          "lat": 63.43658,
+          "lng": 10.39894,
+          "identifier": "NO.Trondheim",
+          "title": "Trondheim, Norway",
+          "timezone": "Europe/Oslo",
+          "region": "NO_MiddleNorway"
+        }
+      ],
+      "polygon": "ak_`L}ionAhjoBcxeUf`i@j_d@faOx}q@zmm@kmj@ll_@vbHx~gBthfDjo~@|vAndKd|{CbabDdoQngiCvxwDpdR{dxAnlw@y`Flyc@b`e@{rIzk`Db`zAhdqDfedGiuOqecDtqqc@",
+      "urls": [
+        "https://energy.skedgo.com/satapp",
+        "https://andromeda.skedgo.com/satapp",
+        "https://matter.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "IT_Torino",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Rome",
+      "cities": [
+        {
+          "lat": 45.072,
+          "lng": 7.689,
+          "identifier": "IT.Turin",
+          "title": "Turin, Italy",
+          "timezone": "Europe/Rome",
+          "region": "IT_Torino"
+        }
+      ],
+      "polygon": "}wwjG_trl@mwf@_zh@wuKhvIluFxdu@yfWpvdAu}WxeXebOsjDawQr_NqnRirVimJ~eBs}C_bOckOjoFukRltm@_jh@|vXarImcWvsAs{ZqrLywQ_uG_~[kaKnyCg}LivIsdLx~TuvUh}L?c}vH`~`J??jjfE",
+      "urls": [
+        "https://matter.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "AU_NSW_Northern",
+      "modes": [
+        "pt_pub",
+        "pt_ltd_SCHOOLBUS",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Australia/Sydney",
+      "cities": [
+        {
+          "lat": -28.34988,
+          "lng": 153.34657,
+          "identifier": "AU.NSW.Tweed-Heads",
+          "title": "Tweed Heads, NSW, Australia",
+          "timezone": "Australia/Sydney",
+          "region": "AU_NSW_Northern"
+        },
+        {
+          "lat": -30.29253,
+          "lng": 153.13288,
+          "identifier": "AU.NSW.Coffs-Harbour",
+          "title": "Coffs Harbour, NSW, Australia",
+          "timezone": "Australia/Sydney",
+          "region": "AU_NSW_Northern"
+        },
+        {
+          "lat": -31.43153,
+          "lng": 152.91016,
+          "identifier": "AU.NSW.Port-Macquarie",
+          "title": "Port Macquarie, NSW, Australia",
+          "timezone": "Australia/Sydney",
+          "region": "AU_NSW_Northern"
+        },
+        {
+          "lat": -28.64442,
+          "lng": 153.61292,
+          "identifier": "AU.NSW.Byron-Bay",
+          "title": "Byron Bay, NSW, Australia",
+          "timezone": "Australia/Sydney",
+          "region": "AU_NSW_Northern"
+        }
+      ],
+      "polygon": "puncEk_hg[eunRg`]gbEybpPgqEownCsfj@ikSw}_@rjDejZqh~@o}Tw~_@xpF_{KxsD_t_@eUmpc@wpFgjp@kuL_uYrh@q~GmpBakFkcCk}AooBeuCy~@ooA{l@_dCacAqz@iw@gr@eMkjAhoBuuGxBq@~FsRaq@ui@_^}dAxd@w|C|fkB}hRxwzLzbyAx`bF~j{A|sEln~Z",
+      "urls": [
+        "https://darkages.skedgo.com/satapp",
+        "https://granduni.skedgo.com/satapp",
+        "https://hadron.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "SE_Umea",
+      "modes": [
+        "pt_pub",
+        "pt_ltd_SCHOOLBUS",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Stockholm",
+      "cities": [
+        {
+          "lat": 63.82566,
+          "lng": 20.26307,
+          "identifier": "SE.Umea",
+          "title": "Umea, Sweden",
+          "timezone": "Europe/Stockholm",
+          "region": "SE_Umea"
+        }
+      ],
+      "polygon": "oadaK{`}gAgy~@ahd@osmAizxA{vYgwsAjpIyxlDcx|@ocW?ezxx@bgdG~puU?nrgn@",
+      "urls": [
+        "https://energy.skedgo.com/satapp",
+        "https://andromeda.skedgo.com/satapp",
+        "https://matter.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "ES_CV_Valencia",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Madrid",
+      "cities": [
+        {
+          "lat": 39.47001,
+          "lng": -0.32725,
+          "identifier": "ES.VC.Valencia",
+          "title": "Valencia, Spain",
+          "timezone": "Europe/Madrid",
+          "region": "ES_CV_Valencia"
+        }
+      ],
+      "polygon": "qzlnFxjgBuqoA??a`~@tqoA?",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://energy.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "CA_BC_Vancouver",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_car-s_MODO",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/Vancouver",
+      "cities": [
+        {
+          "lat": 49.28055,
+          "lng": -123.12253,
+          "identifier": "CA.BC.Vancouver",
+          "title": "Vancouver, BC, Canada",
+          "timezone": "America/Vancouver",
+          "region": "CA_BC_Vancouver"
+        }
+      ],
+      "polygon": "c_clIhh{dVzatb@o{aBevc@rptKkkrLvpf\\wosSj~hR",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://energy.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "CA_BC_Victoria",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_car-s_MODO",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/Vancouver",
+      "cities": [
+        {
+          "lat": 48.427,
+          "lng": -123.364,
+          "identifier": "CA.BC.Victoria",
+          "title": "Victoria, BC, Canada",
+          "timezone": "America/Vancouver",
+          "region": "CA_BC_Victoria"
+        }
+      ],
+      "polygon": "_ejeHd`roVkxi@vt`Hez`Lzd_W_thBm}nDlq~Dy~pNvwdD{vwHj~~Au~{B",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://energy.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "AT_W_Vienna",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Vienna",
+      "cities": [
+        {
+          "lat": 48.20806,
+          "lng": 16.37394,
+          "identifier": "AT.W.Vienna",
+          "title": "Vienna, Austria",
+          "timezone": "Europe/Vienna",
+          "region": "AT_W_Vienna"
+        }
+      ],
+      "polygon": "w_}cHo_}aB_d{@??_laA~c{@?",
+      "urls": [
+        "https://energy.skedgo.com/satapp",
+        "https://hadron.skedgo.com/satapp",
+        "https://baryogenesis.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_VA_VirginiaBeach",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/New_York",
+      "cities": [
+        {
+          "lat": 36.85298,
+          "lng": -75.97742,
+          "identifier": "US.VA.Virginia-Beach",
+          "title": "Virginia Beach, VA, US",
+          "timezone": "America/New_York",
+          "region": "US_VA_VirginiaBeach"
+        }
+      ],
+      "polygon": "_fv~EzytsM}|hC??o`_E||hC?",
+      "urls": [
+        "https://lepton.skedgo.com/satapp",
+        "https://stars.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "AU_ACT_Canberra",
+      "modes": [
+        "pt_pub",
+        "pt_ltd_SCHOOLBUS",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Australia/Sydney",
+      "cities": [
+        {
+          "lat": -35.19233,
+          "lng": 147.3543,
+          "identifier": "AU.NSW.Wagga-Wagga",
+          "title": "Wagga Wagga, NSW, Australia",
+          "timezone": "Australia/Sydney",
+          "region": "AU_ACT_Canberra"
+        },
+        {
+          "lat": -35.26016,
+          "lng": 149.13244,
+          "identifier": "AU.ACT.Canberra",
+          "title": "Canberra, ACT, Australia",
+          "timezone": "Australia/Sydney",
+          "region": "AU_ACT_Canberra"
+        }
+      ],
+      "polygon": "~pf{Eajgb[|Ef`]o{^z~[w|zHswg@tw@ygfOvuoDdPai@aocCnilMzebB_vvCfkcKyra@smTsrGblL}kGztAy~IpnBqtMngJu}K`{@oya@dwBsuWrmTu_Ll_d@||Jh`]u{Gh}LlrSt{Z",
+      "urls": [
+        "https://darkages.skedgo.com/satapp",
+        "https://granduni.skedgo.com/satapp",
+        "https://hadron.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "PL_Warsaw",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Warsaw",
+      "cities": [
+        {
+          "lat": 52.24663,
+          "lng": 21.0145,
+          "identifier": "PL.Warsaw",
+          "title": "Warsaw, Poland",
+          "timezone": "Europe/Warsaw",
+          "region": "PL_Warsaw"
+        }
+      ],
+      "polygon": "mt~bIsejcC`rmBeclIvlyDzsgHhozA~agEg~yEtwpHkijEe_aD",
+      "urls": [
+        "https://stars.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "US_DC_Washington",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/New_York",
+      "cities": [
+        {
+          "lat": 38.8976,
+          "lng": -77.0365,
+          "identifier": "US.DC.Washington",
+          "title": "Washington, DC, USA",
+          "timezone": "America/New_York",
+          "region": "US_DC_Washington"
+        },
+        {
+          "lat": 39.29112,
+          "lng": -76.61378,
+          "identifier": "US.DC.Baltimore",
+          "title": "Baltimore, MD, USA",
+          "timezone": "America/New_York",
+          "region": "US_DC_Washington"
+        }
+      ],
+      "polygon": "oq|iFnbyxMoalE??_buFnalE?",
+      "urls": [
+        "https://lepton.skedgo.com/satapp",
+        "https://matter.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "NZ_N_Wellington",
+      "modes": [
+        "pt_pub",
+        "pt_ltd_SCHOOLBUS",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "NZ",
+      "cities": [
+        {
+          "lat": -41.27845,
+          "lng": 174.7791,
+          "identifier": "NZ.N.Wellington",
+          "title": "Wellington, New Zealand",
+          "timezone": "NZ",
+          "region": "NZ_N_Wellington"
+        }
+      ],
+      "polygon": "~~auF_}dh`@?~_nE_nbJ??_m~^~ocS??~koX",
+      "urls": [
+        "https://granduni.skedgo.com/satapp",
+        "https://energy.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "CA_MB_Winnipeg",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "America/Winnipeg",
+      "cities": [
+        {
+          "lat": 49.916,
+          "lng": -97.13,
+          "identifier": "CA.MB.Winnipeg",
+          "title": "Winnipeg, MB, Canada",
+          "timezone": "America/Winnipeg",
+          "region": "CA_MB_Winnipeg"
+        }
+      ],
+      "polygon": "_`jnH~lnqQ_ry@??_t`B~qy@?",
+      "urls": [
+        "https://stars.skedgo.com/satapp",
+        "https://energy.skedgo.com/satapp"
+      ]
+    },
+    {
+      "name": "CH_Zurich",
+      "modes": [
+        "pt_pub",
+        "cy_bic",
+        "cy_bic-s",
+        "ps_tax",
+        "me_car",
+        "me_mot",
+        "wa_wal"
+      ],
+      "timezone": "Europe/Zurich",
+      "cities": [
+        {
+          "lat": 47.36856,
+          "lng": 8.54044,
+          "identifier": "CH.ZH.Zurich",
+          "title": "Zurich, Switzerland",
+          "timezone": "Europe/Zurich",
+          "region": "CH_Zurich"
+        }
+      ],
+      "polygon": "kpeaHwgcn@yQgbEapAssFoeD{pCgFo`G{Ae~EreCohDthBvg@`YkfDmtA}vAdc@maLsnAgkGpt@euCidBe}@im@gn@c`AowD{^cqDixCiqElMw}C~u@wg@y^{{Dj]azFvlCmThdBw}CdVmzH{x@ehB`f@umIwn@iqEkChhC_zBpaAgwA}_D}[kfDonAa]yQ}gAta@uyDlhCybH{gFzZezBedAnc@`iDqd@rlChhCp}BvQrsFva@fuC}iBlyCyx@`|E}oA`{@_`A}gAidAjnAw_BytAoeBa|EetAvXmtE{wF_LiqEq{@e|F{pB{KoWkp@`VsbGdw@uaB`pEia@}e@qpAi}DhCyNq_Bf{Ay}Cf{Aen@fqA?ir@ohD~qAy}Chw@cA|_AddDnq@dA|r@khC|mC`]~XihCjdA{{DuoBwv@ac@juDsbBhCqvC}hFn~FawM~{Ea{@vx@{yE}wD_xRzoAciMjw@ojFsFwgCpfA_~AsFoaDtlFg~h@v~Lk}OlkGolK|tBqnB~bCmlBip@k_A`vAaxAxQcoEvd@oc@~xA~vAbrDoc@rwAasChpBd_@n}@dwBdIfsDtuBvnC`|D|gAnjBfiEpnBpV?jydJwgs@?",
+      "urls": [
+        "https://recombination.skedgo.com/satapp",
+        "https://hadron.skedgo.com/satapp"
+      ]
+    }
+  ],
+  "hashCode": 1894445646
 }

--- a/Tests/TripKitTests/parsing/TKRegionManagerTest.swift
+++ b/Tests/TripKitTests/parsing/TKRegionManagerTest.swift
@@ -29,7 +29,7 @@ class TKRegionManagerTest: XCTestCase {
   
   func testParsing() {
     XCTAssert(TKRegionManager.shared.hasRegions)
-    XCTAssertEqual(TKRegionManager.shared.regions.count, 143)
+    XCTAssertEqual(TKRegionManager.shared.regions.count, 195)
   }
   
   func testSavingToCache() throws {
@@ -53,7 +53,7 @@ class TKRegionManagerTest: XCTestCase {
     let cachedResponse = try JSONDecoder().decode(TKAPI.RegionsResponse.self, from: regionData)
     TKRegionManager.shared.updateRegions(from: cachedResponse)
     XCTAssert(TKRegionManager.shared.hasRegions)
-    XCTAssertEqual(TKRegionManager.shared.regions.count, 143)
+    XCTAssertEqual(TKRegionManager.shared.regions.count, 195)
   }
   
   func testSortingModes() throws {


### PR DESCRIPTION
- No need to call local search with empty string
- Don't cancel and re-trigger search while map is in "following" mode
- Cancel requests when search aborted before search has completed, implemented by TKAppleGeocoder and TKTripGoGeocoder
- Fix retain cycle in TKUIAutocompletionVC