### PR TITLE
Simplify TKGeoMonitorManager by using geofences from API

### DIFF
--- a/Sources/TripKit/managers/TKGeoMonitorManager.swift
+++ b/Sources/TripKit/managers/TKGeoMonitorManager.swift
@@ -14,22 +14,6 @@ import UserNotifications
 
 public class TKGeoMonitorManager: NSObject {
   
-  enum RegionIdentifier: String {
-    /// the starting stop of the trip
-    case start
-    /// is a stop that is in between start and end of the trip
-    case regular
-    /// the final stop of the trip
-    case end
-    /// 500m to final stop
-    case nearEnd
-  }
-  
-  private enum Constants {
-    static let regularRadius: CLLocationDistance = 2_000
-    static let endRadius: CLLocationDistance = 500
-  }
-  
   private enum Keys {
     static let alertsEnabled = "GODefaultGetOffAlertsEnabled"
   }
@@ -37,9 +21,25 @@ public class TKGeoMonitorManager: NSObject {
   @objc(sharedInstance)
   public static let shared = TKGeoMonitorManager()
   
-  private var geoMonitor: GeoMonitor?
+  private lazy var geoMonitor: GeoMonitor = {
+    return .init(enabledKey: Keys.alertsEnabled) { [weak self] _ in
+      guard let self else { return [] }
+      return self.geofences.map(\.1)
+    } onEvent: { [weak self] event in
+      guard let self else { return }
+      switch event {
+      case .entered(let region, _):
+        guard let match = self.geofences.first(where: { $0.1.identifier == region.identifier })?.0 else { return }
+        self.notify(with: match)
+      case .manual(let region, let location):
+        break
+      case .status(let message, let status):
+        break
+      }
+    }
+  }()
   
-  var regions: [CLCircularRegion] = []
+  var geofences: [(TKAPI.Geofence, CLCircularRegion)] = []
   
   override init() {
     super.init()
@@ -103,171 +103,50 @@ public class TKGeoMonitorManager: NSObject {
   public func monitorRegions(from trip: Trip) {
     // Since only one trip can have notifications at a time, there is no need to save other trips, just need to replace the current one.
     
-    // FIXME: This should use `trip.segment.flatMap(\.geofences)` instead.
-    
-    var nearEndCoordinate: CLLocationCoordinate2D?
-    var regions: [CLCircularRegion] = trip.segments.compactMap { segment in
-      guard let coordinate = segment.start?.coordinate
-      else {
-        return nil
-      }
-      
-      let region: CLCircularRegion =
-        .init(center: coordinate,
-                     radius: Constants.regularRadius,
-                     identifier: segment.order.identifier.rawValue)
-      
-      if segment.order == .end {
-        nearEndCoordinate = coordinate
-      }
-      
-      return region
+    let geofences = trip.segments.flatMap(\.geofences)
+    guard !geofences.isEmpty else {
+      return stopMonitoring()
     }
     
-    if let coordinate = nearEndCoordinate {
-      // Add another circular region at the final stop for 500m radius detection
-      let region: CLCircularRegion =
-        .init(center: coordinate,
-              radius: Constants.endRadius,
-              identifier: RegionIdentifier.nearEnd.rawValue)
-      regions.append(region)
+    self.geofences = geofences.map { geofence -> (TKAPI.Geofence, CLCircularRegion) in
+      switch geofence.kind {
+      case let .circle(center, radius):
+        let region = CLCircularRegion(center: center, radius: radius, identifier: geofence.id)
+        return (geofence, region)
+      }
     }
     
-    monitor(regions: regions)
-  }
-  
-  private func monitor(regions: [CLCircularRegion]) {
-    guard let monitor = geoMonitor
-    else {
-      geoMonitor = .init(enabledKey: Keys.alertsEnabled) { trigger in
-        switch trigger {
-        case .manual:
-          break
-        case .initial:
-          break
-        case .visitMonitoring:
-          break
-        case .regionMonitoring:
-          break
-        case .departedCurrentArea:
-          break
-        }
-        
-        return regions
-      } onEvent: { event in
-        switch event {
-        case .entered(let region, let location):
-          guard let identifier = RegionIdentifier(rawValue: region.identifier)
-          else {
-            return
-          }
-          self.notify(with: identifier)
-          break
-        case .manual(let region, let location):
-          break
-        case .status(let message, let status):
-          break
-        }
-      }
-      
-      startMonitoring()
-      
-      return
-    }
+    startMonitoring()
     
     Task {
-      await monitor.scheduleUpdate(regions: regions)
-      
       startMonitoring()
+      await geoMonitor.update(regions: self.geofences.map(\.1))
     }
   }
   
   private func startMonitoring() {
-    guard let monitor = geoMonitor
-    else {
-      return
-    }
-    monitor.enableInBackground = true
-    monitor.startMonitoring()
+    geoMonitor.enableInBackground = true
+    geoMonitor.startMonitoring()
   }
   
   private func stopMonitoring() {
-    guard let monitor = geoMonitor
-    else {
-      return
-    }
-    monitor.enableInBackground = false
-    monitor.stopMonitoring()
+    geoMonitor.enableInBackground = false
+    geoMonitor.stopMonitoring()
   }
-  
-  func notify(with regionIdentifier: RegionIdentifier) {
-    let request = buildNotificationRequest(from: regionIdentifier)
+
+  func notify(with geofence: TKAPI.Geofence) {
+    let notification = UNMutableNotificationContent()
+    notification.title = geofence.messageTitle
+    notification.body = geofence.messageBody
+    notification.sound = .default
+    
+    let request = UNNotificationRequest(
+      identifier: geofence.id,
+      content: notification,
+      trigger: nil // Fire right away
+    )
+    
     // TODO: Send out this notification request to TripGo (This is in TripKit)
   }
   
-  func buildNotificationRequest(from regionIdentifier: RegionIdentifier) -> UNNotificationRequest {
-    let content: UNNotificationContent
-    switch regionIdentifier {
-    case .start: content = Notifications.tripAboutToStart
-    case .regular: content = Notifications.tripPassedStop
-    case .end: content = Notifications.tripAtFinalStop
-    case .nearEnd: content = Notifications.tripNearFinalStop
-    }
-    
-    return .init(identifier: Notifications.identifier,
-                 content: content,
-                 trigger: Notifications.trigger)
-  }
-  
-}
-
-public extension TKGeoMonitorManager {
-  
-  enum Notifications {
-    static let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 3, repeats: false)
-    static let identifier = "GetOffAlertsNotification"
-    
-    static let tripAboutToStart: UNMutableNotificationContent = {
-      let notification = UNMutableNotificationContent()
-      notification.title = Loc.TripAboutToStart()
-      notification.body = Loc.LeavingOn(location: "Over There Station", time: "4:00 PM")
-      notification.sound = .default
-      return notification
-    }()
-    
-    static let tripNearFinalStop: UNMutableNotificationContent = {
-      let notification = UNMutableNotificationContent()
-      notification.title = Loc.AlmostThere()
-      notification.body = Loc.GettingNearDisembarkationPoint()
-      notification.sound = .default
-      return notification
-    }()
-    
-    static let tripPassedStop: UNMutableNotificationContent = {
-      let notification = UNMutableNotificationContent()
-      notification.title = Loc.Leaving("The Mid Station")
-      notification.body = Loc.Next("The Final Station")
-      notification.sound = .default
-      return notification
-    }()
-    
-    static let tripAtFinalStop: UNMutableNotificationContent = {
-      let notification = UNMutableNotificationContent()
-      notification.title = Loc.ArrivingAtYourStop()
-      notification.body = Loc.PrepareToDisembarkAt("The Final Station")
-      notification.sound = .default
-      return notification
-    }()
-  }
-  
-}
-
-fileprivate extension TKSegmentOrdering {
-  var identifier: TKGeoMonitorManager.RegionIdentifier {
-    switch self {
-    case .start: return .start
-    case .regular: return .regular
-    case .end: return .end
-    }
-  }
 }


### PR DESCRIPTION
We can simplify `TKGeoMonitorManager` by using the geofences and messages as provided by the backend. That simplifies the manager quite a bit. Please review.