### PR TITLE
Selected tweaks

### DIFF
--- a/Sources/TripKit/model/TKBookingTypes.swift
+++ b/Sources/TripKit/model/TKBookingTypes.swift
@@ -398,7 +398,7 @@ extension TKBooking {
     
     public let id: Identifier
     
-    public let status: Status
+    public let status: Status?
 
     /// URL to fetch ticket details, provided if `status == .activated`
     public let ticketURL: URL?

--- a/Sources/TripKit/server/TKServer.swift
+++ b/Sources/TripKit/server/TKServer.swift
@@ -34,11 +34,11 @@ public class TKServer {
       UserDefaults.shared.string(forKey: "developmentServer")
     }
     set {
+      let newValue = newValue.map { value in
+        value.hasSuffix("/") ? value : value.appending("/")
+      }
       let oldValue = customBaseURL
       if var newValue = newValue, !newValue.isEmpty {
-        if !newValue.hasSuffix("/") {
-          newValue.append("/")
-        }
         UserDefaults.shared.set(newValue, forKey: "developmentServer")
       } else {
         UserDefaults.shared.removeObject(forKey: "developmentServer")

--- a/Sources/TripKitUI/cards/TKUIHomeCard.swift
+++ b/Sources/TripKitUI/cards/TKUIHomeCard.swift
@@ -397,7 +397,7 @@ extension TKUIHomeCard: UITableViewDelegate {
       return nil
     }
     
-    header.configure(with: dataSource.sectionModels[section].headerConfiguration) { [weak self] in
+    header.configure(with: dataSource.sectionModels[section].headerConfiguration, homeCard: self) { [weak self] in
       self?.actionTriggered.onNext($0)
     }
     return header

--- a/Sources/TripKitUI/view model/TKUIHomeViewModel+Component.swift
+++ b/Sources/TripKitUI/view model/TKUIHomeViewModel+Component.swift
@@ -14,9 +14,9 @@ import RxCocoa
 
 public struct TKUIHomeHeaderConfiguration {
   public let title: String
-  public var action: (title: String, handler: () -> TKUIHomeCard.ComponentAction)?
+  public var action: (title: String, handler: (TKUIHomeCard) -> TKUIHomeCard.ComponentAction)?
   
-  public init(title: String, action: (String, () -> TKUIHomeCard.ComponentAction)? = nil) {
+  public init(title: String, action: (String, (TKUIHomeCard) -> TKUIHomeCard.ComponentAction)? = nil) {
     self.title = title
     self.action = action
   }

--- a/Sources/TripKitUI/views/TKUIHomeCardSectionHeader.swift
+++ b/Sources/TripKitUI/views/TKUIHomeCardSectionHeader.swift
@@ -53,14 +53,14 @@ class TKUIHomeCardSectionHeader: UITableViewHeaderFooterView {
     disposeBag = DisposeBag()
   }
   
-  func configure(with configuration: TKUIHomeHeaderConfiguration?, onTap: @escaping (TKUIHomeCard.ComponentAction) -> Void) {
+  func configure(with configuration: TKUIHomeHeaderConfiguration?, homeCard: TKUIHomeCard, onTap: @escaping (TKUIHomeCard.ComponentAction) -> Void) {
     if let configuration = configuration {
       label.text = configuration.title
       if let action = configuration.action {
         button.isHidden = false
         button.setTitle(action.title, for: .normal)
         button.rx.tap
-          .subscribe(onNext: { _ in onTap(action.handler()) })
+          .subscribe(onNext: { _ in onTap(action.handler(homeCard)) })
           .disposed(by: disposeBag)
       } else {
         button.isHidden = true


### PR DESCRIPTION
Changed: 

- Pass back card to home-card section configuration
- `PurchasesTicket.status` is optional

Fixed:

- Don't reset user token if `TKServer.customBaseURL` didn't change when setting it