### PR TITLE
Hotfix/investigate service card loop bug

### DIFF
--- a/.github/workflows/docs-dryrun.yml
+++ b/.github/workflows/docs-dryrun.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: macos-15
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.x
       - name: Prepare dependencies

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: macos-15
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.x
       - name: Prepare dependencies
@@ -34,7 +34,7 @@ jobs:
           ./docs.sh
 
       - name: Deploy docs
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -24,9 +24,9 @@ jobs:
       matrix:
         include:
           - os: macos-26
-            xcode: "26.1.1"
+            xcode: "26.4"
           - os: macos-15
-            xcode: "26.1.1"
+            xcode: "26.3"
           - os: macos-15
             xcode: "16.4"
           - os: macos-14
@@ -38,7 +38,7 @@ jobs:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: ${{ matrix.xcode }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build
         run: swift build --target TripKit
 
@@ -47,12 +47,12 @@ jobs:
 
     strategy:
       matrix:
-        swift: ["6.1", "6.0", "5.10"]
+        swift: ["6.2", "6.1", "6.0", "5.10"]
     container:
       image: swift:${{ matrix.swift }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build
         run: swift build --target TripKitAPI
 
@@ -63,13 +63,13 @@ jobs:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Build TripKit Mac
         run: set -o pipefail && xcodebuild build -project TripKit.xcodeproj -scheme "TripKit" -sdk macosx | xcbeautify
       - name: Build TripKitUI iOS
-        run: set -o pipefail && xcodebuild build -project TripKit.xcodeproj -scheme "TripKitUI" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 16' | xcbeautify
+        run: set -o pipefail && xcodebuild build -project TripKit.xcodeproj -scheme "TripKitUI" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17' | xcbeautify
       - name: Build TripKitInterApp iOS
-        run: set -o pipefail && xcodebuild build -project TripKit.xcodeproj -scheme "TripKitInterApp" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 16' | xcbeautify
+        run: set -o pipefail && xcodebuild build -project TripKit.xcodeproj -scheme "TripKitInterApp" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17' | xcbeautify
 
   test_xcode:
     runs-on: macos-15
@@ -78,12 +78,12 @@ jobs:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Run tests
         env:
           TRIPGO_API_KEY: ${{ secrets.TRIPGO_API_KEY }}
         run: |
-          set -o pipefail && xcodebuild test -project TripKit.xcodeproj -scheme "TripKit" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 16' | xcbeautify
+          set -o pipefail && xcodebuild test -project TripKit.xcodeproj -scheme "TripKit" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17' | xcbeautify
 
   example_spm:
     runs-on: macos-15
@@ -92,6 +92,6 @@ jobs:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build TripKitUIExample
-        run: set -o pipefail && xcodebuild build -project TripKit.xcodeproj -scheme TripKitUIExample -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 16' | xcbeautify
+        run: set -o pipefail && xcodebuild build -project TripKit.xcodeproj -scheme TripKitUIExample -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17' | xcbeautify

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -29,8 +29,6 @@ jobs:
             xcode: "26.3"
           - os: macos-15
             xcode: "16.4"
-          - os: macos-14
-            xcode: "16.1" # sic, 16.2 not available on GitHub as of Jan 2025
 
     runs-on: ${{ matrix.os }}
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/skedgo/GeoMonitor.git",
       "state" : {
-        "revision" : "6bd6092fb4e85727d483fe244a11b882c2997f63",
-        "version" : "0.2.0"
+        "revision" : "170e4fdbabd291880de4017a1e396969930d82b7",
+        "version" : "0.3.0"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/Kingfisher.git",
       "state" : {
-        "revision" : "d30a5fad881137e2267f96a8e3fc35c58999bb94",
-        "version" : "8.6.2"
+        "revision" : "c152c1915f60c51e4afa0752656993ee5b3c63db",
+        "version" : "8.8.1"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ReactiveX/RxSwift.git",
       "state" : {
-        "revision" : "5004a18539bd68905c5939aa893075f578f4f03d",
-        "version" : "6.9.1"
+        "revision" : "132aea4f236ccadc51590b38af0357a331d51fa2",
+        "version" : "6.10.2"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/skedgo/TGCardViewController.git",
       "state" : {
-        "revision" : "e5017f7988c5132ab2e4f6666ad350205ec29090",
-        "version" : "2.4.1"
+        "revision" : "776cc3bfe19f6c2debf8f0eff2e82c17980ade99",
+        "version" : "2.4.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "6.1.0")),
     .package(url: "https://github.com/onevcat/Kingfisher.git", .upToNextMajor(from: "8.0.0")),
-    .package(url: "https://github.com/skedgo/GeoMonitor.git", .upToNextMinor(from: "0.2.0")),
+    .package(url: "https://github.com/skedgo/GeoMonitor.git", .upToNextMinor(from: "0.3.0")),
 //    .package(url: "https://github.com/skedgo/TGCardViewController.git", branch: "ios26"),
     .package(url: "https://github.com/skedgo/TGCardViewController.git", .upToNextMajor(from: "2.4.0")),
   ],

--- a/Sources/TripKit/server/parsing/TKAPIToCoreDataConverter.swift
+++ b/Sources/TripKit/server/parsing/TKAPIToCoreDataConverter.swift
@@ -291,16 +291,28 @@ extension Shape {
       
       // add the stops
       if let service = current {
-        // remember the existing visits
-        var existingVisitsByCode: [String: StopVisits] = [:]
+        // Remember the existing visits. We group repeated stop codes into a
+        // list sorted by visit index, so loop services consume matching visits
+        // in route order instead of reusing the same visit object each time.
+        var existingVisitsByCode: [String: [StopVisits]] = [:]
         let visits = (current?.visits ?? []).filter { !($0 is DLSEntry) }
         for visit in visits {
-          existingVisitsByCode[visit.stop.stopCode] = visit
+          existingVisitsByCode[visit.stop.stopCode, default: []].append(visit)
+        }
+        existingVisitsByCode = existingVisitsByCode.mapValues { $0.sorted() }
+
+        func nextExistingVisit(for stopCode: String) -> StopVisits? {
+          guard var candidates = existingVisitsByCode[stopCode], !candidates.isEmpty else {
+            return nil
+          }
+          let match = candidates.removeFirst()
+          existingVisitsByCode[stopCode] = candidates
+          return match
         }
         
         for apiStop in apiShape.stops {
           let visit: StopVisits
-          if let existing = existingVisitsByCode[apiStop.code] {
+          if let existing = nextExistingVisit(for: apiStop.code) {
             visit = existing
           } else {
             visit = StopVisits(context: context)
@@ -314,7 +326,7 @@ extension Shape {
           // hook-up to shape
           shape.addToVisits(visit)
           
-          if !existingVisitsByCode.keys.contains(apiStop.code) {
+          if visit.stop == nil {
             let coordinate = TKNamedCoordinate(latitude: apiStop.lat, longitude: apiStop.lng, name: apiStop.name, address: nil)
             let stop = StopLocation.fetchOrInsertStop(stopCode: apiStop.code, modeInfo: modeInfo, at: coordinate, in: context)
             stop.shortName = apiStop.shortName

--- a/Sources/TripKitUI/managers/TKUITripMonitorManager.swift
+++ b/Sources/TripKitUI/managers/TKUITripMonitorManager.swift
@@ -70,7 +70,7 @@ public class TKUITripMonitorManager: NSObject, ObservableObject {
     } onEvent: { [weak self] event in
       guard let self, let monitoredTrip = self.monitoredTrip else { return }
       switch event {
-      case .entered(let region, _):
+      case .entered(let region, _), .foreground(let region, _):
         guard let match = monitoredTrip.notifications.first(where: { $0.id == region.identifier }) else { return }
         self.notify(with: match, trigger: nil)  // Fire right away
       case .manual(let region, let location):

--- a/Tests/TripKitTests/Data/departures-darwin-loop.json
+++ b/Tests/TripKitTests/Data/departures-darwin-loop.json
@@ -1,0 +1,23 @@
+{
+  "embarkationStops": [
+    {
+      "stopCode": "046",
+      "services": [
+        {
+          "startTime": 1775711400,
+          "serviceTripID": "675194105_B506",
+          "serviceName": "Casuarina to Casuarina - via Wanguri, Lyons, Muirhead",
+          "serviceDirection": "Casuarina to Casuarina - via Wanguri, Lyons, Muirhead",
+          "serviceNumber": "24",
+          "operatorID": "au-nt-cdc-CDC",
+          "operator": "CDC",
+          "modeInfo": {
+            "identifier": "pt_pub_bus",
+            "alt": "bus",
+            "localIcon": "bus"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/Tests/TripKitTests/Data/service-darwin-loop.json
+++ b/Tests/TripKitTests/Data/service-darwin-loop.json
@@ -1,0 +1,58 @@
+{
+  "shapes": [
+    {
+      "travelled": true,
+      "encodedWaypoints": "abc",
+      "serviceTripID": "675194105_B506",
+      "serviceName": "Casuarina to Casuarina - via Wanguri, Lyons, Muirhead",
+      "serviceDirection": "Casuarina to Casuarina - via Wanguri, Lyons, Muirhead",
+      "serviceNumber": "24",
+      "operator": "CDC",
+      "operatorID": "au-nt-cdc-CDC",
+      "routeID": "24",
+      "wheelchairAccessible": true,
+      "stops": [
+        {
+          "lat": -12.37375,
+          "lng": 130.88327,
+          "code": "046",
+          "name": "Trower Rd after Linton St",
+          "wheelchairAccessible": true,
+          "departure": 1775711400
+        },
+        {
+          "lat": -12.37213,
+          "lng": 130.88206,
+          "code": "047",
+          "name": "9 Scaturchio St",
+          "wheelchairAccessible": true,
+          "arrival": 1775711460,
+          "departure": 1775711460
+        },
+        {
+          "lat": -12.37693,
+          "lng": 130.88581,
+          "code": "144",
+          "name": "28 Vanderlin Dve",
+          "wheelchairAccessible": true,
+          "arrival": 1775712900,
+          "departure": 1775712900
+        },
+        {
+          "lat": -12.37375,
+          "lng": 130.88327,
+          "code": "046",
+          "name": "Trower Rd after Linton St",
+          "wheelchairAccessible": true,
+          "arrival": 1775712960,
+          "departure": 1775712960
+        }
+      ]
+    }
+  ],
+  "modeInfo": {
+    "identifier": "pt_pub_bus",
+    "alt": "bus",
+    "localIcon": "bus"
+  }
+}

--- a/Tests/TripKitTests/parsing/TKLoopServiceParsingTest.swift
+++ b/Tests/TripKitTests/parsing/TKLoopServiceParsingTest.swift
@@ -6,8 +6,9 @@ import Testing
 
 @testable import TripKit
 
+@MainActor
 struct TKLoopServiceParsingTest {
-  private static let model: NSManagedObjectModel? = TripKit.loadModel()
+  private static let model = TKTestCase.model
 
   @Test func serviceDetailsPreserveDistinctVisitsForRepeatedStopCodes() throws {
     let context = try makeContext()
@@ -25,7 +26,7 @@ struct TKLoopServiceParsingTest {
     let departureVisit = try firstDepartureVisit(in: context)
     let service = try unwrap(departureVisit.service, "Expected a service on the departure visit.")
 
-    #expect(departureVisit.index == 0)
+    #expect(departureVisit.index == -1)
     #expect(Int(departureVisit.departure?.timeIntervalSince1970 ?? 0) == 1_775_711_400)
 
     let serviceData = try dataFromJSON(named: "service-darwin-loop")

--- a/Tests/TripKitTests/parsing/TKLoopServiceParsingTest.swift
+++ b/Tests/TripKitTests/parsing/TKLoopServiceParsingTest.swift
@@ -1,0 +1,108 @@
+#if canImport(Testing) && canImport(CoreData)
+
+import Foundation
+import CoreData
+import Testing
+
+@testable import TripKit
+
+struct TKLoopServiceParsingTest {
+  private static let model: NSManagedObjectModel? = TripKit.loadModel()
+
+  @Test func serviceDetailsPreserveDistinctVisitsForRepeatedStopCodes() throws {
+    let context = try makeContext()
+    let departuresData = try dataFromJSON(named: "departures-darwin-loop")
+    let departures = try JSONDecoder().decode(TKAPI.Departures.self, from: departuresData)
+
+    let stop = StopLocation.fetchOrInsertStop(
+      stopCode: "046",
+      inRegion: "AU_NT_Darwin",
+      in: context
+    )
+
+    #expect(TKDeparturesProvider.addDepartures(departures, to: [stop]) == false)
+
+    let departureVisit = try firstDepartureVisit(in: context)
+    let service = try unwrap(departureVisit.service, "Expected a service on the departure visit.")
+
+    #expect(departureVisit.index == 0)
+    #expect(Int(departureVisit.departure?.timeIntervalSince1970 ?? 0) == 1_775_711_400)
+
+    let serviceData = try dataFromJSON(named: "service-darwin-loop")
+    let serviceResponse = try JSONDecoder().decode(TKAPI.ServiceResponse.self, from: serviceData)
+
+    #expect(TKBuzzInfoProvider.addContent(from: serviceResponse, to: service))
+
+    let repeatedVisits = service.sortedVisits.filter { $0.stop.stopCode == "046" }
+
+    #expect(service.sortedVisits.count == 4)
+    #expect(repeatedVisits.count == 2)
+    #expect(repeatedVisits.first?.objectID == departureVisit.objectID)
+    #expect(repeatedVisits.map(\.index) == [0, 3])
+    #expect(
+      repeatedVisits.map { Int($0.departure?.timeIntervalSince1970 ?? 0) }
+        == [1_775_711_400, 1_775_712_960]
+    )
+    #expect(departureVisit.index == 0)
+    #expect(Int(departureVisit.departure?.timeIntervalSince1970 ?? 0) == 1_775_711_400)
+  }
+
+}
+
+private extension TKLoopServiceParsingTest {
+
+  enum SetupError: Error {
+    case missingModel
+    case missingFixture(String)
+    case missingValue(String)
+  }
+
+  func makeContext() throws -> NSManagedObjectContext {
+    guard let model = Self.model else { throw SetupError.missingModel }
+
+    let coordinator = NSPersistentStoreCoordinator(managedObjectModel: model)
+    try coordinator.addPersistentStore(ofType: NSInMemoryStoreType, configurationName: nil, at: nil, options: nil)
+
+    let context = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
+    context.persistentStoreCoordinator = coordinator
+    return context
+  }
+
+  func dataFromJSON(named name: String) throws -> Data {
+    let thisSourceFile = URL(fileURLWithPath: #filePath)
+    let thisDirectory = thisSourceFile.deletingLastPathComponent()
+    let jsonPath = thisDirectory
+      .deletingLastPathComponent()
+      .appendingPathComponent("Data", isDirectory: true)
+      .appendingPathComponent(name)
+      .appendingPathExtension("json")
+
+    guard FileManager.default.fileExists(atPath: jsonPath.path) else {
+      throw SetupError.missingFixture(jsonPath.path)
+    }
+
+    return try Data(contentsOf: jsonPath)
+  }
+
+  func firstDepartureVisit(in context: NSManagedObjectContext) throws -> StopVisits {
+    let visit = context.fetchObjects(
+      StopVisits.self,
+      sortDescriptors: [NSSortDescriptor(key: "departure", ascending: true)],
+      predicate: NSPredicate(format: "stop.stopCode = %@", "046"),
+      relationshipKeyPathsForPrefetching: nil,
+      fetchLimit: 1
+    ).first
+
+    return try unwrap(visit, "Expected the seeded Darwin departure visit.")
+  }
+
+  func unwrap<T>(_ value: T?, _ message: String) throws -> T {
+    guard let value else {
+      throw SetupError.missingValue(message)
+    }
+    return value
+  }
+
+}
+
+#endif

--- a/Tests/TripKitTests/realtime/TKRealTimeHandlingTest.swift
+++ b/Tests/TripKitTests/realtime/TKRealTimeHandlingTest.swift
@@ -7,7 +7,7 @@ import Testing
 @testable import TripKit
 
 struct TKRealTimeHandlingTest {
-  private static let model: NSManagedObjectModel? = TripKit.loadModel()
+  private static let model = TKTestCase.model
   
   @Test func capableWithoutRealtimeDisplaysScheduled() throws {
     let context = try makeContext()

--- a/TripKit.xcodeproj/project.pbxproj
+++ b/TripKit.xcodeproj/project.pbxproj
@@ -69,13 +69,6 @@
 			remoteGlobalIDString = 3AB6C61F1D1CD0060089F687;
 			remoteInfo = TripKit;
 		};
-		3ACF47102297EC820096860D /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 3ACF47032297EC820096860D /* MiniMap.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 3A1498D61F0FD33F0061A0D0;
-			remoteInfo = MiniMap;
-		};
 		3ACF47B4229EF0000096860D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 3AB6C6171D1CD0060089F687 /* Project object */;
@@ -144,19 +137,11 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		3A576B0D2E1B8F4F00291841 /* TripKitAPI.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = TripKitAPI.podspec; sourceTree = "<group>"; };
 		3A6DF068202C8C340084CB2C /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
-		3A6DF069202C8C340084CB2C /* TripKitUI.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; path = TripKitUI.podspec; sourceTree = "<group>"; };
-		3A6DF06A202C8C340084CB2C /* TripKit.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; path = TripKit.podspec; sourceTree = "<group>"; };
 		3A6DF084202C8DA30084CB2C /* TripKitUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TripKitUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3A6DF167202C97F60084CB2C /* TripKitInterApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TripKitInterApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		3AA3CC8B202CABE900E54859 /* TripKitInterApp.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; path = TripKitInterApp.podspec; sourceTree = "<group>"; };
 		3AB6C6201D1CD0060089F687 /* TripKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TripKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3AB6C62A1D1CD0060089F687 /* TripKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TripKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		3ACF47032297EC820096860D /* MiniMap.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; path = MiniMap.xcodeproj; sourceTree = "<group>"; };
-		3ACF47062297EC820096860D /* MiniMap.xcworkspace */ = {isa = PBXFileReference; lastKnownFileType = wrapper.workspace; path = MiniMap.xcworkspace; sourceTree = "<group>"; };
-		3ACF470E2297EC820096860D /* Podfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Podfile; sourceTree = "<group>"; };
-		3ACF47142297ED920096860D /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		3ACF47A1229EEDFE0096860D /* TripKitUIExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TripKitUIExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3ADCB5F626CDFCC400E4C13A /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		3AEC06422D2E3E7D003C9A0B /* TripKitAPI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TripKitAPI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -206,7 +191,6 @@
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		3A577CBD2E1B9B5B00291841 /* TripKitUIExample */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (3A577CCA2E1B9B5B00291841 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = TripKitUIExample; sourceTree = "<group>"; };
-		3A577CD12E1B9B6000291841 /* MiniMap */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = MiniMap; sourceTree = "<group>"; };
 		3A577D192E1B9B6A00291841 /* TripKitTests */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (3A577D5B2E1B9B6A00291841 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = TripKitTests; sourceTree = "<group>"; };
 		3A577D932E1B9B6E00291841 /* TripKitUITests */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (3A577DC32E1B9B6F00291841 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = TripKitUITests; sourceTree = "<group>"; };
 		3A8DD2F92E164D9F00FBE268 /* TripKit */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = TripKit; sourceTree = "<group>"; };
@@ -287,10 +271,6 @@
 			children = (
 				3A6DF068202C8C340084CB2C /* README.md */,
 				3ADCB5F626CDFCC400E4C13A /* Package.swift */,
-				3A576B0D2E1B8F4F00291841 /* TripKitAPI.podspec */,
-				3A6DF06A202C8C340084CB2C /* TripKit.podspec */,
-				3AA3CC8B202CABE900E54859 /* TripKitInterApp.podspec */,
-				3A6DF069202C8C340084CB2C /* TripKitUI.podspec */,
 			);
 			name = Metadata;
 			sourceTree = "<group>";
@@ -323,30 +303,9 @@
 		3ACF46FE2297EC820096860D /* Examples */ = {
 			isa = PBXGroup;
 			children = (
-				3ACF47022297EC820096860D /* MiniMap */,
 				3A577CBD2E1B9B5B00291841 /* TripKitUIExample */,
 			);
 			path = Examples;
-			sourceTree = "<group>";
-		};
-		3ACF47022297EC820096860D /* MiniMap */ = {
-			isa = PBXGroup;
-			children = (
-				3ACF47032297EC820096860D /* MiniMap.xcodeproj */,
-				3ACF47062297EC820096860D /* MiniMap.xcworkspace */,
-				3A577CD12E1B9B6000291841 /* MiniMap */,
-				3ACF470E2297EC820096860D /* Podfile */,
-				3ACF47142297ED920096860D /* README.md */,
-			);
-			path = MiniMap;
-			sourceTree = "<group>";
-		};
-		3ACF47042297EC820096860D /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				3ACF47112297EC820096860D /* MiniMap.app */,
-			);
-			name = Products;
 			sourceTree = "<group>";
 		};
 		3AFF25E926C6975F007809CD /* Sources */ = {
@@ -628,12 +587,6 @@
 			);
 			productRefGroup = 3AB6C6211D1CD0060089F687 /* Products */;
 			projectDirPath = "";
-			projectReferences = (
-				{
-					ProductGroup = 3ACF47042297EC820096860D /* Products */;
-					ProjectRef = 3ACF47032297EC820096860D /* MiniMap.xcodeproj */;
-				},
-			);
 			projectRoot = "";
 			targets = (
 				3AB6C61F1D1CD0060089F687 /* TripKit */,
@@ -645,16 +598,6 @@
 			);
 		};
 /* End PBXProject section */
-
-/* Begin PBXReferenceProxy section */
-		3ACF47112297EC820096860D /* MiniMap.app */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.application;
-			path = MiniMap.app;
-			remoteRef = 3ACF47102297EC820096860D /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		3A6DF082202C8DA30084CB2C /* Resources */ = {

--- a/TripKit.xcodeproj/project.pbxproj
+++ b/TripKit.xcodeproj/project.pbxproj
@@ -1512,8 +1512,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/skedgo/GeoMonitor";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.2.0;
+				kind = upToNextMinorVersion;
+				minimumVersion = 0.3.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/TripKit.xctestplan
+++ b/TripKit.xctestplan
@@ -1,0 +1,31 @@
+{
+  "configurations" : [
+    {
+      "id" : "8CE3577A-9EDD-4B04-B109-3F97BFEF34FC",
+      "name" : "Test Scheme Action",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "performanceAntipatternCheckerEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "TripKitTests",
+        "name" : "TripKitTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "TripKitUITests",
+        "name" : "TripKitUITests"
+      }
+    }
+  ],
+  "version" : 1
+}


### PR DESCRIPTION
Root issue: Handle multiple visits to the same stop code within a service, along with tests for it. Addresses RM25151

Also:
- Address test issue of TripKit CoreData model getting instantiated multiple times which causes runtime issues
- SPM updates, in particular for GeoMonitor
- Update GHA to latest versions to address node deprecation warnings
- Update Xcode versions
- Remove unused references from Xcode project