### PR TITLE
Adds `TKOneOffLocationManager`

### DIFF
--- a/Sources/TripKit/managers/TKOneOffLocationManager.swift
+++ b/Sources/TripKit/managers/TKOneOffLocationManager.swift
@@ -10,7 +10,7 @@ import Foundation
 
 import CoreLocation
 
-@available(iOS 14.0, *)
+@available(iOS 14.0, macOS 11.0,  *)
 public class TKOneOffLocationManager: NSObject {
   
   public override init() {
@@ -151,7 +151,7 @@ public class TKOneOffLocationManager: NSObject {
 
 // MARK: - CLLocationManagerDelegate
 
-@available(iOS 14.0, *)
+@available(iOS 14.0, macOS 11.0, *)
 extension TKOneOffLocationManager: CLLocationManagerDelegate {
   
   public func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {

--- a/Sources/TripKit/managers/TKOneOffLocationManager.swift
+++ b/Sources/TripKit/managers/TKOneOffLocationManager.swift
@@ -1,0 +1,196 @@
+//
+//  TKOneOffLocationManager.swift
+//  TripKit
+//
+//  Created by Adrian Schönig on 10/5/2023.
+//  Copyright © 2023 SkedGo Pty Ltd. All rights reserved.
+//
+
+import Foundation
+
+import CoreLocation
+
+@available(iOS 14.0, *)
+public class TKOneOffLocationManager: NSObject {
+  
+  public override init() {
+    locationManager = .init()
+    hasAccess = false
+    
+    super.init()
+    
+    locationManager.delegate = self
+  }
+  
+  public enum LocationFetchError: Error {
+    case accessNotProvided
+    
+    /// Happens if you stop monitoring before a location could be found
+    case noLocationFetchedInTime
+    
+    /// Happens if no accurate fix could be found, best location attached
+    case locationInaccurate(CLLocation)
+  }
+  
+  private let locationManager: CLLocationManager
+  
+  // MARK: - Access
+  
+  /// Whether user has granted any kind of access to the device's location, when-in-use or always
+  @Published public var hasAccess: Bool
+  
+  private var askHandler: (Bool) -> Void = { _ in }
+
+  /// Whether it's possible to bring up the system prompt to ask for access to the device's location
+  public var canAsk: Bool {
+    switch locationManager.authorizationStatus {
+    case .notDetermined:
+      return true
+    case .authorizedAlways, .authorizedWhenInUse, .denied, .restricted:
+      return false
+    @unknown default:
+      return false
+    }
+  }
+  
+  private func updateAccess() {
+    switch locationManager.authorizationStatus {
+    case .authorizedAlways:
+      hasAccess = true
+      // Note: We do NOT update `enableInBackground` here, as that's the user's
+      // setting, i.e., they might not want to have it enabled even though the
+      // app has permissions.
+    case .authorizedWhenInUse:
+      hasAccess = true
+    case .denied, .notDetermined, .restricted:
+      hasAccess = false
+    @unknown default:
+      hasAccess = false
+    }
+  }
+  
+  public func ask(forBackground: Bool = false, _ handler: @escaping (Bool) -> Void = { _ in }) {
+    if forBackground {
+      if locationManager.authorizationStatus == .notDetermined {
+        // Need to *first* ask for when in use, and only for always if that
+        // is granted.
+        ask(forBackground: false) { success in
+          if success {
+            self.ask(forBackground: true, handler)
+          } else {
+            handler(false)
+          }
+        }
+      } else {
+        self.askHandler = handler
+        locationManager.requestAlwaysAuthorization()
+      }
+    } else {
+      self.askHandler = handler
+      locationManager.requestWhenInUseAuthorization()
+    }
+  }
+  
+  @discardableResult
+  public func ask(forBackground: Bool = false) async -> Bool {
+    return await withCheckedContinuation { continuation in
+      ask(forBackground: forBackground) { result in
+        continuation.resume(returning: result)
+      }
+    }
+  }
+  
+  // MARK: - Location fetching
+  
+  @Published public var currentLocation: CLLocation?
+
+  private var withNextLocation: [(Result<CLLocation, Error>) -> Void] = []
+  
+  private var fetchTimer: Timer?
+  
+  public func fetchCurrentLocation() async throws -> CLLocation {
+    guard hasAccess else {
+      throw LocationFetchError.accessNotProvided
+    }
+    
+    let desiredAccuracy = kCLLocationAccuracyHundredMeters
+    if let currentLocation = currentLocation,
+        currentLocation.timestamp.timeIntervalSinceNow > -10,
+        currentLocation.horizontalAccuracy <= desiredAccuracy {
+      // We have a current location and it's less than 10 seconds old. Just use it
+      return currentLocation
+    }
+    
+    let originalAccuracy = locationManager.desiredAccuracy
+    locationManager.desiredAccuracy = desiredAccuracy
+    locationManager.requestLocation()
+    
+    fetchTimer = .scheduledTimer(withTimeInterval: 10, repeats: false) { [unowned self] _ in
+      self.notify(.failure(LocationFetchError.noLocationFetchedInTime))
+    }
+    
+    return try await withCheckedThrowingContinuation { continuation in
+      withNextLocation.append({ [unowned self] result in
+        self.locationManager.desiredAccuracy = originalAccuracy
+        continuation.resume(with: result)
+      })
+    }
+  }
+  
+  private func notify(_ result: Result<CLLocation, Error>) {
+    fetchTimer?.invalidate()
+    fetchTimer = nil
+    
+    withNextLocation.forEach {
+      $0(result)
+    }
+    withNextLocation = []
+  }
+  
+}
+
+// MARK: - CLLocationManagerDelegate
+
+@available(iOS 14.0, *)
+extension TKOneOffLocationManager: CLLocationManagerDelegate {
+  
+  public func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+    guard let latest = locations.last else { return assertionFailure() }
+    
+    guard let latestAccurate = locations
+      .filter({ $0.horizontalAccuracy <= manager.desiredAccuracy })
+      .last
+    else {
+      notify(.failure(LocationFetchError.locationInaccurate(latest)))
+      return
+    }
+
+    self.currentLocation = latestAccurate
+    
+    notify(.success(latestAccurate))
+  }
+  
+  public func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+    notify(.failure(error))
+  }
+  
+  public func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+    if case .notDetermined = manager.authorizationStatus {
+      return // happens immediately when asking for access
+    }
+    
+    updateAccess()
+    askHandler(hasAccess)
+    askHandler = { _ in }
+    
+    switch manager.authorizationStatus {
+    case .authorizedAlways, .authorizedWhenInUse:
+      manager.requestLocation()
+    case .denied, .notDetermined, .restricted:
+      return
+    @unknown default:
+      return
+    }
+  }
+  
+}

--- a/TripKit.xcodeproj/project.pbxproj
+++ b/TripKit.xcodeproj/project.pbxproj
@@ -41,6 +41,8 @@
 		3A89090927E473EE005A49B1 /* TKLocationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A89090727E473EE005A49B1 /* TKLocationProvider.swift */; };
 		3A89090B27E47414005A49B1 /* TKServer+UserAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A89090A27E47414005A49B1 /* TKServer+UserAccount.swift */; };
 		3A89090C27E47414005A49B1 /* TKServer+UserAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A89090A27E47414005A49B1 /* TKServer+UserAccount.swift */; };
