### PR TITLE
Adds TKUICustomization.shared.locationInfoTapHandler

### DIFF
--- a/Sources/TripKit/Resources/de.lproj/TripKit.strings
+++ b/Sources/TripKit/Resources/de.lproj/TripKit.strings
@@ -158,6 +158,9 @@
 /* Status indicator that a mode is enabled */
 "Enabled" = "Aktiviert";
 
+/* Action button title to plan a route ending at this location */
+"End Here" = "Zielort";
+
 /* Placeholder name for destination (then replaced with address or name) */
 "End location" = "Zielort";
 
@@ -395,6 +398,9 @@
 
 /* Title of button to start a trip (primarily after pausing) */
 "Start" = "Abfahrt";
+
+/* Action button title to plan a route starting at this location */
+"Start Here" = "Startort";
 
 /* Placeholder name for origin (then replaced with address or name) */
 "Start location" = "Startort";

--- a/Sources/TripKit/Resources/es.lproj/TripKit.strings
+++ b/Sources/TripKit/Resources/es.lproj/TripKit.strings
@@ -158,6 +158,9 @@
 /* Status indicator that a mode is enabled */
 "Enabled" = "Habilitado";
 
+/* Action button title to plan a route ending at this location */
+"End Here" = "Termina aquí";
+
 /* Placeholder name for destination (then replaced with address or name) */
 "End location" = "Destino final";
 
@@ -395,6 +398,9 @@
 
 /* Title of button to start a trip (primarily after pausing) */
 "Start" = "Inicio";
+
+/* Action button title to plan a route starting at this location */
+"Start Here" = "Comienza aquí";
 
 /* Placeholder name for origin (then replaced with address or name) */
 "Start location" = "Ubicación inicial";

--- a/Sources/TripKit/core/Loc+TripKitUI.swift
+++ b/Sources/TripKit/core/Loc+TripKitUI.swift
@@ -70,6 +70,14 @@ extension Loc {
     return NSLocalizedString("Route", tableName: "TripKit", bundle: .tripKit, comment: "Action button title to plan a route")
   }
   
+  public static var StartHere: String {
+    return NSLocalizedString("Start Here", tableName: "TripKit", bundle: .tripKit, comment: "Action button title to plan a route starting at this location")
+  }
+
+  public static var EndHere: String {
+    return NSLocalizedString("End Here", tableName: "TripKit", bundle: .tripKit, comment: "Action button title to plan a route ending at this location")
+  }
+
   public static var ChangeRoute: String {
     return NSLocalizedString("Change Route", tableName: "TripKit", bundle: .tripKit, comment: "Title of page to change the from/to of the routing results")
   }

--- a/Sources/TripKit/managers/TKCalendarManager+Autocompleting.swift
+++ b/Sources/TripKit/managers/TKCalendarManager+Autocompleting.swift
@@ -16,6 +16,8 @@ extension TKCalendarManager: TKAutocompleting {
     case unexpectedResultObject
   }
   
