### PR TITLE
Remove per-region server URLs (RM25856)

### DIFF
--- a/Sources/TripKit/server/TKServer+ImageUpload.swift
+++ b/Sources/TripKit/server/TKServer+ImageUpload.swift
@@ -11,8 +11,6 @@ import Foundation
 extension TKServer {
   
   public func upload(imageData: Data, contentType: String) async throws {
-    let baseURL = baseURLs(for: nil).first!
-    
     let boundary = UUID().uuidString
     
     var request = URLRequest(url: baseURL.appendingPathComponent("data/user/image"))

--- a/Sources/TripKitAPI/TKRoutingServer.swift
+++ b/Sources/TripKitAPI/TKRoutingServer.swift
@@ -12,20 +12,16 @@ import Foundation
  `TKServer` subclass that is forced to hit the provided `baseURL` and API key for SkedGo calls.
  */
 public class TKRoutingServer: TKServer {
-  let baseURL: URL?
-  
+  private let fixedBaseURL: URL?
+
   public init(baseURL: URL?, apiKey: String?) {
     assert(baseURL != nil || apiKey != nil)
-    self.baseURL = baseURL
+    self.fixedBaseURL = baseURL
     super.init(isShared: false)
     self.apiKey = apiKey ?? TKServer.shared.apiKey
   }
-  
-  public override func baseURLs(for region: TKRegion?) -> [URL] {
-    if let fixed = baseURL {
-      return [fixed]
-    } else {
-      return super.baseURLs(for: region)
-    }
+
+  public override var baseURL: URL {
+    fixedBaseURL ?? super.baseURL
   }
 }

--- a/Sources/TripKitAPI/TKServer.swift
+++ b/Sources/TripKitAPI/TKServer.swift
@@ -80,16 +80,9 @@ public class TKServer {
     }
   }
   
-  public func baseURLs(for region: TKRegion?) -> [URL] {
-    if let dev = Self.customBaseURL.flatMap(URL.init) {
-      return [dev]
-    } else if let urls = region?.urls, !urls.isEmpty {
-      return urls
-    } else {
-      return [URL(string: "https://api.tripgo.com/v1/")!]
-    }
-  }
-  
+  /// Base URL to use for server calls, respecting any ``customBaseURL`` overwrite.
+  open var baseURL: URL { Self.fallbackBaseURL }
+
 }
 
 fileprivate extension String {
@@ -119,7 +112,6 @@ extension TKServer {
   
   public enum RequestError: Error {
     case invalidURL
-    case noBaseURLs
   }
   
   public enum ServerError: Error {
@@ -461,7 +453,6 @@ extension TKServer {
       method: method,
       parameters: parameters,
       headers: adjustedHeaders,
-      baseURLs: baseURLs(for: region).shuffled(),
       callbackOnMain: callbackOnMain,
       info: { uuid, info in
         switch info {
@@ -533,13 +524,11 @@ extension TKServer {
   
   private func hitSkedGo(
     path: String, method: HTTPMethod, parameters: [String: Any]?, headers: [String: String]?,
-    baseURLs: [URL],
     callbackOnMain: Bool,
     info: @escaping ((UUID, Info) -> Void),
-    completion: @escaping (Response<Data?>) -> Void,
-    previousResponse: Response<Data?>? = nil)
+    completion: @escaping (Response<Data?>) -> Void)
   {
-    
+
     func callback(_ response: Response<Data?>) {
       if callbackOnMain {
         DispatchQueue.main.async {
@@ -549,51 +538,18 @@ extension TKServer {
         completion(response)
       }
     }
-    
-    guard let baseURL = baseURLs.first else {
-      // no more server to try
-      if let previousResponse {
-        return callback(previousResponse)
-      } else {
-        assertionFailure("Don't call this without any URLs!")
-        return callback(.init(headers: [:], result: .failure(RequestError.noBaseURLs)))
-      }
-    }
 
     let request: URLRequest
     do {
-      request = try self.request(path: path, baseURL: baseURL, method: method, parameters: parameters, headers: headers)
+      request = try self.request(path: path, baseURL: self.baseURL, method: method, parameters: parameters, headers: headers)
     } catch {
       return callback(.init(headers: [:], result: .failure(error)))
     }
-    
-    let onFail = { [weak self] (previously: Response<Data?>) -> Void in
-      self?.hitSkedGo(
-        path: path, method: method, parameters: parameters, headers: headers,
-        baseURLs: Array(baseURLs.dropFirst()),
-        callbackOnMain: callbackOnMain, info: info, completion: completion,
-        previousResponse: previously
-      )
-    }
-    
+
     Self.hit(request, info: info) { response in
-      switch (response.statusCode ?? 0 >= 500, response.result) {
-      case (_, .success):
-        // All good, no need for failover
-        callback(response)
-        
-      case (true, _):
-        onFail(response)
-        
-      case (_, .failure(let error)):
-        if error is TKUserError {
-          callback(response) // servers can't recover from user errors
-        } else {
-          onFail(response)
-        }
-      }
+      callback(response)
     }
-    
+
   }
   
   private func hit(_ url: URL, method: HTTPMethod, parameters: [String: Any]?, headers: [String: String]?, info: @escaping ((UUID, Info) -> Void), completion: @escaping (Response<Data?>) -> Void) {

--- a/Sources/TripKitAPI/TKServer.swift
+++ b/Sources/TripKitAPI/TKServer.swift
@@ -55,8 +55,8 @@ public class TKServer {
     }
   }
   
-  /// Base URL to use for server calls when ``customBaseURL`` is not set and the server calls
-  /// do not specify a ``TKRegion``.
+  /// Base URL to use for server calls: the ``customBaseURL`` overwrite if set,
+  /// otherwise TripGo's default API endpoint.
   public static var fallbackBaseURL: URL {
     customBaseURL.flatMap(URL.init) ?? URL(string: "https://api.tripgo.com/v1/")!
   }
@@ -81,7 +81,7 @@ public class TKServer {
   }
   
   /// Base URL to use for server calls, respecting any ``customBaseURL`` overwrite.
-  open var baseURL: URL { Self.fallbackBaseURL }
+  public var baseURL: URL { Self.fallbackBaseURL }
 
 }
 
@@ -546,9 +546,7 @@ extension TKServer {
       return callback(.init(headers: [:], result: .failure(error)))
     }
 
-    Self.hit(request, info: info) { response in
-      callback(response)
-    }
+    Self.hit(request, info: info, completion: callback)
 
   }
   

--- a/Sources/TripKitAPI/model/TKRegion.swift
+++ b/Sources/TripKitAPI/model/TKRegion.swift
@@ -50,7 +50,6 @@ open class TKRegion : NSObject, Codable, @unchecked Sendable {
   /// A list of all the mode identifiers this region supports. This is sorted as defined by the server, as the server groups and sorts them in a sensible manner and we want to preserve this sorting.
   public let modeIdentifiers: [String]
 
-  public let urls: [URL]
   let encodedPolygon: String
   
 #if canImport(MapKit)
@@ -72,7 +71,6 @@ open class TKRegion : NSObject, Codable, @unchecked Sendable {
     self.code = code
     self.modeIdentifiers = modes
     self.cities = cities
-    self.urls = []
     self.encodedPolygon = ""
     self.simplePolygon = nil
     self.timeZone = .current
@@ -82,7 +80,6 @@ open class TKRegion : NSObject, Codable, @unchecked Sendable {
     encodedPolygon        = ""
     simplePolygon         = nil
     self.code             = code
-    urls                  = []
     timeZone              = .current
     cities                = []
     self.modeIdentifiers  = modes
@@ -95,7 +92,6 @@ open class TKRegion : NSObject, Codable, @unchecked Sendable {
     case code = "name"
     case cities
     case modeIdentifiers = "modes"
-    case urls
     case encodedPolygon = "polygon"
   }
   
@@ -104,8 +100,7 @@ open class TKRegion : NSObject, Codable, @unchecked Sendable {
     code = try container.decode(String.self, forKey: .code)
     cities = try container.decode([City].self, forKey: .cities)
     modeIdentifiers = try container.decode([String].self, forKey: .modeIdentifiers)
-    urls = try container.decode([URL].self, forKey: .urls)
-    
+
     encodedPolygon = try container.decode(String.self, forKey: .encodedPolygon)
     if encodedPolygon.count == 0 {
       throw TKRegionParserError.emptyPolygon
@@ -129,7 +124,6 @@ open class TKRegion : NSObject, Codable, @unchecked Sendable {
     try container.encode(code, forKey: .code)
     try container.encode(cities, forKey: .cities)
     try container.encode(modeIdentifiers, forKey: .modeIdentifiers)
-    try container.encode(urls, forKey: .urls)
     try container.encode(encodedPolygon, forKey: .encodedPolygon)
   }
 


### PR DESCRIPTION
Follow-up to [RM25856](https://redmine.buzzhives.com/issues/25856) / backend [#25689](https://redmine.buzzhives.com/issues/25689).

`/regions.json` now returns the single global `https://api.tripgo.com/v1/` URL for every region, so the client no longer needs to consume the per-region `urls` array. The global URL overwrite (`TKServer.customBaseURL`) is retained.

## Changes
- **`TKRegion`** — remove the `urls` property and its Codable handling. Old caches and the still-present (deprecated) server field decode fine, since the key is now simply ignored.
- **`TKServer`** — replace `baseURLs(for:) -> [URL]` with `open var baseURL: URL`, an alias for `fallbackBaseURL`. Remove the now-dead multi-URL shuffle + failover in `hitSkedGo` (single base URL, no `dropFirst()` recursion); 5xx/network errors surface directly. Drops the orphaned `RequestError.noBaseURLs`.
- **`TKRoutingServer`** — override `baseURL` instead of `baseURLs(for:)`.
- **`TKServer+ImageUpload`** — use the new `baseURL`.

## ⚠️ Breaking change
`TKRegion.urls` was `public`. Downstream consumers that read `region.urls` will need a companion change.

## Testing
- `xcodebuild build -scheme TripKit` (iOS Simulator) — succeeds.
- Full `TripKit` test suite: 160 tests, 0 failures (20 pre-existing skips).