### PR TITLE
Fix `TKRealTimeHelper.streamRealTime` to also pass on previous updates, too

### DIFF
--- a/Sources/TripKitUI/helper/RxTripKit/TKRealTimeHelper.swift
+++ b/Sources/TripKitUI/helper/RxTripKit/TKRealTimeHelper.swift
@@ -14,7 +14,7 @@ import RxSwift
 
 public enum TKRealTimeHelper {
   
-  public static func streamRealTime(for trip: Trip, pause: Observable<Bool>) -> Observable<TKRealTimeUpdateProgress<Trip>> {
+  public static func streamRealTime(for trip: Trip, pause: Observable<Bool>) -> Observable<Trip> {
     guard trip.wantsRealTimeUpdates else { return .empty() }
     
     // LATER: It might be better to only advance the counter once the inner observable has finished. Currently it's up to the builder to not hit the server too frequently.
@@ -22,15 +22,29 @@ public enum TKRealTimeHelper {
     let counterAdvanced = Observable<Int>.interval(.seconds(1), scheduler: MainScheduler.instance)
     
     return Observable.combineLatest(counterAdvanced, pause.startWith(false)) { (counter: $0, pause: $1) }
-      .filter { TKUITripModeByModeCard.config.builder.shouldUpdate(trip: trip, counter: $0.counter) && !$0.pause }
-      .flatMapLatest { _ -> Observable<TKRealTimeUpdateProgress<Trip>> in
-        let previousURLString = trip.updateURLString
-        return TKRealTimeFetcher.rx.update(trip)
-          .map { ($1 && $0.updateURLString == previousURLString) ? .idle : .updated($0) }
-          .asObservable()
-          .startWith(.updating)
+      .filter {
+        TKUITripModeByModeCard.config.builder.shouldUpdate(trip: trip, counter: $0.counter) && !$0.pause
       }
-      .startWith(.idle)
+      .flatMapLatest { _ -> Observable<(Trip, String?)> in
+        // `trip` will generally stay the same as it's updated in-place, but we
+        // pass back the update URL as that will change between updates if
+        // the trip itself changed.
+        return TKRealTimeFetcher.rx.update(trip)
+          .map { trip, _ in (trip, trip.updateURLString) }
+          .asObservable()
+          .catch { _ in .empty() } // Can happen if Internet collection dropped briefly
+      }
+      .distinctUntilChanged {
+        // We compare the update URLs between each time we fire rather than
+        // just using the `didUpdate`. This is to catch cases where the trip
+        // was updated in the mean time by some other method (e.g., bookings)
+        // but whoever is consuming this stream wouldn't be aware of that, but
+        // still wants to be informed if the trip has changed since the last
+        // time this fired. (EVEN IF the `rx.update` didn't actually update
+        // the trip as the object was already updated!)
+        return $0.1 != nil && $0.1 == $1.1
+      }
+      .map(\.0)
   }
   
 }

--- a/Sources/TripKitUI/view model/TKUITripModeByModeViewModel.swift
+++ b/Sources/TripKitUI/view model/TKUITripModeByModeViewModel.swift
@@ -20,8 +20,7 @@ class TKUITripModeByModeViewModel {
     
     self.realTimeUpdate = TKUITripModeByModeViewModel
       .fetchRealTime(for: trip)
-      .do(onNext: { update in
-        guard case .updated(let trip) = update else { return }
+      .do(onNext: { trip in
         NotificationCenter.default.post(name: .TKUIUpdatedRealTimeData, object: trip)
         
         // Segment changed, too
@@ -29,13 +28,17 @@ class TKUITripModeByModeViewModel {
           .map { Notification(name: .TKUIUpdatedRealTimeData, object: $0) }
           .forEach(NotificationCenter.default.post)
       })
+      .map { trip in
+        .updated(trip)
+      }
+      .startWith(.idle)
   }
   
   let trip: Trip
   
   let realTimeUpdate: Driver<TKRealTimeUpdateProgress<Trip>>
   
-  private static func fetchRealTime(for trip: Trip) -> Driver<TKRealTimeUpdateProgress<Trip>> {
+  private static func fetchRealTime(for trip: Trip) -> Driver<Trip> {
     return TKRealTimeHelper.streamRealTime(for: trip, pause: .just(false))
       .asDriver(onErrorDriveWith: .empty())
   }


### PR DESCRIPTION
Previously, this would not fire with `.updated` if the trip got updated via someone else updating the trip in between.