### PR TITLE
Fix stale modes after using custom transport selector

### DIFF
--- a/Sources/TripKitUI/cards/TKUIRoutingResultsCard.swift
+++ b/Sources/TripKitUI/cards/TKUIRoutingResultsCard.swift
@@ -246,12 +246,18 @@ public class TKUIRoutingResultsCard: TKUITableCard {
     
     if TKUIRoutingResultsCard.config.transportButtonHandler != nil {
       accessoryView.setTransport() // Apply fixed default style
-      
+
       NotificationCenter.default.rx.notification(UserDefaults.didChangeNotification)
         .map { _ in TKSettings.hiddenModeIdentifiers }
         .distinctUntilChanged()
         .subscribe(onNext: { [weak self] _ in
-          self?.changedModes.onNext(nil)
+          // Republish the enabled identifiers (not `nil`) so the view model's
+          // `availableFromChange` pipeline updates `selectedModeIdentifiers`;
+          // otherwise the next route refresh re-uses the modes that were
+          // enabled when the card was opened.
+          guard let self else { return }
+          let regions = [self.request?.startRegion, self.request?.endRegion, self.request?.spanningRegion].compactMap { $0 }
+          self.changedModes.onNext(Self.enabledModeIdentifiers(in: regions))
         })
         .disposed(by: disposeBag)
     }
@@ -659,8 +665,19 @@ extension TKUIRoutingResultsCard {
 
 // MARK: - Mode picker
 
+extension TKUIRoutingResultsCard {
+  /// The mode identifiers currently enabled in `TKSettings`, restricted to the
+  /// routing modes available in the supplied regions (plus any custom modes
+  /// registered on `config`). Used to republish the user's mode selection after
+  /// it has been changed via an external `transportButtonHandler` selector.
+  static func enabledModeIdentifiers(in regions: [TKRegion]) -> [String] {
+    let all = config.routingModes(in: regions).map(\.identifier)
+    return Array(TKSettings.adjustedEnabledModeIdentifiers(all))
+  }
+}
+
 private extension TKUIRoutingResultsCard {
-  
+
   func updateModePicker(_ modes: TKUIRoutingResultsViewModel.AvailableModes, in tableView: UITableView) {
     guard TKUIRoutingResultsCard.config.transportButtonHandler == nil else { return }
 

--- a/Tests/TripKitUITests/TKUIRoutingResultsViewModelTest.swift
+++ b/Tests/TripKitUITests/TKUIRoutingResultsViewModelTest.swift
@@ -222,6 +222,36 @@ final class TKUIRoutingResultsViewModelTest: XCTestCase {
     )
   }
   
+  /// Regression test for the iOS 26+ custom transport mode selector flow.
+  ///
+  /// When the routing results card observes a `TKSettings.hiddenModeIdentifiers`
+  /// change made externally (e.g. by `TransportModeSelectionView` opened via
+  /// `transportButtonHandler`), it must republish the *actual* enabled mode
+  /// identifiers so the view model's `availableFromChange` pipeline picks them
+  /// up. The previous behaviour of emitting `nil` was filtered out by
+  /// `updateAvailableModes`, leaving `selectedModeIdentifiers` stale and causing
+  /// the refreshed routes to still use the old mode set.
+  @MainActor
+  func testEnabledModeIdentifiersReflectsHiddenModeChanges() {
+    TKUIRoutingResultsCard.config.customModes = [
+      .init(identifier: "custom_a", title: "A", icon: .badgeHeart),
+      .init(identifier: "custom_b", title: "B", icon: .badgeHeart),
+      .init(identifier: "custom_c", title: "C", icon: .badgeHeart)
+    ]
+
+    TKSettings.hiddenModeIdentifiers = []
+    var enabled = Set(TKUIRoutingResultsCard.enabledModeIdentifiers(in: []))
+    XCTAssertTrue(enabled.contains("custom_a"))
+    XCTAssertTrue(enabled.contains("custom_b"))
+    XCTAssertTrue(enabled.contains("custom_c"))
+
+    TKSettings.hiddenModeIdentifiers = ["custom_b"]
+    enabled = Set(TKUIRoutingResultsCard.enabledModeIdentifiers(in: []))
+    XCTAssertTrue(enabled.contains("custom_a"))
+    XCTAssertFalse(enabled.contains("custom_b"))
+    XCTAssertTrue(enabled.contains("custom_c"))
+  }
+
   func testAlwaysGroupModeIdentifierPrefixesAdjusterMergesMatchingModes() {
     TKUIRoutingResultsCard.config.routingModeRequestGroupAdjuster =
       TKUIRoutingResultsCard.Configuration.alwaysGroupModeIdentifierPrefixes([


### PR DESCRIPTION
## Summary

When `TKUIRoutingResultsCard.config.transportButtonHandler` is set (e.g. on iOS 26+ in TripGo, where the Transport button opens a custom `TransportModeSelectionView`), changing modes from the external selector doesn't propagate into the next route refresh — the card refreshes but the trips still use the modes that were enabled when the card was opened. Going back and re-opening the card works correctly.

Root cause: the card observes `UserDefaults.didChangeNotification` and fires `changedModes.onNext(nil)`. The view model's `updateAvailableModes` filters `nil` out, so `selectedModeIdentifiers` stays stale. The 1s-debounced `refresh` then triggers a new request, but `combineLatest(updateableRequest, selectedModes)` picks up the new request paired with the *stale* selected modes, and re-fetches with the old set.

Fix: republish the actual enabled identifiers (computed from the request's regions and current `TKSettings`) instead of `nil`, so `availableFromChange` runs and `selectedModeIdentifiers` updates before the refresh fetches.

## Test plan

- [x] New unit test `testEnabledModeIdentifiersReflectsHiddenModeChanges` covers the helper that drives the fix
- [x] Existing `TKUIRoutingResultsViewModelTest` suite still passes (10/10)
- [x] Full `TripKitUITests` target still passes (67/67, 10 skipped)
- [ ] Manual: in TripGo on iOS 26+, open agenda trip → Show alternatives → Transport → toggle a mode → verify refreshed routes respect the new selection without needing to re-open the card

🤖 Generated with [Claude Code](https://claude.com/claude-code)