+		3A8A9BBC2A0B460900BF4603 /* TKOneOffLocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A8A9BBB2A0B460900BF4603 /* TKOneOffLocationManager.swift */; };
+		3A8A9BBD2A0B460900BF4603 /* TKOneOffLocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A8A9BBB2A0B460900BF4603 /* TKOneOffLocationManager.swift */; };
 		3A96B93B293F102800556A44 /* routes-sf.json in Resources */ = {isa = PBXBuildFile; fileRef = 3A96B93A293F102800556A44 /* routes-sf.json */; };
 		3A9A4AC12978F3360084168A /* GeoMonitor in Frameworks */ = {isa = PBXBuildFile; productRef = 3A9A4AC02978F3360084168A /* GeoMonitor */; };
 		3A9C6A8629B58AC4000D43B2 /* TKAPIParsingTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A9C6A8529B58AC4000D43B2 /* TKAPIParsingTest.swift */; };
@@ -925,6 +927,7 @@
 		3A89090527E4739D005A49B1 /* Rx+Concurrency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Rx+Concurrency.swift"; sourceTree = "<group>"; };
 		3A89090727E473EE005A49B1 /* TKLocationProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TKLocationProvider.swift; sourceTree = "<group>"; };
 		3A89090A27E47414005A49B1 /* TKServer+UserAccount.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TKServer+UserAccount.swift"; sourceTree = "<group>"; };
+		3A8A9BBB2A0B460900BF4603 /* TKOneOffLocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TKOneOffLocationManager.swift; sourceTree = "<group>"; };
 		3A963D6026D46AD300C328A1 /* en-US */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-US"; path = "en-US.lproj/TripKit.strings"; sourceTree = "<group>"; };
 		3A96B93A293F102800556A44 /* routes-sf.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "routes-sf.json"; sourceTree = "<group>"; };
 		3A9AC27E27753E1C004B8A52 /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Shared.strings; sourceTree = "<group>"; };
@@ -1958,6 +1961,7 @@
 				3AFF263726C6975F007809CD /* TKContactsManager.swift */,
 				3AFF263526C6975F007809CD /* TKContactsManager+TKAutocompleting.swift */,
 				3AFF263826C6975F007809CD /* TKLocationManager.swift */,
