### PR TITLE
Robustness and refactoring

### DIFF
--- a/Sources/TripKit/server/TKServer+ImageUpload.swift
+++ b/Sources/TripKit/server/TKServer+ImageUpload.swift
@@ -10,7 +10,7 @@ import Foundation
 
 extension TKServer {
   
-  public func upload(_ imageData: Data, onComplete handler: @escaping (Result<TKImage?, Error>) -> Void) {
+  public func upload(imageData: Data, contentType: String) async throws {
     let baseURL = baseURLs(for: nil).first!
     
     let boundary = UUID().uuidString
@@ -21,27 +21,39 @@ extension TKServer {
     request.setValue(userToken, forHTTPHeaderField: "userToken")
     request.setValue(apiKey, forHTTPHeaderField: "X-TripGo-Key")
     request.setValue(TKServer.xTripGoVersion(), forHTTPHeaderField: "X-TripGo-Version")
+    if let headers = TKServer.shared.customHeaders {
+      for (header, value) in headers {
+        request.setValue(value, forHTTPHeaderField: header)
+      }
+    }
     
-    var data = Data()
-    data.append(Data("\r\n--\(boundary)\r\n".utf8))
-    data.append(Data("Content-Disposition: form-data; filename=\"\("user-profile-picture")\"\r\n".utf8))
-    data.append(Data("Content-Type: image/png\r\n\r\n".utf8))
-    data.append(imageData)
-    data.append(Data("\r\n--\(boundary)--\r\n".utf8))
+    var uploadData = Data()
+    uploadData.append(Data("\r\n--\(boundary)\r\n".utf8))
+    uploadData.append(Data("Content-Disposition: form-data; filename=\"\("user-profile-picture")\"\r\n".utf8))
+    uploadData.append(Data("Content-Type: \(contentType)\r\n\r\n".utf8))
+    uploadData.append(imageData)
+    uploadData.append(Data("\r\n--\(boundary)--\r\n".utf8))
     
     let id = UUID()
     TKLog.log("TKServer+Image", request: request, uuid: id)
     
-    let task = URLSession.shared.uploadTask(with: request, from: data) { data, response, error in
-      TKLog.log("TKServer+Image", response: response, data: data, orError: error as NSError?, for: request, uuid: id)
-      if let error = error {
-        handler(.failure(error))
-      } else {
-        handler(.success(TKImage(data: imageData)))
+    do {
+      let (data, response) = try await URLSession.shared.upload(for: request, from: uploadData)
+      TKLog.log("TKServer+Image", response: response, data: data, orError: nil, for: request, uuid: id)
+      if let error = TKError.error(from: data, domain: "com.skedgo.TripKit") {
+        throw error // To be consistent with what `TKServer` does
       }
+    } catch let error as TKError {
+      throw error // Don't log again
+    } catch {
+      TKLog.log("TKServer+Image", response: nil, data: nil, orError: error, for: request, uuid: id)
+      throw error
     }
-    
-    task.resume()
   }
   
+  @discardableResult
+  public func removeImage() async -> Int? {
+    await TKServer.shared.hit(.DELETE, path: "/data/user/image").statusCode
+  }
+
 }

--- a/Sources/TripKit/server/parsing/TKRoutingParser.swift
+++ b/Sources/TripKit/server/parsing/TKRoutingParser.swift
@@ -241,6 +241,14 @@ public final class TKRoutingParser {
       var newTrips = Set<Trip>()
       
       for apiTrip in apiGroup.trips {
+        // Sanity check first if this is useable
+        let missingHashCode = apiTrip.segments.map(\.segmentTemplateHashCode)
+          .first(where: { !templateByHashCodes.keys.contains($0) })
+        if let missingHashCode {
+          TKLog.error("TKRoutingParser", text: "Skipping trip due to missing template for \(missingHashCode) using mode: \(mode). Templates: \(templates).")
+          continue
+        }
+        
         let trip: Trip
         var unmatchedSegmentReferencesByHashCode: [Int: SegmentReference] = [:]
         switch mode {
@@ -294,8 +302,7 @@ public final class TKRoutingParser {
         for (index, apiReference) in apiTrip.segments.enumerated() {
           let hashCode = apiReference.segmentTemplateHashCode
           guard let apiTemplate = templateByHashCodes[hashCode] else {
-            assertionFailure("Missing template for \(hashCode)")
-            continue
+            preconditionFailure("Sanity check above failed")
           }
           let isNewTemplate = !existingTemplateHashCodes.contains(hashCode)
           


### PR DESCRIPTION
- `TKServer.upload` is now async and passes on headers and tweaks logging
- Parsing trips is more robust by skipping invalid trips from backend (due to missing templates)