### PR TITLE
Reviewed style of the mode-by-mode map

### DIFF
--- a/Sources/TripKit/helpers/TKRegionOverlayHelper.swift
+++ b/Sources/TripKit/helpers/TKRegionOverlayHelper.swift
@@ -215,7 +215,7 @@ extension TKRegionOverlayHelper {
                 [$0.longitude, $0.latitude]
               }
             ]
-          ]
+          ] as [String : Any]
         ]
       }
       let geojson: [String: Any] = [

--- a/Sources/TripKit/model/CoreData/Shape+CoreDataClass.swift
+++ b/Sources/TripKit/model/CoreData/Shape+CoreDataClass.swift
@@ -202,8 +202,8 @@ extension Shape: TKDisplayableRoute {
   
   public var selectionIdentifier: String? {
     if let segment = segment?.originalSegmentIncludingContinuation() {
-      // Should match the definition in TripKitUI => TKUIAnnotations+TripKit
       
+      // Should match the definition in TripKitUI => TKUIAnnotations+TripKit
       switch segment.order {
       case .start: return "start"
       case .regular: return String(segment.templateHashCode)

--- a/Sources/TripKit/model/TKSegment.swift
+++ b/Sources/TripKit/model/TKSegment.swift
@@ -61,6 +61,7 @@ public class TKSegment: NSObject {
     self.start = location
     self.end = location
     self.reference = nil
+    self.templateHashCode = 0
     
     super.init()
   }
@@ -76,6 +77,7 @@ public class TKSegment: NSObject {
     assert(template?.end != nil, "Template is missing end: \(String(describing: template))")
     self.start = template?.start
     self.end = template?.end
+    self.templateHashCode = template?.hashCode?.intValue ?? 0
     
     super.init()
   }
@@ -143,7 +145,7 @@ public class TKSegment: NSObject {
   
   public lazy var notifications: [TKAPI.TripNotification] = template?.notifications ?? []
   
-  public var templateHashCode: Int { template?.hashCode?.intValue ?? 0 }
+  public var templateHashCode: Int
   
   public var color: TKColor {
     if let color = service?.color {
@@ -486,6 +488,7 @@ extension TKSegment {
     return segment.arrivalTime.timeIntervalSince(departureTime)
   }
   
+  /// - Returns: The next segment after the current one that is not a continuation; if there's no segment after returns `self`
   @objc
   public func finalSegmentIncludingContinuation() -> TKSegment {
     var segment: TKSegment? = self
@@ -497,6 +500,7 @@ extension TKSegment {
     return segment ?? self
   }
   
+  /// - Returns: The segment before the current one that is not a continuation; if there's no segment before returns `self`
   @objc
   public func originalSegmentIncludingContinuation() -> TKSegment {
     var segment: TKSegment? = self

--- a/Sources/TripKit/vendor/ASPolygonKit/Polygon+GeoJSON.swift
+++ b/Sources/TripKit/vendor/ASPolygonKit/Polygon+GeoJSON.swift
@@ -88,7 +88,7 @@ extension Polygon.UnionStep {
               yours.geoJSON,
               start.geoJSON
             ]
-          ]
+          ] as [String : Any]
         ]]
       }
       
@@ -101,7 +101,7 @@ extension Polygon.UnionStep {
         "geometry": [
           "type": "LineString",
           "coordinates": points.map { [$0.x, $0.y] }
-        ]
+        ] as [String : Any]
       ]]
 
     case let .extendMine(points):
@@ -113,7 +113,7 @@ extension Polygon.UnionStep {
         "geometry": [
           "type": "LineString",
           "coordinates": points.map { [$0.x, $0.y] }
-        ]
+        ] as [String : Any]
       ]]
       
     case let .intersect(intersection, onMine):

--- a/Sources/TripKit/vendor/ASPolygonKit/Polygon.swift
+++ b/Sources/TripKit/vendor/ASPolygonKit/Polygon.swift
@@ -429,11 +429,13 @@ struct Polygon {
       
       if points.count - 2 >= 0 {
         let lastLast = points[points.count - 2]
-        let spanner = Line(start: lastLast, end: point)
-        let next = Line(start: last, end: point)
-        if (abs(spanner.m) > 1_000_000 && abs(next.m) > 1_000_000) // takes care of both being Infinity
-          || abs(spanner.m - next.m) < 0.0001 {
-          points.removeLast() // 3)
+        if point != lastLast {
+          let spanner = Line(start: lastLast, end: point)
+          let next = Line(start: last, end: point)
+          if (abs(spanner.m) > 1_000_000 && abs(next.m) > 1_000_000) // takes care of both being Infinity
+              || abs(spanner.m - next.m) < 0.0001 {
+            points.removeLast() // 3)
+          }
         }
       }
     }

--- a/Sources/TripKitUI/cards/TKUIMapManager+Tiles.swift
+++ b/Sources/TripKitUI/cards/TKUIMapManager+Tiles.swift
@@ -90,9 +90,15 @@ extension TKUIMapManager {
       mapView.pointOfInterestFilter = MKPointOfInterestFilter(excluding: [.publicTransport])
     }
     
+    cleanUpAttributionView(from: mapView)
+  }
+  
+  func cleanUpAttributionView(from mapView: MKMapView) {
     mapView.subviews
       .compactMap { subview -> UIView? in
-        if let visual = subview as? UIVisualEffectView, visual.contentView.subviews.contains(where: { $0 is TKUIAttributionView }) {
+        if subview is TKUIAttributionView {
+          return subview
+        } else if let visual = subview as? UIVisualEffectView, visual.contentView.subviews.contains(where: { $0 is TKUIAttributionView }) {
           return visual
         } else {
           return nil

--- a/Sources/TripKitUI/cards/TKUIServiceMapManager.swift
+++ b/Sources/TripKitUI/cards/TKUIServiceMapManager.swift
@@ -41,9 +41,7 @@ class TKUIServiceMapManager: TKUIMapManager {
       .disposed(by: disposeBag)
     
     viewModel.selectAnnotation
-      .drive(onNext: { [weak self] in
-        self?.mapView?.selectAnnotation($0, animated: true)
-      })
+      .drive(onNext: { [weak self] in self?.select($0) })
       .disposed(by: disposeBag)
 
     viewModel.realTimeUpdate
@@ -69,16 +67,17 @@ class TKUIServiceMapManager: TKUIMapManager {
     (embarkation as? TKUIServiceViewModel.ServiceEmbarkation)?.triggerRealTimeKVO()
     (disembarkation as? TKUIServiceViewModel.ServiceEmbarkation)?.triggerRealTimeKVO()
   }
+  
+  private func select(_ annotation: TKUIIdentifiableAnnotation) {
+    guard
+      let mapView,
+      let match = mapView.annotations.first(where: { ($0 as? TKUIIdentifiableAnnotation)?.identity == annotation.identity })
+    else { return }
 
-  override func annotationBuilder(for annotation: MKAnnotation, in mapView: MKMapView) -> TKUIAnnotationViewBuilder {
-    let builder = super.annotationBuilder(for: annotation, in: mapView)
-    if let visitable = annotation as? TKUIServiceMapContentVisited {
-      builder.circleColor(visitable.color)
-      builder.drawCircleAsTravelled(visitable.isVisited)
-      builder.drawImageAnnotationAsCircle(true)
-    }
-    return builder
+    self.zoom(to: [match], animated: false) // Not animated, so that we can select
+    self.mapView?.selectAnnotation(match, animated: true)
   }
+
 }
 
 // MARK: - Adding the service

--- a/Sources/TripKitUI/cards/TKUITripMapManager.swift
+++ b/Sources/TripKitUI/cards/TKUITripMapManager.swift
@@ -73,15 +73,6 @@ public class TKUITripMapManager: TKUIMapManager, TKUITripMapManagerType {
     super.mapView(mapView, didAdd: views)
   }
   
-  override public func annotationBuilder(for annotation: MKAnnotation, in mapView: MKMapView) -> TKUIAnnotationViewBuilder {
-    let builder = super.annotationBuilder(for: annotation, in: mapView)
-    if let visit = annotation as? StopVisits {
-      let isVisited = trip.uses(visit)
-      builder.drawCircleAsTravelled(isVisited)
-    }
-    return builder
-  }
-  
   public func showTrip(animated: Bool) {
     deselectSegment(animated: animated)
     zoom(to: annotationsToZoomToOnTakingCharge, animated: animated)
@@ -98,8 +89,6 @@ public class TKUITripMapManager: TKUIMapManager, TKUITripMapManagerType {
     
     let annos = segment.annotationsToZoomToOnMap(mode: mode)
     zoom(to: annos, animated: animated)
-    
-    mapView?.selectAnnotation(segment, animated: animated)
   }
   
   public func refresh(with trip: Trip) {
@@ -128,10 +117,8 @@ private extension TKUITripMapManager {
     for segment in trip.segments {
       annotations.append(contentsOf: TKUIMapManagerHelper.additionalMapAnnotations(for: segment))
       
-      // semaphore
-      if segment.hasVisibility(.onMap), segment.coordinate.isValid {
-        annotations.append(segment)
-      }
+      // start/end annotations for the segment itself
+      annotations.append(contentsOf: TKUIMapManagerHelper.annotations(for: segment))
       
       // shapes (+ visits)
       if let toAdd = TKUIMapManagerHelper.shapeAnnotations(for: segment) {

--- a/Sources/TripKitUI/cards/TKUITripModeByModeCard.swift
+++ b/Sources/TripKitUI/cards/TKUITripModeByModeCard.swift
@@ -367,6 +367,10 @@ extension TKUITripModeByModeCard {
       // Update ETA in header
       headerETALabel?.text = TKUITripModeByModeCard.headerTimeText(for: trip)
       
+      // Important to update the map, too, as template hash codes can change
+      // an the map uses those for selection handling
+      (mapManager as? TKUITripMapManager)?.refresh(with: trip)
+      
     } else {
       // We use the index here as the identifier would have changed. The index
       // gives us a good guess for finding the corresponding segment in the new

--- a/Sources/TripKitUI/cards/TKUITripOverviewCard.swift
+++ b/Sources/TripKitUI/cards/TKUITripOverviewCard.swift
@@ -145,6 +145,8 @@ public class TKUITripOverviewCard: TKUITableCard {
     
     viewModel.refreshMap
       .emit(onNext: { [weak tripMapManager] trip in
+        // Important to update the map, too, as template hash codes can change
+        // an the map uses those for selection handling
         tripMapManager?.refresh(with: trip)
       })
       .disposed(by: disposeBag)

--- a/Sources/TripKitUI/helper/Categories/UIImageView+AsAccessoryImage.swift
+++ b/Sources/TripKitUI/helper/Categories/UIImageView+AsAccessoryImage.swift
@@ -14,29 +14,39 @@ extension UIImageView {
   convenience init(asRealTimeAccessoryImageAnimated animated: Bool, tintColor: UIColor? = nil) {
     self.init()
     
-    let images = UIImageView.realTimeAccessoryImage(animated)
-    if animated {
-      self.image = images.last
+    let images = UIImageView.realTimeAccessoryImage(animated, tintColor: tintColor)
+    if images.count > 1, let last = images.last {
+      self.image = last
       self.animationImages = images
       self.animationDuration = 1
-      self.animationRepeatCount = 2
+      self.animationRepeatCount = 3
+      self.contentMode = .scaleAspectFit
       self.startAnimating()
       
     } else {
       self.image = images.first
-    }
-    self.accessibilityLabel = Loc.RealTime
-    if let tintColor {
       self.tintColor = tintColor
     }
+    self.accessibilityLabel = Loc.RealTime
   }
   
-  private static func realTimeAccessoryImage(_ animated: Bool) -> [UIImage] {
+  private static func realTimeAccessoryImage(_ animated: Bool, tintColor: UIColor?) -> [UIImage] {
     if #available(iOS 16.0, *), animated {
-      let image1 = UIImage(systemName: "dot.radiowaves.forward", variableValue: 0.3)
-      let image2 = UIImage(systemName: "dot.radiowaves.forward", variableValue: 0.7)
-      let image3 = UIImage(systemName: "dot.radiowaves.forward", variableValue: 1.0)
-      return [image1, image2, image3, image3, image3, image3, image3, image3].compactMap { $0 }
+      if let tintColor {
+        let config = UIImage.SymbolConfiguration(hierarchicalColor: tintColor)
+        let image1 = UIImage(systemName: "dot.radiowaves.forward", variableValue: 0.3)
+        let image2 = UIImage(systemName: "dot.radiowaves.forward", variableValue: 0.7)
+        let image3 = UIImage(systemName: "dot.radiowaves.forward", variableValue: 1.0)
+        return [image1, image2, image3, image3, image3, image3, image3, image3]
+          .compactMap { $0?.applyingSymbolConfiguration(config)?.pngData() }
+          .compactMap { UIImage(data: $0) }
+
+      } else {
+        let image1 = UIImage(systemName: "dot.radiowaves.forward", variableValue: 0.3)
+        let image2 = UIImage(systemName: "dot.radiowaves.forward", variableValue: 0.7)
+        let image3 = UIImage(systemName: "dot.radiowaves.forward", variableValue: 1.0)
+        return [image1, image2, image3, image3, image3, image3, image3, image3].compactMap { $0 }
+      }
       
     } else if #available(iOS 14.0, *) {
       // Right-pointing, all bars

--- a/Sources/TripKitUI/helper/Categories/UIImageView+AsAccessoryImage.swift
+++ b/Sources/TripKitUI/helper/Categories/UIImageView+AsAccessoryImage.swift
@@ -32,20 +32,23 @@ extension UIImageView {
   
   private static func realTimeAccessoryImage(_ animated: Bool, tintColor: UIColor?) -> [UIImage] {
     if #available(iOS 16.0, *), animated {
+     let name = "dot.radiowaves.forward"
+     let image1 = UIImage(systemName: name, variableValue: 0.3)
+     let image2 = UIImage(systemName: name, variableValue: 0.7)
+     let image3 = UIImage(systemName: name, variableValue: 1.0)
+        
+     let images = [image1, image2, image3, image3, image3, image3, image3, image3]
+        
       if let tintColor {
         let config = UIImage.SymbolConfiguration(hierarchicalColor: tintColor)
-        let image1 = UIImage(systemName: "dot.radiowaves.forward", variableValue: 0.3)
-        let image2 = UIImage(systemName: "dot.radiowaves.forward", variableValue: 0.7)
-        let image3 = UIImage(systemName: "dot.radiowaves.forward", variableValue: 1.0)
-        return [image1, image2, image3, image3, image3, image3, image3, image3]
+       
+        return images
           .compactMap { $0?.applyingSymbolConfiguration(config)?.pngData() }
           .compactMap { UIImage(data: $0) }
 
       } else {
-        let image1 = UIImage(systemName: "dot.radiowaves.forward", variableValue: 0.3)
-        let image2 = UIImage(systemName: "dot.radiowaves.forward", variableValue: 0.7)
-        let image3 = UIImage(systemName: "dot.radiowaves.forward", variableValue: 1.0)
-        return [image1, image2, image3, image3, image3, image3, image3, image3].compactMap { $0 }
+        return images
+           .compactMap { $0 }
       }
       
     } else if #available(iOS 14.0, *) {

--- a/Sources/TripKitUI/helper/RxTripKit/TKRealTimeHelper.swift
+++ b/Sources/TripKitUI/helper/RxTripKit/TKRealTimeHelper.swift
@@ -32,7 +32,7 @@ public enum TKRealTimeHelper {
         return TKRealTimeFetcher.rx.update(trip)
           .map { trip, _ in (trip, trip.updateURLString) }
           .asObservable()
-          .catch { _ in .empty() } // Can happen if Internet collection dropped briefly
+          .catchAndReturn((trip, trip.updateURLString))
       }
       .distinctUntilChanged {
         // We compare the update URLs between each time we fire rather than

--- a/Sources/TripKitUI/view model/TKUIServiceViewModel.swift
+++ b/Sources/TripKitUI/view model/TKUIServiceViewModel.swift
@@ -79,7 +79,7 @@ class TKUIServiceViewModel {
   let mapContent: Driver<MapContent?>
   
   /// Annotation matching the user's selection in the list.
-  let selectAnnotation: Driver<MKAnnotation>
+  let selectAnnotation: Driver<TKUIIdentifiableAnnotation>
   
   /// Status of real-time update
   ///

--- a/Sources/TripKitUI/views/TKUIPolylineRenderer.swift
+++ b/Sources/TripKitUI/views/TKUIPolylineRenderer.swift
@@ -25,7 +25,8 @@ open class TKUIPolylineRenderer: MKPolylineRenderer {
       defaultBorderColor: nil,
       selectedColor: TKStyleManager.globalTintColor(),
       selectedBorderColor: TKStyleManager.globalTintColor().darker(by: 0.5),
-      deselectedColor: .tkLabelSecondary
+      deselectedColor: .tkLabelSecondary,
+      deselectedBorderColor: .tkLabelSecondary
     )
     
     var defaultColor: UIColor?
@@ -33,6 +34,7 @@ open class TKUIPolylineRenderer: MKPolylineRenderer {
     var selectedColor: UIColor
     var selectedBorderColor: UIColor
     var deselectedColor: UIColor
+    var deselectedBorderColor: UIColor
   }
   
   /// Whether there should be a background behind dashes
@@ -159,7 +161,7 @@ open class TKUIPolylineRenderer: MKPolylineRenderer {
 
       } else {
         strokeColor = selectionStyle.deselectedColor
-        borderColor = selectionStyle.deselectedColor
+        borderColor = selectionStyle.deselectedBorderColor
         alpha = 0.3
         lineWidth = 12
       }

--- a/Sources/TripKitUI/views/map annotations/MKAnnotationView+Selectable.swift
+++ b/Sources/TripKitUI/views/map annotations/MKAnnotationView+Selectable.swift
@@ -1,0 +1,36 @@
+//
+//  MKAnnotationView+Selectable.swift
+//  TripKitUI-iOS
+//
+//  Created by Adrian Schönig on 11/4/2023.
+//  Copyright © 2023 SkedGo Pty Ltd. All rights reserved.
+//
+
+import MapKit
+
+extension MKAnnotationView {
+  
+  func updateSelection(for currentSelection: String?) {
+    guard let displayable = annotation as? TKUISelectableOnMap else {
+      alpha = 1
+      isEnabled = true
+      return
+    }
+    
+    let isSelected = displayable.selectionIdentifier == currentSelection
+    
+    let show: Bool
+    switch displayable.selectionCondition {
+    case .ifSelectedOrNoSelection:
+      show = isSelected || currentSelection == nil
+    case .onlyIfSelected:
+      show = isSelected && currentSelection != nil
+    case .onlyIfSomethingElseIsSelected:
+      show = !isSelected && currentSelection != nil
+    }
+
+    isEnabled = show // Don't allow selecting it, if it's hidden
+    alpha = show ? 1 : 0
+  }
+  
+}

--- a/Sources/TripKitUI/views/map annotations/TKUIAnnotations.swift
+++ b/Sources/TripKitUI/views/map annotations/TKUIAnnotations.swift
@@ -26,6 +26,23 @@ public protocol TKUIImageAnnotation: MKAnnotation {
   var imageURL: URL? { get }
 }
 
+public enum TKUISelectionCondition {
+  case onlyIfSomethingElseIsSelected
+  case onlyIfSelected
+  case ifSelectedOrNoSelection
+}
+
+public protocol TKUISelectableOnMap {
+  /// Determines whether this should be shown on the map, when something is selected on the map.
+  /// If the map has a selection identifier and it matches this value, then this will be displayed.
+  ///
+  /// If this has returns a non-nil value, it works in tandem with `selectionCondition`
+  var selectionIdentifier: String? { get }
+  
+  /// When to show this; only has an impact if `selectionIdentifier` returns non-nil
+  var selectionCondition: TKUISelectionCondition { get }
+}
+
 /// For displaying an annotation in a `TKUIModeAnnotationView`
 @objc
 public protocol TKUIModeAnnotation: MKAnnotation {

--- a/Sources/TripKitUI/views/map annotations/TKUICircleAnnotationView.swift
+++ b/Sources/TripKitUI/views/map annotations/TKUICircleAnnotationView.swift
@@ -9,6 +9,12 @@
 import Foundation
 import MapKit
 
+public protocol TKUICircleDisplayable: MKAnnotation {
+  var circleColor: UIColor { get }
+  var isTravelled: Bool { get }
+  var asLarge: Bool { get }
+}
+
 open class TKUICircleAnnotationView: MKAnnotationView {
   private enum Constants {
     static let circleSize: CGFloat   = 12.0
@@ -29,7 +35,6 @@ open class TKUICircleAnnotationView: MKAnnotationView {
     
     let radius = Constants.circleSize * (drawLarge ? 1 : Constants.smallFactor)
     frame.size = CGSize(width: radius, height: radius)
-    isOpaque = true
     backgroundColor = .clear
   }
   

--- a/Sources/TripKitUI/views/map annotations/TKUISemaphoreView.swift
+++ b/Sources/TripKitUI/views/map annotations/TKUISemaphoreView.swift
@@ -16,12 +16,19 @@ import TripKit
 
 /// An annotation that can be displayed using TripKitUI's `TKUISemaphoreView`
 /// or just as a point on the map.
-public protocol TKUISemaphoreDisplayable: TKUIImageAnnotation {
-  var semaphoreMode: TKUISemaphoreView.Mode? { get }
+public protocol TKUISemaphoreDisplayable: TKUIImageAnnotation, TKUISelectableOnMap {
   var bearing: NSNumber? { get }
   var imageIsTemplate: Bool { get }
   var isTerminal: Bool { get }
-  var selectionIdentifier: String? { get }
+  var semaphoreMode: TKUISemaphoreView.Mode { get }
+}
+
+extension TKUISemaphoreDisplayable {
+  public var selectionIdentifier: String? { nil }
+  
+  public var isTerminal: Bool { false }
+  
+  public var selectionCondition: TKUISelectionCondition { .ifSelectedOrNoSelection }
 }
 
 public class TKUISemaphoreView: MKAnnotationView {
@@ -160,17 +167,18 @@ public class TKUISemaphoreView: MKAnnotationView {
       timeLabelX += baseHeadOverlap
     }
     
-    if let imageView = accessoryImageView, let image = imageView.image {
+    if let imageView = accessoryImageView {
       var imageViewX = horizontalPadding
       if label == .onRight {
         imageViewX += baseHeadOverlap
       }
-      imageView.frame.size = image.size
+      let imageSize = CGSize(width: 14, height: 14)
+      imageView.frame.size = imageSize
       imageView.frame.origin.x = imageViewX
-      imageView.frame.origin.y = (timeViewHeight - image.size.height) / 2
+      imageView.frame.origin.y = (timeViewHeight - imageSize.height) / 2
       
       // make space for the image
-      let space = image.size.width + horizontalPadding / 3
+      let space = imageSize.width + horizontalPadding / 3
       timeViewWidth += space
       timeLabelX += space
       if label == .onLeft {
@@ -288,14 +296,7 @@ extension TKUISemaphoreView {
       self.modeImageView = modeImageView
     }
   }
-  
-  func updateSelection(for identifier: String?) {
-    guard let displayable = annotation as? TKUISemaphoreDisplayable else { return }
-    guard let target = identifier else { alpha = 1; return }
-    
-    let selected = displayable.selectionIdentifier == target
-    alpha = selected ? 1 : 0.3
-  }
+
   
   func rotateHead(magneticHeading: CLLocationDirection) {
     guard let bearing = (annotation as? TKUISemaphoreDisplayable)?.bearing?.floatValue else { return }

--- a/TripKit.xcodeproj/project.pbxproj
+++ b/TripKit.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		3A41FD2B2978F5DF00841E61 /* TKUITripMonitorManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13FD8EB29741CF2006C338D /* TKUITripMonitorManager.swift */; };
 		3A41FD2C2978F5DF00841E61 /* TKUINotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1EB54A6297706DD00CA4708 /* TKUINotificationManager.swift */; };
 		3A55D16626FC5C5800A3D6EB /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 3A55D16526FC5C5800A3D6EB /* Kingfisher */; };
+		3A5E8EEE29E522F100B08DE0 /* MKAnnotationView+Selectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A5E8EED29E522F100B08DE0 /* MKAnnotationView+Selectable.swift */; };
 		3A772559292B2FBE002F2C60 /* TKUISimpleHomeMapManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A772558292B2FBE002F2C60 /* TKUISimpleHomeMapManager.swift */; };
 		3A89090627E4739D005A49B1 /* Rx+Concurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A89090527E4739D005A49B1 /* Rx+Concurrency.swift */; };
 		3A89090827E473EE005A49B1 /* TKLocationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A89090727E473EE005A49B1 /* TKLocationProvider.swift */; };
@@ -976,6 +977,7 @@
 		3A1AABB226CB78DE00FDDB06 /* pelias-us.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "pelias-us.json"; sourceTree = "<group>"; };
 		3A1AABB326CB78DE00FDDB06 /* pelias-de.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "pelias-de.json"; sourceTree = "<group>"; };
 		3A1AABB726CB7BB100FDDB06 /* TKVehicular.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TKVehicular.swift; sourceTree = "<group>"; };
+		3A5E8EED29E522F100B08DE0 /* MKAnnotationView+Selectable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MKAnnotationView+Selectable.swift"; sourceTree = "<group>"; };
 		3A6DF068202C8C340084CB2C /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		3A6DF069202C8C340084CB2C /* TripKitUI.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; path = TripKitUI.podspec; sourceTree = "<group>"; };
 		3A6DF06A202C8C340084CB2C /* TripKit.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; path = TripKit.podspec; sourceTree = "<group>"; };
@@ -2605,6 +2607,7 @@
 				3AFF279626C6975F007809CD /* TKUISemaphoreView.swift */,
 				3AFF279926C6975F007809CD /* TKUIVehicleAnnotationView.swift */,
 				3AFF279326C6975F007809CD /* TKUIVehicleView.swift */,
+				3A5E8EED29E522F100B08DE0 /* MKAnnotationView+Selectable.swift */,
 			);
 			path = "map annotations";
 			sourceTree = "<group>";
@@ -3777,6 +3780,7 @@
 				3AFF2B1026C69B63007809CD /* TKUITimetableViewController.swift in Sources */,
 				3AFF2AEE26C69B56007809CD /* TKUICardAction.swift in Sources */,
 				3AFF2B7626C69BB9007809CD /* TKUIServiceTitleView+Rx.swift in Sources */,
+				3A5E8EEE29E522F100B08DE0 /* MKAnnotationView+Selectable.swift in Sources */,
 				3AFF2BB126C69BE7007809CD /* TKUICustomization.swift in Sources */,
 				3AFF2B5B26C69BA4007809CD /* TKUIProgressCell.swift in Sources */,
 				3AFF2B1F26C69B85007809CD /* TKUINearbyViewModel.swift in Sources */,

--- a/TripKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TripKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/Kingfisher.git",
       "state" : {
-        "revision" : "59eb199fdb8dd47733624e8b0277822d0232579e",
-        "version" : "7.2.2"
+        "revision" : "af4be924ad984cf4d16f4ae4df424e79a443d435",
+        "version" : "7.6.2"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/skedgo/TGCardViewController.git",
       "state" : {
-        "revision" : "19ade273d1d31b8e9e5a17c53249410fb1ca3de3",
-        "version" : "2.1.2"
+        "revision" : "12f3686c0e0bfd96fb28aba800da3420bc8dcae5",
+        "version" : "2.2.8"
       }
     }
   ],


### PR DESCRIPTION
Now shows semaphores only for the selected leg.

Also:
- Improve selection of stops from TKUIServiceCard
- Fix display of real-time indicator in semaphore
- Fix tile attribution view sticking around
- Fix some real-time updates not reflected on the map
- Fixes issue where template hash code is temporarily lost due to real-time updates, which messes with various things.
- Address some warnings and add some comments
- Don't allow tapping hidden map annotations (by disabling them)
- Minor refactoring