+				3A8A9BBB2A0B460900BF4603 /* TKOneOffLocationManager.swift */,
 				3AD653E628FE872900A846C5 /* TKPermissionManager.swift */,
 				3AFF263226C6975F007809CD /* TKPermissionManager+AuthorizationAlert.swift */,
 				3AFF263926C6975F007809CD /* TKRegionManager.swift */,
@@ -3307,6 +3311,7 @@
 				3AFF28D126C697D9007809CD /* TKCoordinates.swift in Sources */,
 				3AFF298126C69845007809CD /* CLLocationCoordinate2D+DecodePolylineString.swift in Sources */,
 				3AFF289126C697CA007809CD /* AlertAPIModels.swift in Sources */,
+				3A8A9BBD2A0B460900BF4603 /* TKOneOffLocationManager.swift in Sources */,
 				3AFF297826C69836007809CD /* TKStyleManager+UIKit.swift in Sources */,
 				3AFF289026C697CA007809CD /* UserAPIModel.swift in Sources */,
 				3AFF295F26C6981E007809CD /* TKQuickBookingHelper.swift in Sources */,
@@ -3766,6 +3771,7 @@
 				3A1AABAC26CB6F8000FDDB06 /* TKAutocompletionResult+Icon.swift in Sources */,
 				3AFF283726C6977B007809CD /* TKSegment+Shareable.swift in Sources */,
 				3AFF289526C697CB007809CD /* DeparturesAPIModel.swift in Sources */,
+				3A8A9BBC2A0B460900BF4603 /* TKOneOffLocationManager.swift in Sources */,
 				3AFF291026C697DA007809CD /* TKCoordinates.swift in Sources */,
 				3AFF297C26C69845007809CD /* CLLocationCoordinate2D+DecodePolylineString.swift in Sources */,
 				3AFF28A326C697CB007809CD /* AlertAPIModels.swift in Sources */,


### PR DESCRIPTION
Adds a simpler location manager, useful for just getting the current location.

It's a simpler version of `TKLocationManager` that's based on some of the code in `GeoMonitor`. I first tried using `TKLocationManager` but it's not working well for just fetching a single location and then forgetting about the rest.