### PR TITLE
Fix for making the home card respect the customiser's `canBeHidden`

### DIFF
--- a/Sources/TripKitUI/controller/TKUIHomeCardCustomizationViewController.swift
+++ b/Sources/TripKitUI/controller/TKUIHomeCardCustomizationViewController.swift
@@ -102,6 +102,8 @@ fileprivate class DataSource: RxTableViewSectionedReloadDataSource<TKUIHomeCardC
       ? UIImage(systemName: "checkmark.circle.fill")
       : UIImage(systemName: "circle")
     
+    cell.stateImageView.alpha = item.canBeHidden ? 1 : 0.3
+    
     if item.isEnabled {
       cell.accessibilityTraits.insert(.selected)
     } else {

--- a/Sources/TripKitUI/view model/TKUIHomeCardCustomizationViewModel.swift
+++ b/Sources/TripKitUI/view model/TKUIHomeCardCustomizationViewModel.swift
@@ -58,12 +58,14 @@ extension TKUIHomeCardCustomizationViewModel {
     let title: String
     let icon: UIImage
     let isEnabled: Bool
+    let canBeHidden: Bool
     
     init(_ customized: TKUIHomeCard.CustomizedItem) {
       self.identity = customized.id
       self.title = customized.item.name
       self.icon = customized.item.icon
       self.isEnabled = customized.isEnabled
+      self.canBeHidden = customized.item.canBeHidden
     }
   }
   
@@ -90,7 +92,7 @@ extension TKUIHomeCardCustomizationViewModel {
       let item = updated.remove(at: move.sourceIndex.row)
       updated.insert(item, at: move.destinationIndex.row)
     case .selection(let selection):
-      if let index = items.firstIndex(where: { $0.id == selection.identity}) {
+      if let index = items.firstIndex(where: { $0.id == selection.identity}), updated[index].item.canBeHidden {
         updated[index].isEnabled = !updated[index].isEnabled
       }
     }


### PR DESCRIPTION
The option existed but was never used. The `enabled` toggle will now be faded out to indicate that you can't hide those sections.