### PR TITLE
Feature/20774 location modes

### DIFF
--- a/Sources/TripKit/managers/TKRegionManager.swift
+++ b/Sources/TripKit/managers/TKRegionManager.swift
@@ -44,7 +44,7 @@ public class TKRegionManager: NSObject {
         return try JSONDecoder().decode(TKAPI.RegionsResponse.self, from: data)
       }.value
       if let response {
-        await updateRegions(from: response)
+        updateRegions(from: response)
       }
 
     } catch {
@@ -77,7 +77,7 @@ public class TKRegionManager: NSObject {
 extension TKRegionManager {
 
   @MainActor
-  func updateRegions(from response: TKAPI.RegionsResponse) async {
+  func updateRegions(from response: TKAPI.RegionsResponse) {
     // Silently ignore obviously bad data
     guard response.modes != nil, response.regions != nil else {
       // This asset isn't valid, due to race conditions
@@ -88,10 +88,8 @@ extension TKRegionManager {
     self.response = response
     NotificationCenter.default.post(name: .TKRegionManagerUpdatedRegions, object: self)
     
-    Task.detached(priority: .utility) {
-      if let encoded = try? JSONEncoder().encode(response) {
-        TKRegionManager.saveToCache(encoded)
-      }
+    if let encoded = try? JSONEncoder().encode(response) {
+      TKRegionManager.saveToCache(encoded)
     }
   }
   

--- a/Sources/TripKit/managers/TKStyleManager.swift
+++ b/Sources/TripKit/managers/TKStyleManager.swift
@@ -85,6 +85,16 @@ extension TKStyleManager {
     return image!
   }
   
+  public static func image(systemName: String) -> TKImage? {
+#if canImport(UIKit)
+    return TKImage(systemName: systemName)?.withRenderingMode(.alwaysTemplate)
+#elseif os(macOS)
+    return nil
+#else
+    return nil
+#endif
+  }
+  
   public static func optionalImage(named: String) -> TKImage? {
 #if canImport(UIKit)
     return TKImage(named: named, in: .tripKit, compatibleWith: nil)

--- a/Sources/TripKit/model/TKNamedCoordinate.swift
+++ b/Sources/TripKit/model/TKNamedCoordinate.swift
@@ -76,6 +76,8 @@ open class TKNamedCoordinate : NSObject, NSSecureCoding, Codable, TKClusterable 
   
   @objc public var isSuburb: Bool = false
   
+  public var modeIdentifiers: [String]? = nil
+  
   public var priority: Float?
 
   @objc(namedCoordinateForAnnotation:)
@@ -144,6 +146,7 @@ open class TKNamedCoordinate : NSObject, NSSecureCoding, Codable, TKClusterable 
     case isDraggable
     case isSuburb
     case clusterIdentifier
+    case modeIdentifiers
   }
   
   public required init(from decoder: Decoder) throws {
@@ -170,6 +173,7 @@ open class TKNamedCoordinate : NSObject, NSSecureCoding, Codable, TKClusterable 
     locationID = try container.decodeIfPresent(String.self, forKey: .locationID)
     timeZoneID = try container.decodeIfPresent(String.self, forKey: .timeZoneID)
     clusterIdentifier = try container.decodeIfPresent(String.self, forKey: .clusterIdentifier)
+    modeIdentifiers = try container.decodeIfPresent([String].self, forKey: .modeIdentifiers)
     isDraggable = (try container.decodeIfPresent(Bool.self, forKey: .isDraggable)) ?? false
     isSuburb = (try container.decodeIfPresent(Bool.self, forKey: .isSuburb)) ?? false
 
@@ -189,6 +193,7 @@ open class TKNamedCoordinate : NSObject, NSSecureCoding, Codable, TKClusterable 
     try container.encode(locationID, forKey: .locationID)
     try container.encode(timeZoneID, forKey: .timeZoneID)
     try container.encode(clusterIdentifier, forKey: .clusterIdentifier)
+    try container.encode(modeIdentifiers, forKey: .modeIdentifiers)
     try container.encode(isDraggable, forKey: .isDraggable)
     try container.encode(isSuburb, forKey: .isSuburb)
 
@@ -214,6 +219,7 @@ open class TKNamedCoordinate : NSObject, NSSecureCoding, Codable, TKClusterable 
         self.locationID = decoded.locationID
         self.timeZoneID = decoded.timeZoneID
         self.clusterIdentifier = decoded.clusterIdentifier
+        self.modeIdentifiers = decoded.modeIdentifiers
         self.data = decoded.data
         self.isSuburb = decoded.isSuburb
         self.isDraggable = decoded.isDraggable
@@ -235,6 +241,7 @@ open class TKNamedCoordinate : NSObject, NSSecureCoding, Codable, TKClusterable 
       locationID = aDecoder.decodeObject(of: NSString.self, forKey: "locationID") as String?
       timeZoneID = aDecoder.decodeObject(of: NSString.self, forKey: "timeZone") as String?
       clusterIdentifier = aDecoder.decodeObject(of: NSString.self, forKey: "clusterIdentifier") as String?
+      modeIdentifiers = aDecoder.decodeObject(of: [NSString.self, NSArray.self], forKey: "modeIdentifiers") as? [String]
       _placemark = aDecoder.decodeObject(of: CLPlacemark.self, forKey: "placemark")
       isDraggable = aDecoder.decodeBool(forKey: "isDraggable")
       isSuburb = aDecoder.decodeBool(forKey: "isSuburb")
@@ -256,6 +263,7 @@ open class TKNamedCoordinate : NSObject, NSSecureCoding, Codable, TKClusterable 
     aCoder.encode(locationID, forKey: "locationID")
     aCoder.encode(timeZoneID, forKey: "timeZone")
     aCoder.encode(clusterIdentifier, forKey: "clusterIdentifier")
+    aCoder.encode(modeIdentifiers, forKey: "modeIdentifiers")
     aCoder.encode(_placemark, forKey: "placemark")
     aCoder.encode(isDraggable, forKey: "isDraggable")
     aCoder.encode(isSuburb, forKey: "isSuburb")

--- a/Sources/TripKit/model/TKNamedCoordinate.swift
+++ b/Sources/TripKit/model/TKNamedCoordinate.swift
@@ -76,6 +76,8 @@ open class TKNamedCoordinate : NSObject, NSSecureCoding, Codable, TKClusterable 
   
   @objc public var isSuburb: Bool = false
   
+  public var klass: String? = nil
+  
   public var modeIdentifiers: [String]? = nil
   
   public var priority: Float?
@@ -147,6 +149,7 @@ open class TKNamedCoordinate : NSObject, NSSecureCoding, Codable, TKClusterable 
     case isSuburb
     case clusterIdentifier
     case modeIdentifiers
+    case klass = "class"
   }
   
   public required init(from decoder: Decoder) throws {
@@ -174,6 +177,7 @@ open class TKNamedCoordinate : NSObject, NSSecureCoding, Codable, TKClusterable 
     timeZoneID = try container.decodeIfPresent(String.self, forKey: .timeZoneID)
     clusterIdentifier = try container.decodeIfPresent(String.self, forKey: .clusterIdentifier)
     modeIdentifiers = try container.decodeIfPresent([String].self, forKey: .modeIdentifiers)
+    klass = try container.decodeIfPresent(String.self, forKey: .klass)
     isDraggable = (try container.decodeIfPresent(Bool.self, forKey: .isDraggable)) ?? false
     isSuburb = (try container.decodeIfPresent(Bool.self, forKey: .isSuburb)) ?? false
 
@@ -194,6 +198,7 @@ open class TKNamedCoordinate : NSObject, NSSecureCoding, Codable, TKClusterable 
     try container.encode(timeZoneID, forKey: .timeZoneID)
     try container.encode(clusterIdentifier, forKey: .clusterIdentifier)
     try container.encode(modeIdentifiers, forKey: .modeIdentifiers)
+    try container.encode(klass, forKey: .klass)
     try container.encode(isDraggable, forKey: .isDraggable)
     try container.encode(isSuburb, forKey: .isSuburb)
 
@@ -220,6 +225,7 @@ open class TKNamedCoordinate : NSObject, NSSecureCoding, Codable, TKClusterable 
         self.timeZoneID = decoded.timeZoneID
         self.clusterIdentifier = decoded.clusterIdentifier
         self.modeIdentifiers = decoded.modeIdentifiers
+        self.klass = decoded.klass
         self.data = decoded.data
         self.isSuburb = decoded.isSuburb
         self.isDraggable = decoded.isDraggable
@@ -242,6 +248,7 @@ open class TKNamedCoordinate : NSObject, NSSecureCoding, Codable, TKClusterable 
       timeZoneID = aDecoder.decodeObject(of: NSString.self, forKey: "timeZone") as String?
       clusterIdentifier = aDecoder.decodeObject(of: NSString.self, forKey: "clusterIdentifier") as String?
       modeIdentifiers = aDecoder.decodeObject(of: [NSString.self, NSArray.self], forKey: "modeIdentifiers") as? [String]
+      klass = aDecoder.decodeObject(of: NSString.self, forKey: "klass") as String?
       _placemark = aDecoder.decodeObject(of: CLPlacemark.self, forKey: "placemark")
       isDraggable = aDecoder.decodeBool(forKey: "isDraggable")
       isSuburb = aDecoder.decodeBool(forKey: "isSuburb")
@@ -264,6 +271,7 @@ open class TKNamedCoordinate : NSObject, NSSecureCoding, Codable, TKClusterable 
     aCoder.encode(timeZoneID, forKey: "timeZone")
     aCoder.encode(clusterIdentifier, forKey: "clusterIdentifier")
     aCoder.encode(modeIdentifiers, forKey: "modeIdentifiers")
+    aCoder.encode(klass, forKey: "klass")
     aCoder.encode(_placemark, forKey: "placemark")
     aCoder.encode(isDraggable, forKey: "isDraggable")
     aCoder.encode(isSuburb, forKey: "isSuburb")

--- a/Sources/TripKit/search/TKTripGoGeocoder.swift
+++ b/Sources/TripKit/search/TKTripGoGeocoder.swift
@@ -135,14 +135,23 @@ extension TKTripGoGeocoder: TKAutocompleting {
                 accessoryAccessibilityLabel: Loc.ShowTimetable,
                 score: tuple.score
               )
+              
             } else {
+              let preferredImage: TKImage?
+              switch named.klass {
+              case "SchoolLocation":
+                preferredImage = TKStyleManager.image(systemName: "graduationcap.fill")
+              default:
+                preferredImage = nil
+              }
+              
               return TKAutocompletionResult(
                 object: named,
                 title: name,
                 titleHighlightRanges: tuple.titleHighlight,
                 subtitle: named.address,
                 subtitleHighlightRanges: tuple.subtitleHighlight,
-                image: TKAutocompletionResult.image(for: .pin),
+                image: preferredImage ?? TKAutocompletionResult.image(for: .pin),
                 score: tuple.score
               )
             }
@@ -194,8 +203,13 @@ extension TKTripGoGeocoder {
       return .init(score: ranged, titleHighlight: highlight ?? [])
     
     } else if let query = query, let name = named.name ?? named.title {
+      var boost: Int = 0
+      // Rank those higher which get special modal functionality
+      if named.modeIdentifiers != nil {
+        boost += 20
+      }
       let titleScore = TKAutocompletionResult.nameScore(searchTerm: query, candidate: name)
-      let ranged = TKAutocompletionResult.rangedScore(for: titleScore.score, min: 0, max: 50)
+      let ranged = TKAutocompletionResult.rangedScore(for: titleScore.score, min: 0 + boost, max: 50 + boost)
       return .init(score: ranged, titleHighlight: titleScore.ranges)
 
     } else {

--- a/Sources/TripKit/server/TKRouter.swift
+++ b/Sources/TripKit/server/TKRouter.swift
@@ -242,13 +242,13 @@ extension TKRouter {
     
     let includesAllModes = try request.performAndWait { $0.additional.contains { $0.name == "allModes" } }
     
+    let enabledModes = try modes ?? request.performAndWait(\.modes)
     if includesAllModes {
-      modeIdentifiers = try modes ?? request.performAndWait(\.modes)
+      modeIdentifiers = enabledModes
       fetchTrips(for: request, bestOnly: false, additional: nil, callbackQueue: queue, completion: completion)
       return 1
     }
     
-    let enabledModes = try modes ?? request.performAndWait(\.modes)
     guard !enabledModes.isEmpty else {
       throw RoutingError.invalidRequest("No modes enabled")
     }

--- a/Sources/TripKit/server/TKServer+Regions.swift
+++ b/Sources/TripKit/server/TKServer+Regions.swift
@@ -89,7 +89,7 @@ extension TKRegionManager {
     
     switch response.result {
     case .success(let model):
-      await updateRegions(from: model)
+      updateRegions(from: model)
       if hasRegions {
         return
       } else {

--- a/Sources/TripKitUI/cards/TKUIMapManager.swift
+++ b/Sources/TripKitUI/cards/TKUIMapManager.swift
@@ -72,6 +72,9 @@ open class TKUIMapManager: TGMapManager {
   /// - default: TKUIAnnotationViewBuilder
   public static var annotationBuilderFactory: ((MKAnnotation, MKMapView) -> TKUIAnnotationViewBuilder) = TKUIAnnotationViewBuilder.init
   
+  /// The POI categories from Apple Maps to never show on the map, e.g., as they are added separately.
+  public static var pointsOfInterestsToExclude: [MKPointOfInterestCategory] = [.publicTransport]
+  
   static var tileOverlays: [String: MKTileOverlay] = [:]
   
   /// Callback that fires when attributions need to be displayed. In particular when using `tiles`.
@@ -199,7 +202,7 @@ open class TKUIMapManager: TGMapManager {
     // Keep heading
     heading = mapView.camera.heading
     
-    mapView.pointOfInterestFilter = MKPointOfInterestFilter(excluding: [.publicTransport])
+    mapView.pointOfInterestFilter = MKPointOfInterestFilter(excluding: TKUIMapManager.pointsOfInterestsToExclude)
 
     // Add content
     mapView.addOverlays(overlays, level: overlayLevel)

--- a/Sources/TripKitUI/controller/TKUIAutocompletionViewController.swift
+++ b/Sources/TripKitUI/controller/TKUIAutocompletionViewController.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import MapKit
+import SwiftUI
 
 import RxCocoa
 import RxSwift
@@ -60,14 +61,27 @@ public class TKUIAutocompletionViewController: UITableViewController {
           // Shouldn't but can happen on dealloc
           return UITableViewCell(style: .default, reuseIdentifier: nil)
         }
-        guard let cell = tv.dequeueReusableCell(withIdentifier: TKUIAutocompletionResultCell.reuseIdentifier, for: ip) as? TKUIAutocompletionResultCell else {
-          preconditionFailure("Couldn't dequeue TKUIAutocompletionResultCell")
+        
+        if #available(iOS 16, *) {
+          let cell = tv.dequeueReusableCell(withIdentifier: "plain", for: ip)
+          cell.contentConfiguration = UIHostingConfiguration {
+            TKUIAutocompletionResultView(
+              item: item,
+              onAccessoryTapped: self.showAccessoryButtons ? { self.accessoryTapped.onNext($0) } : nil
+            )
+          }
+          return cell
+          
+        } else {
+          guard let cell = tv.dequeueReusableCell(withIdentifier: TKUIAutocompletionResultCell.reuseIdentifier, for: ip) as? TKUIAutocompletionResultCell else {
+            preconditionFailure("Couldn't dequeue TKUIAutocompletionResultCell")
+          }
+          cell.configure(
+            with: item,
+            onAccessoryTapped: self.showAccessoryButtons ? { self.accessoryTapped.onNext($0) } : nil
+          )
+          return cell
         }
-        cell.configure(
-          with: item,
-          onAccessoryTapped: self.showAccessoryButtons ? { self.accessoryTapped.onNext($0) } : nil
-        )
-        return cell
       },
       titleForHeaderInSection: { ds, index in
         return ds.sectionModels[index].title
@@ -78,7 +92,11 @@ public class TKUIAutocompletionViewController: UITableViewController {
     tableView.delegate = nil
     tableView.dataSource = nil
     
-    tableView.register(TKUIAutocompletionResultCell.self, forCellReuseIdentifier: TKUIAutocompletionResultCell.reuseIdentifier)
+    if #available(iOS 16, *) {
+      tableView.register(UITableViewCell.self, forCellReuseIdentifier: "plain")
+    } else {
+      tableView.register(TKUIAutocompletionResultCell.self, forCellReuseIdentifier: TKUIAutocompletionResultCell.reuseIdentifier)
+    }
     
     viewModel = TKUIAutocompletionViewModel(
       providers: providers,

--- a/Sources/TripKitUI/helper/RxTripKit/TKGeocoding+Rx.swift
+++ b/Sources/TripKitUI/helper/RxTripKit/TKGeocoding+Rx.swift
@@ -132,7 +132,10 @@ public extension Array where Element == TKAutocompleting {
   func autocomplete(_ text: Observable<(String, forced: Bool)>, mapRect: Observable<MKMapRect>) -> Observable<[TKAutocompletionResult]> {
     
     return text
-      .distinctUntilChanged { $0.0 == $1.0 && $0.forced == $1.forced && !$1.forced }
+      .map { ($0.0 == Loc.CurrentLocation || $0.0 == Loc.Location) ? ("", forced: $0.1) : $0 }
+      .distinctUntilChanged { (lhs: (String, forced: Bool), rhs: (String, forced: Bool)) -> Bool in
+        lhs.0 == rhs.0 && lhs.forced == rhs.forced && !rhs.forced
+      }
       .withLatestFrom(mapRect) { ($0, $1) }
       .debounce(.milliseconds(200), scheduler: MainScheduler.asyncInstance)
       .flatMapLatest { input, mapRect -> Observable<[TKAutocompletionResult]> in

--- a/Sources/TripKitUI/helper/RxTripKit/TKUIResultsFetcher.swift
+++ b/Sources/TripKitUI/helper/RxTripKit/TKUIResultsFetcher.swift
@@ -82,7 +82,7 @@ public class TKUIResultsFetcher {
       prepared = prepared.flatMap { (request: TripRequest, _) in
         let modesToAdjust: Set<String> = modes ?? request.modes
         let region = request.startRegion ?? request.spanningRegion
-        return modeAdjuster(region, modesToAdjust)
+        return modeAdjuster(region, modesToAdjust, request)
           .map { (request, $0) }
       }
     }
@@ -112,7 +112,7 @@ public class TKUIResultsFetcher {
   
   /// Replace the set of provided modes with the modes returned by the `Single`, called before
   /// by `streamTrips` at the very start and information is not cached.
-  public static var modeReplacementHandler: ((TKRegion, Set<String>) -> Single<Set<String>>)? = nil
+  public static var modeReplacementHandler: ((TKRegion, Set<String>, TripRequest) -> Single<Set<String>>)? = nil
   
 }
 

--- a/Sources/TripKitUI/view model/TKUIAutocompletionViewModel.swift
+++ b/Sources/TripKitUI/view model/TKUIAutocompletionViewModel.swift
@@ -87,7 +87,7 @@ class TKUIAutocompletionViewModel {
       if let provided = completion.accessoryButtonImage {
         return provided
       } else if provider?.allowLocationInfoButton == true, TKUICustomization.shared.locationInfoTapHandler != nil {
-        return UIImage(systemName: "info.circle")
+        return UIImage(systemName: "info.circle")?.withRenderingMode(.alwaysTemplate)
       } else {
         return nil
       }
@@ -192,7 +192,8 @@ extension TKUIAutocompletionViewModel {
     
     let searchTrigger = Observable.combineLatest(
       searchText,
-      refresh.asObservable().map { true }.startWith(false)) { ($0.0, forced: $0.1 || $1) }
+      refresh.asObservable().map { true }.startWith(false)
+    ) { ($0.0, forced: $0.1 || $1) }
 
     return providers.autocomplete(searchTrigger, mapRect: biasMapRect.asObservable())
       .map { completions in

--- a/Sources/TripKitUI/views/TKUIAutocompletionResultCell.swift
+++ b/Sources/TripKitUI/views/TKUIAutocompletionResultCell.swift
@@ -10,6 +10,7 @@ import UIKit
 
 import TripKit
 
+@available(iOS, deprecated: 16.0, message: "Use TKUIAutocompletionResultView")
 class TKUIAutocompletionResultCell: UITableViewCell {
   
   static let reuseIdentifier = "TKUIAutocompletionResultCell"
@@ -50,7 +51,7 @@ extension TKUIAutocompletionResultCell {
   
   private func configure(title: String, titleHighlightRanges: [NSRange] = [], subtitle: String? = nil, subtitleHighlightRanges: [NSRange] = [], image: UIImage? = nil) {
     imageView?.image = image
-    imageView?.tintColor = .tkLabelPrimary
+    imageView?.tintColor = .tkLabelTertiary // Matches icons
     textLabel?.set(text: title, highlightRanges: titleHighlightRanges, textColor: .tkLabelPrimary)
     detailTextLabel?.set(text: subtitle, highlightRanges: subtitleHighlightRanges, textColor: .tkLabelSecondary)
     contentView.alpha = 1

--- a/Sources/TripKitUI/views/TKUIAutocompletionResultView.swift
+++ b/Sources/TripKitUI/views/TKUIAutocompletionResultView.swift
@@ -1,0 +1,126 @@
+//
+//  TKUIAutocompletionResultView.swift
+//  TripKitUI-iOS
+//
+//  Created by Adrian Schönig on 27/3/2024.
+//  Copyright © 2024 SkedGo Pty Ltd. All rights reserved.
+//
+
+import SwiftUI
+
+import TripKit
+
+@available(iOS 16.0, *)
+struct TKUIAutocompletionResultView: View {
+  typealias Item = TKUIAutocompletionViewModel.Item
+  
+  let item: Item
+  var onAccessoryTapped: ((Item) -> Void)? = nil
+  
+  var body: some View {
+    switch item {
+    case .autocompletion(let autocompletionItem):
+      let result = autocompletionItem.completion
+
+      HStack {
+        Image(uiImage: result.image)
+          .resizable()
+          .scaledToFit()
+          .frame(width: 19)
+          .foregroundStyle(Color(uiColor: .tkLabelTertiary))
+        
+        VStack(alignment: .leading) {
+          Text.build(result.title, highlightRanges: result.titleHighlightRanges, textColor: .tkLabelPrimary)
+          
+          if let subtitle = result.subtitle, !subtitle.isEmpty {
+            Text.build(subtitle, highlightRanges: result.subtitleHighlightRanges, textColor: .tkLabelSecondary)
+          }
+        }
+        
+        Spacer(minLength: 0)
+        
+        if let accessory = autocompletionItem.accessoryImage, let onAccessoryTapped {
+          Button {
+            onAccessoryTapped(item)
+            
+          } label: {
+            Image(uiImage: accessory)
+              .resizable()
+              .scaledToFit()
+              .frame(width: 24)
+              .foregroundStyle(Color(uiColor: .tkLabelTertiary))
+          }
+        }
+      }
+      .opacity(autocompletionItem.showFaded ? 0.33 : 1)
+      
+    case .action(let action):
+      HStack {
+        Image(uiImage: TKAutocompletionResult.image(for: .currentLocation))
+          .resizable()
+          .scaledToFit()
+          .frame(width: 19)
+          .opacity(0) // just for consistent sizing
+        
+        Text(verbatim: action.title)
+          .bold()
+      }
+      
+    case .currentLocation:
+      HStack {
+        Image(uiImage: TKAutocompletionResult.image(for: .currentLocation))
+          .resizable()
+          .scaledToFit()
+          .frame(width: 19)
+          .foregroundStyle(Color(uiColor: .tkLabelTertiary))
+        
+        Text(verbatim: Loc.CurrentLocation)
+      }
+      
+    }
+  }
+}
+
+@available(iOS 16.0, *)
+extension Text {
+  @ViewBuilder
+  static func build(_ text: String, highlightRanges: [NSRange], textColor: UIColor) -> some View {
+    if highlightRanges.isEmpty {
+      Text(verbatim: text)
+        .foregroundStyle(Color(uiColor: textColor))
+    } else {
+      let attributed: NSAttributedString = {
+        let attributed = NSMutableAttributedString(string: text, attributes: [
+          .foregroundColor: textColor,
+          .font: TKStyleManager.customFont(forTextStyle: .body),
+        ])
+        for range in highlightRanges {
+          attributed.addAttribute(.font, value: TKStyleManager.boldCustomFont(forTextStyle: .body), range: range)
+        }
+        return attributed
+      }()
+      
+      Text(AttributedString(attributed))
+    }
+  }
+}
+
+@available(iOS 16.0, *)
+#Preview {
+  TKUIAutocompletionResultView(
+    item: .autocompletion(.init(
+      index: 0,
+      completion: TKAutocompletionResult(
+        object: "",
+        title: "Alfred Deaking High School",
+        titleHighlightRanges: [
+          .init(location: 0, length: 3)
+        ],
+        subtitle: "Near some street in Canberra",
+        image: TKStyleManager.image(systemName: "graduationcap.fill")!
+      ),
+      includeAccessory: true
+    )),
+    onAccessoryTapped: { _ in }
+  )
+}

--- a/TripKit.xcodeproj/project.pbxproj
+++ b/TripKit.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		3A7491232B9EB4A300AE3A89 /* TKBicycleAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A7491212B9EB4A300AE3A89 /* TKBicycleAccessibility.swift */; };
 		3A7491252B9EB6D100AE3A89 /* TKBicycleAccessibility+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A7491242B9EB6D100AE3A89 /* TKBicycleAccessibility+UI.swift */; };
 		3A772559292B2FBE002F2C60 /* TKUISimpleHomeMapManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A772558292B2FBE002F2C60 /* TKUISimpleHomeMapManager.swift */; };
+		3A7F54932BB3EE8D00FCA71E /* TKUIAutocompletionResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A7F54922BB3EE8D00FCA71E /* TKUIAutocompletionResultView.swift */; };
 		3A855DA82B0B3DC500D923AE /* Trip+Match.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A855DA72B0B3DC500D923AE /* Trip+Match.swift */; };
 		3A89090627E4739D005A49B1 /* Rx+Concurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A89090527E4739D005A49B1 /* Rx+Concurrency.swift */; };
 		3A89090827E473EE005A49B1 /* TKLocationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A89090727E473EE005A49B1 /* TKLocationProvider.swift */; };
@@ -944,6 +945,7 @@
 		3A7491212B9EB4A300AE3A89 /* TKBicycleAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TKBicycleAccessibility.swift; sourceTree = "<group>"; };
 		3A7491242B9EB6D100AE3A89 /* TKBicycleAccessibility+UI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TKBicycleAccessibility+UI.swift"; sourceTree = "<group>"; };
 		3A772558292B2FBE002F2C60 /* TKUISimpleHomeMapManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TKUISimpleHomeMapManager.swift; sourceTree = "<group>"; };
+		3A7F54922BB3EE8D00FCA71E /* TKUIAutocompletionResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TKUIAutocompletionResultView.swift; sourceTree = "<group>"; };
 		3A855DA72B0B3DC500D923AE /* Trip+Match.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Trip+Match.swift"; sourceTree = "<group>"; };
 		3A89090527E4739D005A49B1 /* Rx+Concurrency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Rx+Concurrency.swift"; sourceTree = "<group>"; };
 		3A89090727E473EE005A49B1 /* TKLocationProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TKLocationProvider.swift; sourceTree = "<group>"; };
@@ -2453,6 +2455,7 @@
 				3AFF279D26C6975F007809CD /* timetable */,
 				3AFF277A26C6975F007809CD /* trip overview */,
 				3AFF274226C6975F007809CD /* TKUIAutocompletionResultCell.swift */,
+				3A7F54922BB3EE8D00FCA71E /* TKUIAutocompletionResultView.swift */,
 				3AE8932529ED3A2900E9EB4E /* TKUICardActionsViewFactory.swift */,
 				3A32B90E29ED16CF000B66F0 /* TKUICardActions.swift */,
 				3AFF275126C6975F007809CD /* TKUIDepartureCell.swift */,
@@ -3716,6 +3719,7 @@
 				3AFF2BD326C69BFC007809CD /* RxPickerViewAdapter.swift in Sources */,
 				D33949ED2732AC3F00B38B79 /* TKUITimePickerSheet+Configuration.swift in Sources */,
 				3AFF2B8926C69BBE007809CD /* TKUIHomeHeaderView.swift in Sources */,
+				3A7F54932BB3EE8D00FCA71E /* TKUIAutocompletionResultView.swift in Sources */,
 				3AFF2BAB26C69BE7007809CD /* Trip+Titles.swift in Sources */,
 				3AFF2B6326C69BB1007809CD /* TKUISegmentTitleView.swift in Sources */,
 				3AFF2B2426C69B85007809CD /* TKUIHomeViewModel+Component.swift in Sources */,


### PR DESCRIPTION
New:
- Pass on suggested modes from `geocode.json` to `routing.json`
- Pass on selected modes to `geocode.json` for mode-specific results
- Allow customising which POIs to show on the map, via `TKUIMapManager.pointsOfInterestsToExclude`
- Adds `TKUIAutocompletionResultView` as a replacement for `TKUIAutocompletionResultCell`

Fixed:
- Don't geocode "Current Location" or "Location"