### PR TITLE
Disable polyline selection on trip overview card

### DIFF
--- a/Sources/TripKitUI/cards/TKUIMapManager.swift
+++ b/Sources/TripKitUI/cards/TKUIMapManager.swift
@@ -119,6 +119,15 @@ open class TKUIMapManager: TGMapManager {
   /// Cache of renderers, used to update styling when selection changes
   private var renderers: [WeakRenderers] = []
   
+  /// Whether user interaction for selecting annotation is enabled, defaults to `true`.
+  open var annotationSelectionEnabled: Bool = true {
+    didSet {
+      if !annotationSelectionEnabled {
+        selectionIdentifier = nil
+      }
+    }
+  }
+  
   /// The identifier for what should be drawn as selected on the map
   public var selectionIdentifier: String? {
     didSet {
@@ -372,6 +381,7 @@ extension TKUIMapManager {
   
   private func updateSelectionForTapping(_ view: MKAnnotationView) {
     guard
+      annotationSelectionEnabled,
       let selectable = view.annotation as? TKUISelectableOnMap,
       let identifier = selectable.selectionIdentifier
       else { return }

--- a/Sources/TripKitUI/cards/TKUITripModeByModeCard.swift
+++ b/Sources/TripKitUI/cards/TKUITripModeByModeCard.swift
@@ -188,6 +188,8 @@ public class TKUITripModeByModeCard: TGPageCard {
   
   public override func didAppear(animated: Bool) {
     super.didAppear(animated: animated)
+    
+    tripMapManager.annotationSelectionEnabled = true
 
     TKUIEventCallback.handler(.cardAppeared(self))
     if let controller = self.controller {

--- a/Sources/TripKitUI/cards/TKUITripOverviewCard.swift
+++ b/Sources/TripKitUI/cards/TKUITripOverviewCard.swift
@@ -222,6 +222,11 @@ public class TKUITripOverviewCard: TKUITableCard {
       tripMapManager?.deselectSegment(animated: animated)
     }
     
+    // Annotation selection on the trip map manager is used by the mode-by-mode
+    // card, but not the overview card; as it doesn't do anything useful, and
+    // you can't undo it.
+    tripMapManager?.annotationSelectionEnabled = false
+    
     TKUIEventCallback.handler(.cardAppeared(self))
   }
 


### PR DESCRIPTION
Just keep it on mode-by-mode card. It's distracting and not useful on the overview card.

Resolves https://redmine.buzzhives.com/issues/19584