+  public var allowLocationInfoButton: Bool { false }
+  
   public func autocomplete(_ input: String, near mapRect: MKMapRect, completion: @escaping (Result<[TKAutocompletionResult], Error>) -> Void) {
     
     let events = input.isEmpty

--- a/Sources/TripKit/managers/TKContactsManager+TKAutocompleting.swift
+++ b/Sources/TripKit/managers/TKContactsManager+TKAutocompleting.swift
@@ -26,6 +26,8 @@ extension TKContactsManager {
 
 extension TKContactsManager: TKAutocompleting {
   
+  public var allowLocationInfoButton: Bool { false }
+  
   public func autocomplete(_ input: String, near mapRect: MKMapRect, completion: @escaping (Result<[TKAutocompletionResult], Error>) -> Void) {
     
     guard !input.isEmpty else {

--- a/Sources/TripKit/search/TKGeocoding.swift
+++ b/Sources/TripKit/search/TKGeocoding.swift
@@ -48,10 +48,14 @@ public protocol TKAutocompleting {
   func triggerAdditional(presenter: UIViewController, completion: @escaping (Bool) -> Void)
   
   #endif
+  
+  var allowLocationInfoButton: Bool { get }
 
 }
 
 extension TKAutocompleting {
+  
+  public var allowLocationInfoButton: Bool { true }
   
   #if os(iOS) || os(tvOS)
   public func additionalActionTitle() -> String? {

--- a/Sources/TripKit/search/TKRegionAutocompleter.swift
+++ b/Sources/TripKit/search/TKRegionAutocompleter.swift
@@ -13,6 +13,8 @@ public class TKRegionAutocompleter: TKAutocompleting {
   public init() {
   }
   
+  public var allowLocationInfoButton: Bool { false }
+  
   public func autocomplete(_ input: String, near mapRect: MKMapRect, completion: @escaping (Result<[TKAutocompletionResult], Error>) -> Void) {
     
     let scoredMatches = TKRegionManager.shared.regions

--- a/Sources/TripKitUI/cards/TKUILocationMapManager.swift
+++ b/Sources/TripKitUI/cards/TKUILocationMapManager.swift
@@ -1,0 +1,35 @@
+//
+//  TKUILocationMapManager.swift
+//  TripKitUI-iOS
+//
+//  Created by Adrian Schönig on 1/5/2023.
+//  Copyright © 2023 SkedGo Pty Ltd. All rights reserved.
+//
+
+import MapKit
+
+import TripKit
+
+/// A simple map manager that displays the pin of the provided ``TKNamedCoordinate``
+public class TKUILocationMapManager: TKUIMapManager {
+  
+  let coordinate: TKNamedCoordinate
+  
+  public init(for namedCoordinate: TKNamedCoordinate) {
+    self.coordinate = namedCoordinate
+    
+    super.init()
+    
+    self.preferredZoomLevel = .road
+    self.showOverlayPolygon = true
+    
+    self.annotations = [coordinate]
+  }
+  
+  public override func takeCharge(of mapView: MKMapView, animated: Bool) {
+    super.takeCharge(of: mapView, animated: animated)
+    
+    self.zoom(to: [coordinate], animated: animated)
+  }
+  
+}

--- a/Sources/TripKitUI/cards/TKUIRoutingResultsCard.swift
+++ b/Sources/TripKitUI/cards/TKUIRoutingResultsCard.swift
@@ -194,7 +194,8 @@ public class TKUIRoutingResultsCard: TKUITableCard {
     
     let mapInput: TKUIRoutingResultsViewModel.MapInput = (
       tappedMapRoute: mapManager.selectedMapRoute,
-      droppedPin: mapManager.droppedPin
+      droppedPin: mapManager.droppedPin,
+      tappedPin: (mapManager as? TKUIRoutingResultsMapManager)?.tappedPin ?? .empty()
     )
     
     let viewModel: TKUIRoutingResultsViewModel
@@ -666,7 +667,7 @@ private extension TKUIRoutingResultsCard {
 private extension TKUIRoutingResultsCard {
   
   func navigate(to next: TKUIRoutingResultsViewModel.Next) {
-    guard let controller = controller else { return }
+    guard let controller else { return }
     
     switch next {
     case .showTrip(let trip):
@@ -692,6 +693,15 @@ private extension TKUIRoutingResultsCard {
       
     case .trigger(let action, let group):
       _ = action.handler(action, self, group, controller.view)
+      
+    case .showLocation(let annotation, _):
+      guard let handler = TKUICustomization.shared.locationInfoTapHandler else {
+        return assertionFailure("Shouldn't show that disclosure icon without a tap handler")
+      }
+      switch handler(.init(annotation: annotation, routeButton: .notAllowed)) {
+      case .push(let card):
+        controller.push(card)
+      }
     }
   }
   

--- a/Sources/TripKitUI/helper/RxTripKit/NSManagedObjectContext+Rx.swift
+++ b/Sources/TripKitUI/helper/RxTripKit/NSManagedObjectContext+Rx.swift
@@ -31,6 +31,8 @@ import RxSwift
   extension Reactive where Base: NSManagedObjectContext {
     public func fetchObjects<E: NSManagedObject>(_ entity: E.Type, sortDescriptors: [NSSortDescriptor], predicate: NSPredicate? = nil, relationshipKeyPathsForPrefetching: [String]? = nil) -> Observable<[E]> {
       
+      let base = self.base
+      
       return Observable.create { observer in
         
         // configure the request
@@ -45,7 +47,7 @@ import RxSwift
         var delegate: FetchedResultsControllerDelegateProxy<E>?
         
         // set up the work and delegate forwarding messages to the delegate proxy
-        controller = NSFetchedResultsController(fetchRequest: request, managedObjectContext: self.base, sectionNameKeyPath: nil, cacheName: nil)
+        controller = NSFetchedResultsController(fetchRequest: request, managedObjectContext: base, sectionNameKeyPath: nil, cacheName: nil)
         delegate = FetchedResultsControllerDelegateProxy<E>(observer)
         controller!.delegate = delegate
         do {

--- a/Sources/TripKitUI/helper/TKUICustomization.swift
+++ b/Sources/TripKitUI/helper/TKUICustomization.swift
@@ -11,6 +11,8 @@ import UIKit
 
 import TGCardViewController
 
+import TripKit
+
 /// This class let's you customise various aspects of TripKitUI that apply across multiple view controllers
 /// or cards. You can do this by setting the various parts of `TKUICustomization.shared`, which should
 /// be done before displaying any view controllers or cards.
@@ -66,4 +68,32 @@ public class TKUICustomization {
   /// Default to `false`.
   public var colorCodeTransitIcons: Bool = false
   
+  
+  /// Provide a tap handler here to add an (i) accessory button next to
+  /// autocompletion results, that otherwise don't get an accessory button.
+  ///
+  /// This handler is called when that button is tapped.
+  public var locationInfoTapHandler: ((TKUILocationInfo) -> TKUILocationHandlerAction)? = nil
+  
+}
+
+public struct TKUILocationInfo {
+  public enum RouteButton {
+    /// If this is present, then the location info should include a route button, which the provided
+    /// title and tap handler. If there's already a route button in the location info screen, then
+    /// this should replace it.
+    case replace(title: String, onTap: () -> Void)
+
+    case allowed
+
+    case notAllowed
+  }
+  
+  public let annotation: MKAnnotation
+  
+  public let routeButton: RouteButton
+}
+
+public enum TKUILocationHandlerAction {
+  case push(TGCard)
 }

--- a/Sources/TripKitUI/view model/TKUIAutocompletionViewModel.swift
+++ b/Sources/TripKitUI/view model/TKUIAutocompletionViewModel.swift
@@ -66,10 +66,31 @@ class TKUIAutocompletionViewModel {
     var image: UIImage { completion.image }
     var title: String { completion.title }
     var subtitle: String? { completion.subtitle }
-    var accessoryAccessibilityLabel: String? { includeAccessory ? completion.accessoryAccessibilityLabel : nil }
-    var accessoryImage: UIImage? { includeAccessory ? completion.accessoryButtonImage : nil }
     var showFaded: Bool { completion.isInSupportedRegion?.boolValue == false }
     var provider: TKAutocompleting? { completion.provider as? TKAutocompleting }
+
+    var accessoryAccessibilityLabel: String? {
+      guard includeAccessory else { return nil }
+      
+      if let provided = completion.accessoryAccessibilityLabel {
+        return provided
+      } else if TKUICustomization.shared.locationInfoTapHandler != nil {
+        return title
+      } else {
+        return nil
+      }
+    }
+    var accessoryImage: UIImage? {
+      guard includeAccessory else { return nil }
+
+      if let provided = completion.accessoryButtonImage {
+        return provided
+      } else if provider?.allowLocationInfoButton == true, TKUICustomization.shared.locationInfoTapHandler != nil {
+        return UIImage(systemName: "info.circle")
+      } else {
+        return nil
+      }
+    }
   }
   
   struct ActionItem {

--- a/Sources/TripKitUI/view model/TKUIHomeViewModel+Search.swift
+++ b/Sources/TripKitUI/view model/TKUIHomeViewModel+Search.swift
@@ -48,8 +48,15 @@ extension TKUIHomeViewModel {
         switch annotation {
         case let stop as TKUIStopAnnotation: return .push(TKUITimetableCard(stops: [stop]))
         default:
-          assertionFailure("Unexpected annotation: \(annotation)")
-          return .push(TKUIRoutingResultsCard(destination: annotation))
+          if let tapHandler = TKUICustomization.shared.locationInfoTapHandler {
+            switch tapHandler(.init(annotation: annotation, routeButton: .allowed)) {
+            case .push(let card):
+              return .push(card)
+            }
+          } else {
+            assertionFailure("Unexpected annotation: \(annotation)")
+            return .push(TKUIRoutingResultsCard(destination: annotation))
+          }
         }
       }
     

--- a/Sources/TripKitUI/view model/TKUIRoutingQueryInputViewModel+State.swift
+++ b/Sources/TripKitUI/view model/TKUIRoutingQueryInputViewModel+State.swift
@@ -18,6 +18,7 @@ extension TKUIRoutingQueryInputViewModel {
     case typeText(String)
     case selectMode(TKUIRoutingResultsViewModel.SearchMode)
     case selectResult(MKAnnotation)
+    case select(MKAnnotation, TKUIRoutingResultsViewModel.SearchMode)
     case swap
   }
   
@@ -43,6 +44,7 @@ extension TKUIRoutingQueryInputViewModel {
         inputs.tappedSwap.asObservable().map { .swap },
         inputs.searchText.distinctUntilChanged { $0.0 == $1.0 }.map { .typeText($0.0) },
         inputs.selectedSearchMode.asObservable().distinctUntilChanged().map { .selectMode($0) },
+        inputs.accessoryCallback.asObservable().map { .select($0, $1) }
       ])
 
     let initialState = State(
@@ -81,7 +83,8 @@ extension TKUIRoutingQueryInputViewModel {
             state.destination = nil
           }
 
-        case (.selectResult(let selection), .origin):
+        case (.selectResult(let selection), .origin),
+             (.select(let selection, .origin), _):
           state.origin = selection
           state.originText = (selection.title ?? nil) ?? ""
           
@@ -90,7 +93,8 @@ extension TKUIRoutingQueryInputViewModel {
           state.searchMode = state.destination == nil ? .destination : .origin
           state.mode = state.destination == nil ? .destination : nil
         
-        case (.selectResult(let selection), .destination):
+        case (.selectResult(let selection), .destination),
+             (.select(let selection, .destination), _):
           state.destination = selection
           state.destinationText = (selection.title ?? nil) ?? ""
 

--- a/Sources/TripKitUI/view model/TKUIRoutingQueryInputViewModel+State.swift
+++ b/Sources/TripKitUI/view model/TKUIRoutingQueryInputViewModel+State.swift
@@ -108,6 +108,7 @@ extension TKUIRoutingQueryInputViewModel {
           state.mode = mode
         
         case (.swap, _):
+          state.mode = state.mode ?? .destination
           (state.origin, state.destination) = (state.destination, state.origin)
           (state.originText, state.destinationText) = (state.destinationText, state.originText)
         }

--- a/Sources/TripKitUI/view model/TKUIRoutingQueryInputViewModel.swift
+++ b/Sources/TripKitUI/view model/TKUIRoutingQueryInputViewModel.swift
@@ -12,6 +12,8 @@ import MapKit
 import RxSwift
 import RxCocoa
 
+import TGCardViewController
+
 import TripKit
 
 class TKUIRoutingQueryInputViewModel {
@@ -26,6 +28,14 @@ class TKUIRoutingQueryInputViewModel {
     var selected: Signal<Item> = .empty()
     var selectedSearchMode: Signal<TKUIRoutingResultsViewModel.SearchMode> = .empty()
     var tappedSwap: Signal<Void> = .empty()
+    var accessoryTapped: Signal<Item>? = nil
+    var accessoryCallback: Signal<(MKAnnotation, TKUIRoutingResultsViewModel.SearchMode)> = .empty()
+  }
+  
+  enum Next {
+    case route(origin: MKAnnotation, destination: MKAnnotation)
+    case push(TGCard)
+    case popBack(select: MKAnnotation, mode: TKUIRoutingResultsViewModel.SearchMode, route: Bool)
   }
   
   init(origin: MKAnnotation? = nil, destination: MKAnnotation? = nil, biasMapRect: MKMapRect = .null, startMode: TKUIRoutingResultsViewModel.SearchMode? = nil, inputs: UIInput, providers: [TKAutocompleting]? = nil) {
@@ -38,6 +48,7 @@ class TKUIRoutingQueryInputViewModel {
       includeCurrentLocation: true,
       searchText: inputs.searchText.startWith(("", forced: false)),
       selected: inputs.selected,
+      accessorySelected: inputs.accessoryTapped,
       biasMapRect: .just(biasMapRect)
     )
     
@@ -48,7 +59,7 @@ class TKUIRoutingQueryInputViewModel {
       )
       .share(replay: 1, scope: .whileConnected)
     
-    activeMode = state.map { $0.mode }
+    activeMode = state.map(\.mode)
       .distinctUntilChanged()
       .asDriver(onErrorDriveWith: .empty())
     
@@ -64,11 +75,63 @@ class TKUIRoutingQueryInputViewModel {
       .map { $0.origin != nil && $0.destination != nil }
       .asDriver(onErrorJustReturn: false)
 
-    selections = inputs.tappedRoute.asObservable()
+    let selections = inputs.tappedRoute.asObservable()
       .withLatestFrom(state)
       .filter { $0.origin != nil && $0.destination != nil }
-      .map { ($0.origin!, $0.destination!) }
+      .map { Next.route(origin: $0.origin!, destination: $0.destination!) }
       .asSignal(onErrorSignalWith: .empty())
+    
+    let routeASAP = state
+      .filter { $0.mode == nil && $0.origin != nil && $0.destination != nil }
+      .map { Next.route(origin: $0.origin!, destination: $0.destination!) }
+      .asSignal(onErrorSignalWith: .empty())
+
+    // If we have a `TKUICustomization.shared.locationInfoTapHandler` set, we:
+    // - Add an (i) in the TKUIAutocompletionViewModel, which then triggers
+    //   `accessorySelection` on its tap.
+    // - When that is tapped, we grab the current state, and ask the handler
+    //   to present the location *along with a context sensitive route* button
+    // - The handler should then push an appropriate card that includes that
+    //   button.
+    // - If the user then taps that button, we trigger the 'tap info route'
+    //   publisher, which in turn asks the routing query input card to pop back
+    //   to itself, and trigger the `accessoryCallback` publisher...
+    // - Yikes. If that is triggered, we update the state accordingly, and
+    //   optionally, dismiss the routing query input card.
+    let tapInfoRoutePublisher = PublishSubject<Next>()
+    let accessoryTaps: Signal<Next>
+    if let handler = TKUICustomization.shared.locationInfoTapHandler {
+      accessoryTaps = autocompletionModel.accessorySelection
+        .asObservable()
+        .withLatestFrom(state) { annotation, state -> Next in
+          let routeButton: TKUILocationInfo.RouteButton
+          switch state.mode {
+          case .origin:
+            routeButton = .replace(title: Loc.StartHere, onTap: {
+              tapInfoRoutePublisher.onNext(.popBack(select: annotation, mode: .origin, route: destination != nil))
+            })
+          case .destination, .none:
+            routeButton = .replace(title: Loc.EndHere, onTap: {
+              tapInfoRoutePublisher.onNext(.popBack(select: annotation, mode: .destination, route: true))
+            })
+          }
+          
+          switch handler(.init(annotation: annotation, routeButton: routeButton)) {
+          case .push(let card):
+            return .push(card)
+          }
+        }
+        .asSignal(onErrorSignalWith: Signal<Next>.empty())
+    } else {
+      accessoryTaps = .empty()
+    }
+    
+    next = Signal.merge([
+      routeASAP,
+      selections,
+      accessoryTaps,
+      tapInfoRoutePublisher.asSignal(onErrorSignalWith: .empty())
+    ])
 }
   
   let activeMode: Driver<TKUIRoutingResultsViewModel.SearchMode?>
@@ -79,7 +142,7 @@ class TKUIRoutingQueryInputViewModel {
   
   let enableRouteButton: Driver<Bool>
   
-  let selections: Signal<(MKAnnotation, MKAnnotation)>
-  
   let triggerAction: Signal<TKAutocompleting>
+  
+  let next: Signal<Next>
 }

--- a/Sources/TripKitUI/view model/TKUIRoutingResultsViewModel+CalculateRoutes.swift
+++ b/Sources/TripKitUI/view model/TKUIRoutingResultsViewModel+CalculateRoutes.swift
@@ -15,14 +15,14 @@ import TripKit
 
 extension TKUIRoutingResultsViewModel {
   
-  public struct RouteBuilder: Codable {
-    public enum Time: Equatable, Codable {
+  struct RouteBuilder: Codable {
+    enum Time: Equatable, Codable {
       private enum CodingKeys: String, CodingKey {
         case type
         case date
       }
       
-      public init(from decoder: Decoder) throws {
+      init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let type = try container.decode(String.self, forKey: .type)
         let date = try? container.decode(Date.self, forKey: .date)
@@ -33,7 +33,7 @@ extension TKUIRoutingResultsViewModel {
         }
       }
       
-      public func encode(to encoder: Encoder) throws {
+      func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         switch self {
         case .leaveASAP:
@@ -54,6 +54,7 @@ extension TKUIRoutingResultsViewModel {
     
     init(destination: MKAnnotation, origin: MKAnnotation? = nil) {
       self.mode = origin == nil ? .origin : .destination
+      self.select = .destination
       self.origin = origin.map(TKNamedCoordinate.namedCoordinate(for:))
       self.destination = TKNamedCoordinate.namedCoordinate(for: destination)
       self.time = TKUIRoutingResultsCard.config.timePickerConfig.allowsASAP ? .leaveASAP : nil
@@ -67,6 +68,7 @@ extension TKUIRoutingResultsViewModel {
     }
     
     fileprivate(set) var mode: TKUIRoutingResultsViewModel.SearchMode
+    fileprivate(set) var select: TKUIRoutingResultsViewModel.SearchMode?
     fileprivate(set) var origin: TKNamedCoordinate?
     fileprivate(set) var destination: TKNamedCoordinate?
     fileprivate(set) var time: Time?
@@ -134,6 +136,7 @@ extension TKUIRoutingResultsViewModel {
         }
         
         if let pin = change.pin {
+          updated.select = updated.mode
           updated.dropPin(at: pin)
         }
         
@@ -143,6 +146,7 @@ extension TKUIRoutingResultsViewModel {
           } else {
             updated.destination = TKNamedCoordinate.namedCoordinate(for: search.location)
           }
+          updated.select = .none
         }
         
         return (updated, id: Self.buildId(for: updated, force: change.forceRefresh) )

--- a/Tests/TripKitUITests/TKUIRoutingQueryInputViewModelTest.swift
+++ b/Tests/TripKitUITests/TKUIRoutingQueryInputViewModelTest.swift
@@ -91,7 +91,7 @@ class TKUIRoutingQueryInputViewModelTest: XCTestCase {
         .select("Nuremberg", index: 0),
         .mode(.destination),
         .type("B"),
-        .select("Bahia Blanca", index: 0),
+        .select("Bahia Blanca", index: 0), // => Triggers route automatically
       ])
     
     XCTAssertEqual(results, [
@@ -100,6 +100,7 @@ class TKUIRoutingQueryInputViewModelTest: XCTestCase {
       "Nuremberg -- ",
       "Nuremberg -- B",
       "Nuremberg -- Bahia Blanca",
+      "✅ Nuremberg -- Bahia Blanca",
     ])
   }
 
@@ -141,18 +142,21 @@ class TKUIRoutingQueryInputViewModelTest: XCTestCase {
   func testSwapping() throws {
     let results = run([
         .type("N"),
-        .select("Nuremberg", index: 0),
+        .select("Nuremberg", index: 0), // => Trigger route automatically
+        
+        // Come back then swap
         .swap,
         .mode(.destination),
         .type("B"),
-        .select("Bahia Blanca", index: 0),
-        .route
+        .select("Bahia Blanca", index: 0), // => Triggger route automatically
       ])
     
     XCTAssertEqual(results, [
       "\(Loc.CurrentLocation) -- ",
       "\(Loc.CurrentLocation) -- N",
       "\(Loc.CurrentLocation) -- Nuremberg",
+      "✅ \(Loc.CurrentLocation) -- Nuremberg",
+      
       "Nuremberg -- \(Loc.CurrentLocation)",
       "Nuremberg -- B",
       "Nuremberg -- Bahia Blanca",
@@ -189,10 +193,14 @@ extension TKUIRoutingQueryInputViewModelTest {
     for (index, action) in actions.enumerated() {
       let time: TestTime = (index + 1) * 100
       switch action {
-      case .type(let text): searches.append(.next(time, (text, forced: false)))
-      case .mode(let mode): modes.append(.next(time, mode))
-      case .swap: swaps.append(.next(time, ()))
-      case .route: routes.append(.next(time, ()))
+      case .type(let text):
+        searches.append(.next(time, (text, forced: false)))
+      case .mode(let mode):
+        modes.append(.next(time, mode))
+      case .swap:
+        swaps.append(.next(time, ()))
+      case .route:
+        routes.append(.next(time, ()))
       
       case .select(let text, let index):
         let result = TKAutocompletionResult()
@@ -222,10 +230,9 @@ extension TKUIRoutingQueryInputViewModelTest {
       .bind(to: observer)
       .disposed(by: bag)
     
-    viewModel.selections
+    viewModel.next
       .asObservable()
-      .map { (($0.0.title ?? nil) ?? "", ($0.1.title ?? nil) ?? "") }
-      .map { "✅ \($0) -- \($1)" }
+      .map(\.title)
       .bind(to: observer)
       .disposed(by: bag)
     
@@ -272,6 +279,19 @@ fileprivate extension TKUIRoutingQueryInputViewModel.Item {
     switch self {
     case .action, .currentLocation: return nil
     case .autocompletion(let item): return item.accessoryImage
+    }
+  }
+}
+
+fileprivate extension TKUIRoutingQueryInputViewModel.Next {
+  var title: String {
+    switch self {
+    case let .route(origin, destination):
+      return "✅ \((origin.title ?? nil) ?? "") -- \((destination.title ?? nil) ?? "")"
+    case .push:
+      return "✅ Push card"
+    case .popBack:
+      return "✅ Pop back"
     }
   }
 }

--- a/TripKit.xcodeproj/project.pbxproj
+++ b/TripKit.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		3A1F744925C8F5AA00C72CEE /* TripKitUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A6DF084202C8DA30084CB2C /* TripKitUI.framework */; };
 		3A41FD2B2978F5DF00841E61 /* TKUITripMonitorManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13FD8EB29741CF2006C338D /* TKUITripMonitorManager.swift */; };
 		3A41FD2C2978F5DF00841E61 /* TKUINotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1EB54A6297706DD00CA4708 /* TKUINotificationManager.swift */; };
+		3A4D441229FF9070005295E5 /* TKUILocationMapManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4D441129FF9070005295E5 /* TKUILocationMapManager.swift */; };
 		3A55D16626FC5C5800A3D6EB /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 3A55D16526FC5C5800A3D6EB /* Kingfisher */; };
 		3A9A4AC12978F3360084168A /* GeoMonitor in Frameworks */ = {isa = PBXBuildFile; productRef = 3A9A4AC02978F3360084168A /* GeoMonitor */; };
 		3AA1092126FABC6000C52879 /* TKReporter+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA1092026FABC6000C52879 /* TKReporter+Rx.swift */; };
@@ -962,6 +963,7 @@
 		3A1AABB226CB78DE00FDDB06 /* pelias-us.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "pelias-us.json"; sourceTree = "<group>"; };
 		3A1AABB326CB78DE00FDDB06 /* pelias-de.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "pelias-de.json"; sourceTree = "<group>"; };
 		3A1AABB726CB7BB100FDDB06 /* TKVehicular.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TKVehicular.swift; sourceTree = "<group>"; };
+		3A4D441129FF9070005295E5 /* TKUILocationMapManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TKUILocationMapManager.swift; sourceTree = "<group>"; };
 		3A6DF068202C8C340084CB2C /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		3A6DF069202C8C340084CB2C /* TripKitUI.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; path = TripKitUI.podspec; sourceTree = "<group>"; };
 		3A6DF06A202C8C340084CB2C /* TripKit.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; path = TripKit.podspec; sourceTree = "<group>"; };
@@ -2331,6 +2333,7 @@
 				3AFF270226C6975F007809CD /* TKUIHomeCard+Customizer.swift */,
 				3AFF26E826C6975F007809CD /* TKUIHomeCard+MapManager.swift */,
 				3AFF26F726C6975F007809CD /* TKUIHomeCard+Search.swift */,
+				3A4D441129FF9070005295E5 /* TKUILocationMapManager.swift */,
 				3AFF26F126C6975F007809CD /* TKUIMapManager.swift */,
 				3AFF26FC26C6975F007809CD /* TKUIMapManager+Tiles.swift */,
 				3AFF26FB26C6975F007809CD /* TKUINearbyMapManager.swift */,
@@ -3655,6 +3658,7 @@
 				3AFF2B1726C69B85007809CD /* TKUISegmentDirectionsViewModel.swift in Sources */,
 				3AFF2B6826C69BB9007809CD /* TKUICollectionViewBubbleLayout.swift in Sources */,
 				3AFF2BBD26C69BE7007809CD /* TKUIMapManagerHelper.swift in Sources */,
+				3A4D441229FF9070005295E5 /* TKUILocationMapManager.swift in Sources */,
 				3AFF2BA926C69BE7007809CD /* RxHelpers.swift in Sources */,
 				3AFF2B2C26C69B85007809CD /* TKUIServiceViewModel+Content.swift in Sources */,
 				3AFF2BD226C69BFC007809CD /* DataSources.swift in Sources */,


### PR DESCRIPTION
- Add customisation to TripKitUI to allow adding a generic (i) button (`TKAutocompleting` providers can opt out of it)
- Push location details card when tapping the button
- Use that in the search on home card
- Use that in the search from routing query input card => This should then show "Start here" or "End here"
- Add (i) button callout to map pins when dropping in routing results card
- Auto-select map pin when dropping one on home card or routing results card
