### PR TITLE
Fixes for TKOneOffLocationManager

### DIFF
--- a/Sources/TripKit/managers/TKOneOffLocationManager.swift
+++ b/Sources/TripKit/managers/TKOneOffLocationManager.swift
@@ -139,7 +139,7 @@ public final class TKOneOffLocationManager: NSObject {
     
     timeoutTask = Task { [weak self] in
       do {
-        if #available(iOS 16.0, *) {
+        if #available(iOS 16.0, macOS 13.0, *) {
           try await Task.sleep(for: .seconds(10))
         } else {
           try await Task.sleep(nanoseconds: 10_000_000_000)


### PR DESCRIPTION
- Populate `hasAccess` and latest location on initialisation
- Refactor timeout from `Timer` to `Task.sleep`
- Improve capture semantics by replacing unowned references with weak references for memory safety

Should now properly work for:

```swift
try await TKOneOffLocationManager().fetchCurrentLocation()
```