### PR TITLE
Re-instate support for asking for calendar access on iOS 17

### DIFF
--- a/.github/workflows/docs-dryrun.yml
+++ b/.github/workflows/docs-dryrun.yml
@@ -9,10 +9,10 @@ on:
 jobs:
   build_docs:
     name: Build docs
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - name: Checkout main
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - uses: actions/setup-python@v2
         with:
           python-version: 3.x

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,10 +9,10 @@ on:
 jobs:
   build_docs:
     name: Build and deploy docs
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - name: Checkout main
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - uses: actions/setup-python@v2
         with:
           python-version: 3.x

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: macos-13
 
     steps:
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
       - uses: actions/checkout@v4
       - name: Build
         run: swift build --target TripKit

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -8,15 +8,15 @@ on:
 
 jobs:
   build_spm:
-    runs-on: macos-12
+    runs-on: macos-13
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build
         run: swift build --target TripKit
 
   build_xcode:
-    runs-on: macos-12
+    runs-on: macos-13
 
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
@@ -31,13 +31,13 @@ jobs:
         run: xcodebuild build -quiet -project TripKit.xcodeproj -scheme "TripKitInterApp-iOS" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14'
 
   test_xcode:
-    runs-on: macos-12
+    runs-on: macos-13
 
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run tests
         env:
           TRIPGO_API_KEY: ${{ secrets.TRIPGO_API_KEY }}
@@ -55,13 +55,13 @@ jobs:
         # even if the test fails in the previous step.
 
   examples:
-    runs-on: macos-12
+    runs-on: macos-13
 
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build TripKitUIExample
         run: xcodebuild build -quiet -project TripKit.xcodeproj -scheme TripKitUIExample -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14'
       - name: Build MiniMap

--- a/Examples/MiniMap/MiniMap/AppDelegate.swift
+++ b/Examples/MiniMap/MiniMap/AppDelegate.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 SkedGo Pty Ltd. All rights reserved.
 //
 
-import Cocoa
+import AppKit
 
 import TripKit
 

--- a/Examples/MiniMap/MiniMap/ViewController.swift
+++ b/Examples/MiniMap/MiniMap/ViewController.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 SkedGo Pty Ltd. All rights reserved.
 //
 
-import Cocoa
+import AppKit
 import MapKit
 
 import TripKit

--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let package = Package(
         "TGCardViewController",
         "GeoMonitor",
       ],
-      exclude: ["Supporting Files/Info.plist"]
+      exclude: ["Supporting Files/Info.plist", "vendor/RxCombine/LICENSE"]
     ),
     .testTarget(
       name: "TripKitTests",

--- a/Sources/TripKit/core/TKCrossPlatform.swift
+++ b/Sources/TripKit/core/TKCrossPlatform.swift
@@ -14,7 +14,7 @@ import Foundation
   public typealias TKImage = UIImage
   public typealias TKFont  = UIFont
 #elseif os(OSX)
-  import Cocoa
+  import AppKit
   public typealias TKColor = NSColor
   public typealias TKImage = NSImage
   public typealias TKFont  = NSFont

--- a/Sources/TripKit/managers/TKCalendarManager.swift
+++ b/Sources/TripKit/managers/TKCalendarManager.swift
@@ -76,9 +76,9 @@ extension TKCalendarManager: TKPermissionManager {
       return .notDetermined
     case .restricted:
       return .restricted
-    case .denied:
+    case .denied, .writeOnly:
       return .denied
-    case .authorized:
+    case .authorized, .fullAccess:
       return .authorized
     @unknown default:
       return .notDetermined
@@ -87,10 +87,19 @@ extension TKCalendarManager: TKPermissionManager {
   
   public func askForPermission(_ completion: @escaping (Bool) -> Void) {
     let oldStore = self.eventStore
-    oldStore.requestAccess(to: .event) { granted, _ in
-      self.eventStore = .init()
-      DispatchQueue.main.async {
-        completion(granted)
+    if #available(iOS 17.0, macOS 14.0, *) {
+      oldStore.requestFullAccessToEvents { granted, _ in
+        self.eventStore = .init()
+        DispatchQueue.main.async {
+          completion(granted)
+        }
+      }
+    } else {
+      oldStore.requestAccess(to: .event) { granted, _ in
+        self.eventStore = .init()
+        DispatchQueue.main.async {
+          completion(granted)
+        }
       }
     }
   }

--- a/Sources/TripKit/vendor/ASPolygonKit/QuickLookable.swift
+++ b/Sources/TripKit/vendor/ASPolygonKit/QuickLookable.swift
@@ -12,7 +12,7 @@ import Foundation
 #if os(iOS) || os(tvOS)
   import UIKit
 #elseif os(OSX)
-  import Cocoa
+  import AppKit
 #endif
   
 extension Polygon {

--- a/Sources/TripKitUI/views/trip overview/TKUIPathChartView.swift
+++ b/Sources/TripKitUI/views/trip overview/TKUIPathChartView.swift
@@ -15,7 +15,7 @@ import class TripKit.Shape
 
 @available(iOS 16.0, *)
 struct TKUIPathChartView<V>: View where V: TKUIPathChartable & Hashable {
-  init?(values: [TKUIPathChartView.ChartValue<V>], totalDistance: CLLocationDistance? = nil) {
+  init?(values: [TKUIPathChartView.ChartValue], totalDistance: CLLocationDistance? = nil) {
     let longEnough = values.filter { $0.distance > 25 }
     guard !longEnough.isEmpty else { return nil }
     
@@ -37,12 +37,12 @@ struct TKUIPathChartView<V>: View where V: TKUIPathChartable & Hashable {
     }
   }
   
-  struct ChartValue<V>: Hashable where V: TKUIPathChartable & Hashable {
+  struct ChartValue: Hashable {
     var value: V
     var distance: CLLocationDistance
   }
 
-  let values: [ChartValue<V>]
+  let values: [ChartValue]
   let totalDistance: CLLocationDistance
   
   var body: some View {


### PR DESCRIPTION
The old `requestAccess(to: .event)` immediately errors.