### PR TITLE
Example for how to add a stop over to trip by long-tapping the map

### DIFF
--- a/Sources/TripKit/vendor/ASPolygonKit/Polygon.swift
+++ b/Sources/TripKit/vendor/ASPolygonKit/Polygon.swift
@@ -429,11 +429,13 @@ struct Polygon {
       
       if points.count - 2 >= 0 {
         let lastLast = points[points.count - 2]
-        let spanner = Line(start: lastLast, end: point)
-        let next = Line(start: last, end: point)
-        if (abs(spanner.m) > 1_000_000 && abs(next.m) > 1_000_000) // takes care of both being Infinity
-          || abs(spanner.m - next.m) < 0.0001 {
-          points.removeLast() // 3)
+        if point != lastLast {
+          let spanner = Line(start: lastLast, end: point)
+          let next = Line(start: last, end: point)
+          if (abs(spanner.m) > 1_000_000 && abs(next.m) > 1_000_000) // takes care of both being Infinity
+              || abs(spanner.m - next.m) < 0.0001 {
+            points.removeLast() // 3)
+          }
         }
       }
     }

--- a/Sources/TripKitUI/cards/TKUITripMapManager.swift
+++ b/Sources/TripKitUI/cards/TKUITripMapManager.swift
@@ -69,7 +69,8 @@ public class TKUITripMapManager: TKUIMapManager, TKUITripMapManagerType {
     mapView.addGestureRecognizer(dropPinRecognizer)
     dropPinRecognizer.rx.event
       .filter { $0.state == .began }
-      .map { [unowned mapView] in
+      .compactMap { [unowned mapView] in
+        guard TKUITripOverviewCard.config.enableDropToAddStopover else { return nil }
         let point = $0.location(in: mapView)
         return mapView.convert(point, toCoordinateFrom: mapView)
       }

--- a/Sources/TripKitUI/cards/TKUITripOverviewCard+Configuration.swift
+++ b/Sources/TripKitUI/cards/TKUITripOverviewCard+Configuration.swift
@@ -87,5 +87,14 @@ public extension TKUITripOverviewCard {
     
     /// Set this to limit how many alerts are shown for a segment
     public var maximumAlertsPerSegment: Int = 3
+    
+    // MARK: - Example features
+    
+    /// Enables long-tap gesture on the map which will then add a stopover and push a new
+    /// card.
+    ///
+    /// - warning: The UX isn't refined for this, so this is meant as a demo more than a
+    /// feature to add to production apps.
+    public var enableDropToAddStopover: Bool = false
   }
 }

--- a/Sources/TripKitUI/cards/TKUITripOverviewCard.swift
+++ b/Sources/TripKitUI/cards/TKUITripOverviewCard.swift
@@ -135,6 +135,7 @@ public class TKUITripOverviewCard: TKUITableCard {
       inputs: TKUITripOverviewViewModel.UIInput(
         selected: mergedSelection,
         alertsEnabled: notificationFooterView.notificationSwitch.rx.value.asSignal(onErrorSignalWith: .empty()),
+        droppedPin: tripMapManager?.droppedPin ?? .empty(),
         isVisible: isVisible.asDriver(onErrorJustReturn: true)
       )
     )
@@ -372,6 +373,10 @@ extension TKUITripOverviewCard {
     case .showAlternativeRoutes(let request):
       let card = TKUIRoutingResultsCard(request: request)
       card.onSelection = selectedAlternativeTripCallback
+      controller?.push(card)
+
+    case .showAlternative(let trip):
+      let card = TKUITripOverviewCard(trip: trip)
       controller?.push(card)
     }
   }


### PR DESCRIPTION
Also adds `TKWaypointRouter.fetchTrip(addingStopOver:to:)`

(Not yet to be merged, should be opt-in for TKUITripOverviewCard and indicate progress)