### PR TITLE
Fix dark-mode contrast for region-specific mode icons (RM25943)

### DIFF
--- a/Sources/TripKitUI/views/TKUITripSegmentsView.swift
+++ b/Sources/TripKitUI/views/TKUITripSegmentsView.swift
@@ -194,11 +194,13 @@ public class TKUITripSegmentsView : UIView {
           newFrame = brandFrame
 
         } else {
-          // remote images that aren't templates look weird on the background colour
+          // Remote images that aren't templates (e.g. the black "R"/"S" region
+          // icons) are drawn as-is and can be invisible on the card's own
+          // background, so keep a white backing circle behind them. Only remove
+          // it if the image fails to load — the placeholder is shown then.
           let modeCircleBackground = asTemplate ? nil : addCircle(frame: newFrame)
           modeImageView.setImage(with: modeImageURL, asTemplate: asTemplate, placeholder: modeImage) { succeeded in
-            guard succeeded else { return }
-            modeCircleBackground?.removeFromSuperview()
+            if !succeeded { modeCircleBackground?.removeFromSuperview() }
           }
         }
         if !asTemplate {


### PR DESCRIPTION
## Why

Region-specific public-transport mode icons — e.g. the black **R** for German regional trains, the **S** for S-Bahn — are delivered by the API as *non-template* remote images: a dark glyph on a transparent background, designed to sit on a light surface. In dark mode they render black-on-dark and become effectively invisible in the trip-segment mode strip (the row of icons in the card header, shared across the trip overview, mode-by-mode, and routing-results cells).

`TKUITripSegmentsView` already draws a white backing circle behind these icons. This regressed in the 2021 Objective-C → Swift port (`9be5c2f16e`), which inverted the image-load completion condition — the Swift `guard succeeded else { return }` removes the backing on *success* instead of on failure. This restores the original behaviour: the white circle stays behind a loaded icon and is only removed if the image fails to load.

## Scope

Deliberately narrow — this fixes the mode-icon strip only. The trip-overview timeline and the departures/timetable cards have related dark-mode / white-route contrast issues tracked separately as follow-ups to RM25943.

## Testing

- Route a trip through a German region (e.g. Hannover / Hameln regional trains) so a region-specific `R`/`S` icon appears in the card-header mode strip.
- In **dark mode**, confirm the icon shows on its white backing circle and is legible.
- Confirm light mode and non-region icons are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)